### PR TITLE
Allow usage of Field Modifiers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -515,10 +515,15 @@ tasks.register("testRun", JavaExec) {
 	description = "Runs the application same as for integration tests."
 	dependsOn "integrationTestSetup"
 
+	environment "ARCHAPPL_SHORT_TERM_FOLDER", "${buildDir}/storage/sts"
+	environment "ARCHAPPL_MEDIUM_TERM_FOLDER", "${buildDir}/storage/mts"
+	environment "ARCHAPPL_LONG_TERM_FOLDER", "${buildDir}/storage/lts"
+
 	mainClass = "org.epics.archiverappliance.TestRun"
 
 	classpath = sourceSets.test.runtimeClasspath
 	args "-c2"
+
 }
 
 spotless {

--- a/src/main/edu/stanford/slac/archiverappliance/PBOverHTTP/PBOverHTTPStoragePlugin.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PBOverHTTP/PBOverHTTPStoragePlugin.java
@@ -39,177 +39,183 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 /**
- * A read-only storage plugin that gets data using the PB/http protocol from a server. 
+ * A read-only storage plugin that gets data using the PB/http protocol from a server.
  * @author mshankar
  *
  */
 public class PBOverHTTPStoragePlugin implements StoragePlugin {
-	private static Logger logger = LogManager.getLogger(PBOverHTTPStoragePlugin.class.getName());
-	private String accessURL = null;
-	private String desc = "A event stream backed by a .raw response from a remote server.";
-	private String name;
-	private boolean skipExternalServers = false;
+    private static Logger logger = LogManager.getLogger(PBOverHTTPStoragePlugin.class.getName());
+    private String accessURL = null;
+    private String desc = "A event stream backed by a .raw response from a remote server.";
+    private String name;
+    private boolean skipExternalServers = false;
 
-	@Override
-    public List<Callable<EventStream>> getDataForPV(BasicContext context, String pvName, Instant startTime,
-                                                    Instant endTime, PostProcessor postProcessor) throws IOException {
-		String getURL = accessURL + "?pv=" + pvName 
-				+ "&from=" + TimeUtils.convertToISO8601String(startTime) 
-				+ "&to=" + TimeUtils.convertToISO8601String(endTime) 
-				+ (postProcessor != null ? "&pp="+postProcessor.getExtension() : "")
-				+ (skipExternalServers ? "&skipExternalServers=true" : "");
-		logger.info("URL to fetch data is " + getURL);
-		return getDataBehindURL(getURL, startTime, postProcessor);
-	}
+    @Override
+    public List<Callable<EventStream>> getDataForPV(
+            BasicContext context, String pvName, Instant startTime, Instant endTime, PostProcessor postProcessor)
+            throws IOException {
+        String getURL = accessURL + "?pv=" + pvName
+                + "&from=" + TimeUtils.convertToISO8601String(startTime)
+                + "&to=" + TimeUtils.convertToISO8601String(endTime)
+                + (postProcessor != null ? "&pp=" + postProcessor.getExtension() : "")
+                + (skipExternalServers ? "&skipExternalServers=true" : "");
+        logger.info("URL to fetch data is " + getURL);
+        return getDataBehindURL(getURL, startTime, postProcessor);
+    }
 
-    public List<Callable<EventStream>> getDataForMultiPVs(BasicContext context, List<String> pvNames, Instant startTime,
-                                                          Instant endTime, PostProcessor postProcessor) throws IOException {
-		String getURL = accessURL;
-		for (int i = 0; i < pvNames.size(); i++)
-			if (i == 0) getURL += "?pv=" + pvNames.get(i);
-			else 		getURL += "&pv=" + pvNames.get(i);
-		getURL += "&from=" + TimeUtils.convertToISO8601String(startTime) 
-				+ "&to=" + TimeUtils.convertToISO8601String(endTime) 
-				+ (postProcessor != null ? "&pp="+postProcessor.getExtension() : "")
-				+ (skipExternalServers ? "&skipExternalServers=true" : "");
-		logger.info("URL to fetch data is " + getURL);
-		return getDataBehindURL(getURL, startTime, postProcessor);
-	}
+    public List<Callable<EventStream>> getDataForMultiPVs(
+            BasicContext context, List<String> pvNames, Instant startTime, Instant endTime, PostProcessor postProcessor)
+            throws IOException {
+        String getURL = accessURL;
+        for (int i = 0; i < pvNames.size(); i++)
+            if (i == 0) getURL += "?pv=" + pvNames.get(i);
+            else getURL += "&pv=" + pvNames.get(i);
+        getURL += "&from=" + TimeUtils.convertToISO8601String(startTime)
+                + "&to=" + TimeUtils.convertToISO8601String(endTime)
+                + (postProcessor != null ? "&pp=" + postProcessor.getExtension() : "")
+                + (skipExternalServers ? "&skipExternalServers=true" : "");
+        logger.info("URL to fetch data is " + getURL);
+        return getDataBehindURL(getURL, startTime, postProcessor);
+    }
 
-    private List<Callable<EventStream>> getDataBehindURL(String getURL, Instant startTime, PostProcessor postProcessor) {
-		try {
-			CloseableHttpClient httpclient = HttpClients.createDefault();
-			HttpGet getMethod = new HttpGet(getURL);
-			getMethod.addHeader("Connection", "close"); // https://www.nuxeo.com/blog/using-httpclient-properly-avoid-closewait-tcp-connections/
-			try(CloseableHttpResponse response = httpclient.execute(getMethod)) {
-				if(response.getStatusLine().getStatusCode() == 200) {
-					HttpEntity entity = response.getEntity();
-					if (entity != null) {
-						logger.debug("Obtained a HTTP entity of length " + entity.getContentLength());
-						ByteArrayOutputStream bos = new ByteArrayOutputStream();
-						entity.writeTo(bos);
-						bos.close();
-						ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
-						InputStreamBackedEventStream isStream = new InputStreamBackedEventStream(bis, startTime);
-						if(isStream.getDescription() != null) { 
-							isStream.getDescription().setSource(this.getName());
-						} else { 
-							logger.warn("No desc attached to input stream for url " + getURL);
-						}
-						return CallableEventStream.makeOneStreamCallableList(isStream, postProcessor, true);
-					} else { 
-						logger.debug("Obtained empty HTTP entity from " + getURL);
-					}
-				} else {
-					logger.warn("Invalid status code " + response.getStatusLine().getStatusCode()  + " when connecting to URL " + getURL);
-					HttpEntity entity = response.getEntity();
-					if (entity != null) {
-						ByteArrayOutputStream sbuf = new ByteArrayOutputStream();
-						entity.writeTo(sbuf);
-						logger.warn(sbuf.toString("UTF-8"));
-					}
-				}
-			}
-		} catch (FileNotFoundException fex) {
-			logger.debug("No data from remote site " + getURL);
-			return null;
-		} catch(Throwable t) {
-			logger.warn("Exception fetching data from URL " + getURL, t);
-		}
-		return null;
+    private List<Callable<EventStream>> getDataBehindURL(
+            String getURL, Instant startTime, PostProcessor postProcessor) {
+        try {
+            CloseableHttpClient httpclient = HttpClients.createDefault();
+            HttpGet getMethod = new HttpGet(getURL);
+            getMethod.addHeader(
+                    "Connection",
+                    "close"); // https://www.nuxeo.com/blog/using-httpclient-properly-avoid-closewait-tcp-connections/
+            try (CloseableHttpResponse response = httpclient.execute(getMethod)) {
+                if (response.getStatusLine().getStatusCode() == 200) {
+                    HttpEntity entity = response.getEntity();
+                    if (entity != null) {
+                        logger.debug("Obtained a HTTP entity of length " + entity.getContentLength());
+                        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                        entity.writeTo(bos);
+                        bos.close();
+                        ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
+                        InputStreamBackedEventStream isStream = new InputStreamBackedEventStream(bis, startTime);
+                        if (isStream.getDescription() != null) {
+                            isStream.getDescription().setSource(this.getName());
+                        } else {
+                            logger.warn("No desc attached to input stream for url " + getURL);
+                        }
+                        return CallableEventStream.makeOneStreamCallableList(isStream, postProcessor, true);
+                    } else {
+                        logger.debug("Obtained empty HTTP entity from " + getURL);
+                    }
+                } else {
+                    logger.warn("Invalid status code "
+                            + response.getStatusLine().getStatusCode() + " when connecting to URL " + getURL);
+                    HttpEntity entity = response.getEntity();
+                    if (entity != null) {
+                        ByteArrayOutputStream sbuf = new ByteArrayOutputStream();
+                        entity.writeTo(sbuf);
+                        logger.warn(sbuf.toString("UTF-8"));
+                    }
+                }
+            }
+        } catch (FileNotFoundException fex) {
+            logger.debug("No data from remote site " + getURL);
+            return null;
+        } catch (Throwable t) {
+            logger.warn("Exception fetching data from URL " + getURL, t);
+        }
+        return null;
+    }
 
-	}
-	
-
-	@Override
+    @Override
     public int appendData(BasicContext context, String pvName, EventStream stream) {
-		throw new RuntimeException("Append Data is not available for HTTP streams");
-	}
+        throw new RuntimeException("Append Data is not available for HTTP streams");
+    }
 
-	@Override
-	public String getDescription() {
-		return desc;
-	}
+    @Override
+    public String getDescription() {
+        return desc;
+    }
 
-	@Override
-	public void initialize(String configURL, ConfigService configService) throws IOException {
-		try {
-			URI srcURI = new URI(configURL);
-			HashMap<String, String> queryNVPairs = URIUtils.parseQueryString(srcURI);
-			if(queryNVPairs.containsKey("rawURL")) {
-				this.setAccessURL(queryNVPairs.get("rawURL"));
-			} else {
-				throw new IOException("Cannot initialize the pbraw plugin; this needs the URL to the engine/Raw over HTTP to be specified " + configURL);
-			}
-			
-			if(queryNVPairs.containsKey("name")) {
-				name = queryNVPairs.get("name");
-			} else {
-				name = new URL(this.getAccessURL()).getHost();
-				logger.debug("Using the default name of " + name + " for this plain pb engine");
-			}
+    @Override
+    public void initialize(String configURL, ConfigService configService) throws IOException {
+        try {
+            URI srcURI = new URI(configURL);
+            HashMap<String, String> queryNVPairs = URIUtils.parseQueryString(srcURI);
+            if (queryNVPairs.containsKey("rawURL")) {
+                this.setAccessURL(queryNVPairs.get("rawURL"));
+            } else {
+                throw new IOException(
+                        "Cannot initialize the pbraw plugin; this needs the URL to the engine/Raw over HTTP to be specified "
+                                + configURL);
+            }
 
-			if(queryNVPairs.containsKey("skipExternalServers")) {
-				logger.debug("Telling the remote server to skip all data from external (potentially ChannelArchiver) servers");
-				this.skipExternalServers = Boolean.parseBoolean(queryNVPairs.get("skipExternalServers"));
-			}
-		} catch(URISyntaxException ex) {
-			throw new IOException(ex);
-		}
-	}
-	
-	public String getAccessURL() {
-		return accessURL;
-	}
+            if (queryNVPairs.containsKey("name")) {
+                name = queryNVPairs.get("name");
+            } else {
+                name = new URL(this.getAccessURL()).getHost();
+                logger.debug("Using the default name of " + name + " for this plain pb engine");
+            }
 
+            if (queryNVPairs.containsKey("skipExternalServers")) {
+                logger.debug(
+                        "Telling the remote server to skip all data from external (potentially ChannelArchiver) servers");
+                this.skipExternalServers = Boolean.parseBoolean(queryNVPairs.get("skipExternalServers"));
+            }
+        } catch (URISyntaxException ex) {
+            throw new IOException(ex);
+        }
+    }
 
-	public void setAccessURL(String aURL) {
-		this.accessURL = aURL;
-		this.setDesc("PB over HTTP from URL " + aURL);
-		loadPBclasses();
-	}
-	
-	private static void loadPBclasses() {
-		try {
-			EPICSEvent.ScalarDouble.newBuilder()
-			.setSecondsintoyear(0)
-			.setNano(0)
-			.setVal(0)
-			.setSeverity(0)
-			.setStatus(0)
-			.build().toByteArray();
-		} catch(Exception ex) {
-			logger.error(ex.getMessage(), ex);
-		}
-	}
+    public String getAccessURL() {
+        return accessURL;
+    }
 
-	public void setDesc(String newDesc) {
-		this.desc = newDesc;
-	}
+    public void setAccessURL(String aURL) {
+        this.accessURL = aURL;
+        this.setDesc("PB over HTTP from URL " + aURL);
+        loadPBclasses();
+    }
 
+    private static void loadPBclasses() {
+        try {
+            EPICSEvent.ScalarDouble.newBuilder()
+                    .setSecondsintoyear(0)
+                    .setNano(0)
+                    .setVal(0)
+                    .setSeverity(0)
+                    .setStatus(0)
+                    .build()
+                    .toByteArray();
+        } catch (Exception ex) {
+            logger.error(ex.getMessage(), ex);
+        }
+    }
 
-	@Override
-	public Event getLastKnownEvent(BasicContext context, String pvName) throws IOException {
-		throw new UnsupportedOperationException();
-	}
-	
-	@Override
-	public Event getFirstKnownEvent(BasicContext context, String pvName) throws IOException {
-		return null;
-	}
+    public void setDesc(String newDesc) {
+        this.desc = newDesc;
+    }
 
+    @Override
+    public Event getLastKnownEvent(BasicContext context, String pvName) throws IOException {
+        throw new UnsupportedOperationException();
+    }
 
-	@Override
-	public String getName() {
-		return name;
-	}
-	
-	@Override
-	public void renamePV(BasicContext context, String oldName, String newName) throws IOException {
-		// Nothing to do here.
-	}
-	@Override
-	public void convert(BasicContext context, String pvName, ConversionFunction conversionFuntion) throws IOException {
-		// Nothing to do here.
-	}
+    @Override
+    public Event getFirstKnownEvent(BasicContext context, String pvName) throws IOException {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void renamePV(BasicContext context, String oldName, String newName) throws IOException {
+        // Nothing to do here.
+    }
+
+    @Override
+    public void convert(BasicContext context, String pvName, ConversionFunction conversionFuntion) throws IOException {
+        // Nothing to do here.
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PBOverHTTP/PBOverHTTPStoragePlugin.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PBOverHTTP/PBOverHTTPStoragePlugin.java
@@ -33,6 +33,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -54,7 +56,7 @@ public class PBOverHTTPStoragePlugin implements StoragePlugin {
     public List<Callable<EventStream>> getDataForPV(
             BasicContext context, String pvName, Instant startTime, Instant endTime, PostProcessor postProcessor)
             throws IOException {
-        String getURL = accessURL + "?pv=" + pvName
+        String getURL = accessURL + "?pv=" + URLEncoder.encode(pvName, StandardCharsets.UTF_8)
                 + "&from=" + TimeUtils.convertToISO8601String(startTime)
                 + "&to=" + TimeUtils.convertToISO8601String(endTime)
                 + (postProcessor != null ? "&pp=" + postProcessor.getExtension() : "")

--- a/src/main/org/epics/archiverappliance/config/ConfigServiceForTests.java
+++ b/src/main/org/epics/archiverappliance/config/ConfigServiceForTests.java
@@ -9,7 +9,6 @@ import org.epics.archiverappliance.engine.pv.EngineContext;
 import org.epics.archiverappliance.etl.common.PBThreeTierETLPVLookup;
 import org.epics.archiverappliance.mgmt.MgmtRuntimeState;
 
-import javax.servlet.ServletContext;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -21,6 +20,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Executors;
+import javax.servlet.ServletContext;
 
 public class ConfigServiceForTests extends DefaultConfigService {
     public static final String TESTAPPLIANCE0 = "appliance0";
@@ -33,11 +33,13 @@ public class ConfigServiceForTests extends DefaultConfigService {
      * This name is supposed to be something that we will not encounter in the field.
      */
     public static final String ARCH_UNIT_TEST_PVNAME_PREFIX = "--ArchUnitTest";
+
     protected static final String DEFAULT_PB_SHORT_TERM_TEST_DATA_FOLDER = getDefaultShortTermFolder();
     /**
      * A folder which is used to store the data for the unit tests...
      */
     protected static final String DEFAULT_PB_TEST_DATA_FOLDER = getDefaultPBTestFolder();
+
     static HashMap<String, ArchDBRTypes> samplePV2DBRtypemap = new HashMap<String, ArchDBRTypes>();
     private static final Logger logger = LogManager.getLogger(ConfigServiceForTests.class.getName());
     private static final Logger configlogger = LogManager.getLogger("config." + ConfigServiceForTests.class.getName());
@@ -62,28 +64,30 @@ public class ConfigServiceForTests extends DefaultConfigService {
      *
      * @throws ConfigException
      */
-	public ConfigServiceForTests() throws ConfigException {
-		super();
-	}
+    public ConfigServiceForTests() throws ConfigException {
+        super();
+    }
+
     public ConfigServiceForTests(int jcaCommandThreadCount) throws ConfigException {
         this(new File("./build/classes"), jcaCommandThreadCount);
     }
 
-	public static final int defaultMinutesDisconnect = 1;
-	public ConfigServiceForTests(File WebInfClassesFolder, int jcaCommandThreadCount) throws ConfigException {
-		this.webInfClassesFolder = WebInfClassesFolder;
-		configlogger.info("The WEB-INF/classes folder is " + this.webInfClassesFolder.getAbsolutePath());
-		appliances = new HashMap<String, ApplianceInfo>();
-		pv2appliancemapping = new ConcurrentHashMap<String, ApplianceInfo>();
-		namedFlags = new ConcurrentHashMap<String, Boolean>();
-		typeInfos = new ConcurrentHashMap<String, PVTypeInfo>();
-		archivePVRequests = new ConcurrentHashMap<String, UserSpecifiedSamplingParams>();
-		aliasNamesToRealNames = new ConcurrentHashMap<String, String>();
-		channelArchiverDataServers = new ConcurrentHashMap<String, String>();
-		pvsForThisAppliance = new ConcurrentSkipListSet<String>();
-		pausedPVsForThisAppliance = new ConcurrentSkipListSet<String>();
-		pv2ChannelArchiverDataServer = new ConcurrentHashMap<String, List<ChannelArchiverDataServerPVInfo>>();
-		appliancesConfigLoaded = new ConcurrentHashMap<String, Boolean>();
+    public static final int defaultMinutesDisconnect = 1;
+
+    public ConfigServiceForTests(File WebInfClassesFolder, int jcaCommandThreadCount) throws ConfigException {
+        this.webInfClassesFolder = WebInfClassesFolder;
+        configlogger.info("The WEB-INF/classes folder is " + this.webInfClassesFolder.getAbsolutePath());
+        appliances = new HashMap<String, ApplianceInfo>();
+        pv2appliancemapping = new ConcurrentHashMap<String, ApplianceInfo>();
+        namedFlags = new ConcurrentHashMap<String, Boolean>();
+        typeInfos = new ConcurrentHashMap<String, PVTypeInfo>();
+        archivePVRequests = new ConcurrentHashMap<String, UserSpecifiedSamplingParams>();
+        aliasNamesToRealNames = new ConcurrentHashMap<String, String>();
+        channelArchiverDataServers = new ConcurrentHashMap<String, String>();
+        pvsForThisAppliance = new ConcurrentSkipListSet<String>();
+        pausedPVsForThisAppliance = new ConcurrentSkipListSet<String>();
+        pv2ChannelArchiverDataServer = new ConcurrentHashMap<String, List<ChannelArchiverDataServerPVInfo>>();
+        appliancesConfigLoaded = new ConcurrentHashMap<String, Boolean>();
 
         myApplianceInfo = new ApplianceInfo(
                 TESTAPPLIANCE0,
@@ -179,16 +183,16 @@ public class ConfigServiceForTests extends DefaultConfigService {
         }
     }
 
-	@Override
-	public ApplianceInfo getApplianceForPV(String pvName) {
-		ApplianceInfo applianceInfo = super.getApplianceForPV(pvName);
-		// We should do the following code only for unit tests (and not for the real config service).
+    @Override
+    public ApplianceInfo getApplianceForPV(String pvName) {
+        ApplianceInfo applianceInfo = super.getApplianceForPV(pvName);
+        // We should do the following code only for unit tests (and not for the real config service).
         if (applianceInfo == null && pvName.startsWith(ConfigServiceForTests.ARCH_UNIT_TEST_PVNAME_PREFIX)) {
-			logger.debug("Setting appliance for unit test pv " + pvName + " to self in unit tests mode.");
-			applianceInfo = myApplianceInfo;
-		}
-		return applianceInfo;
-	}
+            logger.debug("Setting appliance for unit test pv " + pvName + " to self in unit tests mode.");
+            applianceInfo = myApplianceInfo;
+        }
+        return applianceInfo;
+    }
 
     /**
      * Register the pv to the appliance
@@ -199,23 +203,25 @@ public class ConfigServiceForTests extends DefaultConfigService {
      * @param applianceInfo ApplianceInfo
      * @throws AlreadyRegisteredException pv already registered.
      */
-	@Override
-	public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo) throws AlreadyRegisteredException {
-		super.registerPVToAppliance(pvName, applianceInfo);
-		if (applianceInfo.getIdentity().equals(myApplianceInfo.getIdentity())) {
-			logger.info("Adding pv " + pvName + " to this appliance's pvs and to ETL");
-			this.pvsForThisAppliance.add(pvName);
+    @Override
+    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo) throws AlreadyRegisteredException {
+        super.registerPVToAppliance(pvName, applianceInfo);
+        if (applianceInfo.getIdentity().equals(myApplianceInfo.getIdentity())) {
+            logger.info("Adding pv " + pvName + " to this appliance's pvs and to ETL");
+            this.pvsForThisAppliance.add(pvName);
             if (this.getETLLookup() != null) {
-            	this.getETLLookup().addETLJobsForUnitTests(pvName, this.getTypeInfoForPV(pvName));
+                this.getETLLookup().addETLJobsForUnitTests(pvName, this.getTypeInfoForPV(pvName));
             }
         }
     }
 
-
     @Override
     public InputStream getPolicyText() throws IOException {
         if (webInfClassesFolder != null) {
-            String policyURL = ConfigServiceForTests.class.getClassLoader().getResource("policies.py").getPath().toString();
+            String policyURL = ConfigServiceForTests.class
+                    .getClassLoader()
+                    .getResource("policies.py")
+                    .getPath();
             return new FileInputStream(policyURL);
         }
         return super.getPolicyText();
@@ -273,12 +279,11 @@ public class ConfigServiceForTests extends DefaultConfigService {
         this.rootFolder = rootFolder;
     }
 
-
-	@Override
-	public String getWebInfFolder() {
-		if (this.webInfClassesFolder != null) {
-			return this.webInfClassesFolder.getAbsolutePath();
-		}
+    @Override
+    public String getWebInfFolder() {
+        if (this.webInfClassesFolder != null) {
+            return this.webInfClassesFolder.getAbsolutePath();
+        }
 
         return super.getWebInfFolder();
     }

--- a/src/main/org/epics/archiverappliance/config/ConfigServiceForTests.java
+++ b/src/main/org/epics/archiverappliance/config/ConfigServiceForTests.java
@@ -235,7 +235,7 @@ public class ConfigServiceForTests extends DefaultConfigService {
         // For the unit tests, we have a naming convention that identifies the DBR type etc based on the name of the
         // PV...
         if (pvName.startsWith(ConfigServiceForTests.ARCH_UNIT_TEST_PVNAME_PREFIX)) {
-            pvName = PVNames.stripFieldNameFromPVName(pvName);
+            pvName = PVNames.channelNamePVName(pvName);
             logger.info("Unit test typeinfo for pv " + pvName);
             ArchDBRTypes namingConventionType = samplePV2DBRtypemap.get(pvName);
             if (namingConventionType == null) {

--- a/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
+++ b/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
@@ -1115,8 +1115,8 @@ public class DefaultConfigService implements ConfigService {
 
     @Override
     public boolean isBeingArchivedOnThisAppliance(String pvName) {
-        boolean isField = PVNames.isField(pvName);
-        String plainPVName = PVNames.stripFieldNameFromPVName(pvName);
+        boolean isField = PVNames.isFieldOrFieldModifier(pvName);
+        String plainPVName = PVNames.channelNamePVName(pvName);
         String fieldName = PVNames.getFieldName(pvName);
         if (isField) {
             // If this is a field, we have two possibilities.
@@ -1536,7 +1536,7 @@ public class DefaultConfigService implements ConfigService {
                 new HashMap<String, List<ChannelArchiverDataServerPVInfo>>();
         long totalPVsProxied = 0;
         for (NamesHandler.ChannelDescription pvChannelDesc : handler.getChannels()) {
-            String pvName = PVNames.normalizePVName(pvChannelDesc.getName());
+            String pvName = PVNames.normalizeChannelName(pvChannelDesc.getName());
             if (this.pv2ChannelArchiverDataServer.containsKey(pvName)) {
                 List<ChannelArchiverDataServerPVInfo> alreadyExistingServers =
                         this.pv2ChannelArchiverDataServer.get(pvName);
@@ -1645,7 +1645,7 @@ public class DefaultConfigService implements ConfigService {
 
     @Override
     public List<ChannelArchiverDataServerPVInfo> getChannelArchiverDataServers(String pvName) {
-        String normalizedPVName = PVNames.normalizePVName(pvName);
+        String normalizedPVName = PVNames.normalizeChannelName(pvName);
         logger.debug(() -> "Looking for CA sever for pv " + normalizedPVName);
         return pv2ChannelArchiverDataServer.get(normalizedPVName);
     }
@@ -2158,7 +2158,7 @@ public class DefaultConfigService implements ConfigService {
         // Add fields and the VAL field
         for (String pvName : allPVs) {
             func.accept(pvName);
-            if (!PVNames.isField(pvName)) {
+            if (!PVNames.isFieldOrFieldModifier(pvName)) {
                 func.accept(pvName + ".VAL");
                 PVTypeInfo typeInfo = this.getTypeInfoForPV(pvName);
                 if (typeInfo != null) {
@@ -2171,7 +2171,7 @@ public class DefaultConfigService implements ConfigService {
         List<String> allAliases = this.getAllAliases();
         for (String pvName : allAliases) {
             func.accept(pvName);
-            if (!PVNames.isField(pvName)) {
+            if (!PVNames.isFieldOrFieldModifier(pvName)) {
                 func.accept(pvName + ".VAL");
                 PVTypeInfo typeInfo = this.getTypeInfoForPV(pvName);
                 if (typeInfo != null) {
@@ -2183,7 +2183,7 @@ public class DefaultConfigService implements ConfigService {
         }
         for (String pvName : this.getArchiveRequestsCurrentlyInWorkflow()) {
             func.accept(pvName);
-            if (!PVNames.isField(pvName)) {
+            if (!PVNames.isFieldOrFieldModifier(pvName)) {
                 func.accept(pvName + ".VAL");
             }
         }

--- a/src/main/org/epics/archiverappliance/engine/bpl/GetDataAtTimeEngine.java
+++ b/src/main/org/epics/archiverappliance/engine/bpl/GetDataAtTimeEngine.java
@@ -88,7 +88,7 @@ public class GetDataAtTimeEngine implements BPLAction {
     @Override
     public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
             throws IOException {
-        List<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
+        List<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req);
         logger.debug("Getting data at time for PVs " + pvNames.size());
 
         String timeStr = req.getParameter("at");

--- a/src/main/org/epics/archiverappliance/engine/bpl/GetDataAtTimeEngine.java
+++ b/src/main/org/epics/archiverappliance/engine/bpl/GetDataAtTimeEngine.java
@@ -20,122 +20,139 @@ import org.epics.archiverappliance.engine.membuf.ArrayListEventStream;
 import org.epics.archiverappliance.engine.model.ArchiveChannel;
 import org.epics.archiverappliance.engine.pv.EngineContext;
 import org.epics.archiverappliance.mgmt.bpl.PVsMatchingParameter;
-import org.epics.archiverappliance.retrieval.mimeresponses.MimeResponse;
 import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * PV for getting the data for multiple PV's from the engine's buffers at a particular time.
  * We loop thru all the values and find the latest value in the engine that is older or equal to the specified time.
- * If no such sample is present, we do not add the PV to the JSON response. 
+ * If no such sample is present, we do not add the PV to the JSON response.
  * @author mshankar
  *
  */
 public class GetDataAtTimeEngine implements BPLAction {
-	private static final Logger logger = LogManager.getLogger(GetDataAtTimeEngine.class);
-	
-	/**
-	 * Evaluate a new event from an event stream to see if it is applicable as a source of data for getDataForTime.
-	 * We mostly want to find the latest event before or at the requested timestamp.
-	 * @param atTime
-	 * @param newEventToConsider
-	 * @param alreadyExistingEvent
-	 * @param fieldIsEmbeddedInStream
-	 * @param fieldName
-	 * @return
-	 */
-    private static DBRTimeEvent evaluatePotentialEvent(Instant atTime, DBRTimeEvent newEventToConsider, DBRTimeEvent alreadyExistingEvent, boolean fieldIsEmbeddedInStream, String fieldName) {
-        if (newEventToConsider != null && newEventToConsider.getEventTimeStamp().isBefore(atTime) || newEventToConsider.getEventTimeStamp().equals(atTime)) {
-			if(alreadyExistingEvent != null) {
+    private static final Logger logger = LogManager.getLogger(GetDataAtTimeEngine.class);
+
+    /**
+     * Evaluate a new event from an event stream to see if it is applicable as a source of data for getDataForTime.
+     * We mostly want to find the latest event before or at the requested timestamp.
+     * @param atTime
+     * @param newEventToConsider
+     * @param alreadyExistingEvent
+     * @param fieldIsEmbeddedInStream
+     * @param fieldName
+     * @return
+     */
+    private static DBRTimeEvent evaluatePotentialEvent(
+            Instant atTime,
+            DBRTimeEvent newEventToConsider,
+            DBRTimeEvent alreadyExistingEvent,
+            boolean fieldIsEmbeddedInStream,
+            String fieldName) {
+        if (newEventToConsider != null && newEventToConsider.getEventTimeStamp().isBefore(atTime)
+                || newEventToConsider.getEventTimeStamp().equals(atTime)) {
+            if (alreadyExistingEvent != null) {
                 if (newEventToConsider.getEventTimeStamp().isAfter(alreadyExistingEvent.getEventTimeStamp())) {
-					if(fieldIsEmbeddedInStream) {
-						if(newEventToConsider.hasFieldValues() && newEventToConsider.getFieldValue(fieldName) != null) {
-							return newEventToConsider;
-						}
-					} else {
-						return newEventToConsider;
-					}
-				}
-			} else {
-				if(fieldIsEmbeddedInStream) {
-					if(newEventToConsider.hasFieldValues() && newEventToConsider.getFieldValue(fieldName) != null) {
-						return newEventToConsider;
-					}
-				} else {
-					return newEventToConsider;
-				}
-			}
-		}
-		return alreadyExistingEvent;
-	}
-	
-	@Override
-	public void execute(HttpServletRequest req, HttpServletResponse resp,
-			ConfigService configService) throws IOException {
-		List<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
-		logger.debug("Getting data at time for PVs " + pvNames.size());
+                    if (fieldIsEmbeddedInStream) {
+                        if (newEventToConsider.hasFieldValues()
+                                && newEventToConsider.getFieldValue(fieldName) != null) {
+                            return newEventToConsider;
+                        }
+                    } else {
+                        return newEventToConsider;
+                    }
+                }
+            } else {
+                if (fieldIsEmbeddedInStream) {
+                    if (newEventToConsider.hasFieldValues() && newEventToConsider.getFieldValue(fieldName) != null) {
+                        return newEventToConsider;
+                    }
+                } else {
+                    return newEventToConsider;
+                }
+            }
+        }
+        return alreadyExistingEvent;
+    }
 
-		String timeStr = req.getParameter("at");
+    @Override
+    public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws IOException {
+        List<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
+        logger.debug("Getting data at time for PVs " + pvNames.size());
+
+        String timeStr = req.getParameter("at");
         Instant atTime = TimeUtils.now();
-		if(timeStr != null) {
-			atTime = TimeUtils.convertFromISO8601String(timeStr);
-		}
+        if (timeStr != null) {
+            atTime = TimeUtils.convertFromISO8601String(timeStr);
+        }
 
-		EngineContext engineContext = configService.getEngineContext();
-		HashMap<String, HashMap<String, Object>> values = new HashMap<String, HashMap<String, Object>>();
-		for(String pvName : pvNames) {
-			String nameFromUser = pvName;
-			String fieldName = PVNames.getFieldName(pvName);
-			boolean fieldIsEmbeddedInStream = false;
+        EngineContext engineContext = configService.getEngineContext();
+        HashMap<String, HashMap<String, Object>> values = new HashMap<String, HashMap<String, Object>>();
+        for (String pvName : pvNames) {
+            String nameFromUser = pvName;
+            String fieldName = PVNames.getFieldName(pvName);
+            boolean fieldIsEmbeddedInStream = false;
 
-			PVTypeInfo rootTypeInfo = PVNames.determineAppropriatePVTypeInfo(pvName, configService);
-			if(rootTypeInfo == null) continue;
-			pvName = rootTypeInfo.getPvName();
+            PVTypeInfo rootTypeInfo = PVNames.determineAppropriatePVTypeInfo(pvName, configService);
+            if (rootTypeInfo == null) continue;
+            pvName = rootTypeInfo.getPvName();
 
-			if(fieldName != null && Arrays.asList(rootTypeInfo.getArchiveFields()).contains(fieldName)) {
-				fieldIsEmbeddedInStream = true;
-			}
+            if (fieldName != null
+                    && Arrays.asList(rootTypeInfo.getArchiveFields()).contains(fieldName)) {
+                fieldIsEmbeddedInStream = true;
+            }
 
-			if(engineContext.getChannelList().containsKey(pvName)){
-				ArchiveChannel archiveChannel = engineContext.getChannelList().get(pvName);
-				ArrayListEventStream st = archiveChannel.getPVData();
-				DBRTimeEvent potentialEvent = null;
-				for(Event ev : st) {
-					potentialEvent = evaluatePotentialEvent(atTime, (DBRTimeEvent) ev, potentialEvent, fieldIsEmbeddedInStream, fieldName);
-				}
-				if(archiveChannel.getLastArchivedValue() != null) {
-					potentialEvent = evaluatePotentialEvent(atTime, archiveChannel.getLastArchivedValue(), potentialEvent, fieldIsEmbeddedInStream, fieldName);
-				}
+            if (engineContext.getChannelList().containsKey(pvName)) {
+                ArchiveChannel archiveChannel = engineContext.getChannelList().get(pvName);
+                ArrayListEventStream st = archiveChannel.getPVData();
+                DBRTimeEvent potentialEvent = null;
+                for (Event ev : st) {
+                    potentialEvent = evaluatePotentialEvent(
+                            atTime, (DBRTimeEvent) ev, potentialEvent, fieldIsEmbeddedInStream, fieldName);
+                }
+                if (archiveChannel.getLastArchivedValue() != null) {
+                    potentialEvent = evaluatePotentialEvent(
+                            atTime,
+                            archiveChannel.getLastArchivedValue(),
+                            potentialEvent,
+                            fieldIsEmbeddedInStream,
+                            fieldName);
+                }
 
-				if(potentialEvent != null) {
-					HashMap<String, Object> evnt = new HashMap<String, Object>();
-					evnt.put("secs", potentialEvent.getEpochSeconds());
+                if (potentialEvent != null) {
+                    HashMap<String, Object> evnt = new HashMap<String, Object>();
+                    evnt.put("secs", potentialEvent.getEpochSeconds());
                     evnt.put("nanos", potentialEvent.getEventTimeStamp().getNano());
-					evnt.put("severity", potentialEvent.getSeverity());
-					evnt.put("status", potentialEvent.getStatus());
-					if(fieldIsEmbeddedInStream) {
-						evnt.put("val", JSONValue.parse(potentialEvent.getFields().get(fieldName)));
-					} else {
-						evnt.put("val", JSONValue.parse(potentialEvent.getSampleValue().toJSONString()));
-					}
-					values.put(nameFromUser, evnt);
-				}
-			}
-		}
+                    evnt.put("severity", potentialEvent.getSeverity());
+                    evnt.put("status", potentialEvent.getStatus());
+                    if (fieldIsEmbeddedInStream) {
+                        evnt.put(
+                                "val",
+                                JSONValue.parse(potentialEvent.getFields().get(fieldName)));
+                    } else {
+                        evnt.put(
+                                "val",
+                                JSONValue.parse(potentialEvent.getSampleValue().toJSONString()));
+                    }
+                    values.put(nameFromUser, evnt);
+                }
+            }
+        }
 
-		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
-		try(PrintWriter out = resp.getWriter()) {
-			JSONObject.writeJSONString(values, out);
-		}
-	}
+        resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+        try (PrintWriter out = resp.getWriter()) {
+            JSONObject.writeJSONString(values, out);
+        }
+    }
 }

--- a/src/main/org/epics/archiverappliance/engine/model/ArchiveChannel.java
+++ b/src/main/org/epics/archiverappliance/engine/model/ArchiveChannel.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
-
+ *
  * Copyright (c) 2010 Oak Ridge National Laboratory.
-
+ *
  * All rights reserved. This program and the accompanying materials
-
+ *
  * are made available under the terms of the Eclipse Public License v1.0
-
+ *
  * which accompanies this distribution, and is available at
-
+ *
  * http://www.eclipse.org/legal/epl-v10.html
-
+ *
  ******************************************************************************/
 package org.epics.archiverappliance.engine.model;
 
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * Base for archived channels. An ArchiveChannel has
  * <ol>
@@ -53,7 +54,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * @version Initial version:CSS
  * @version 4-Jun-2012, Luofeng Li:added codes to support for the new archiver
  */
-
 @SuppressWarnings("nls")
 public abstract class ArchiveChannel {
     private static final Logger logger = LogManager.getLogger(ArchiveChannel.class);
@@ -62,8 +62,8 @@ public abstract class ArchiveChannel {
      * Throttled log for NaN samples
      */
     private static final ThrottledLogger trouble_sample_log = new ThrottledLogger(LogLevel.info, 60);
-    private static final Instant PAST_CUTOFF_TIMESTAMP =
-            TimeUtils.convertFromISO8601String("1991-01-01T00:00:00.000Z");
+
+    private static final Instant PAST_CUTOFF_TIMESTAMP = TimeUtils.convertFromISO8601String("1991-01-01T00:00:00.000Z");
     private static final int FUTURE_CUTOFF_SECONDS = 30 * 60;
     /**
      * Initialize the metafields for this channel. In addition to the metafields specified  here, we also generate PV's
@@ -81,8 +81,8 @@ public abstract class ArchiveChannel {
     static HashMap<String, ArchDBRTypes> metaFieldOverrideTypes = new HashMap<String, ArchDBRTypes>();
 
     static {
-        fieldsAvailableFromDBRControl.addAll(Arrays.asList(
-                "PREC", "EGU", "HOPR", "LOPR", "HIHI", "HIGH", "LOW", "LOLO", "DRVH", "DRVL"));
+        fieldsAvailableFromDBRControl.addAll(
+                Arrays.asList("PREC", "EGU", "HOPR", "LOPR", "HIHI", "HIGH", "LOW", "LOLO", "DRVH", "DRVL"));
     }
 
     static {
@@ -337,34 +337,48 @@ public abstract class ArchiveChannel {
     /**
      * Add a pv for this PV for the given metafield.
      */
-	private void addMetaField(String fieldName, ConfigService configservice, boolean isRuntimeOnly, boolean usePVAccess, boolean useDBEProperties) throws IOException {
-		if(this.pv == null) throw new IOException("Cannot add metadata fields for channel that does not have its PV initialized.");
+    private void addMetaField(
+            String fieldName,
+            ConfigService configservice,
+            boolean isRuntimeOnly,
+            boolean usePVAccess,
+            boolean useDBEProperties)
+            throws IOException {
+        if (this.pv == null)
+            throw new IOException("Cannot add metadata fields for channel that does not have its PV initialized.");
 
-		if (!usePVAccess) {
-			EPICS_V3_PV v3Pv = (EPICS_V3_PV) this.pv;
-			v3AddMetaField(v3Pv, fieldName, configservice, isRuntimeOnly, useDBEProperties);
-		} else {
-			EPICS_V4_PV v4Pv = (EPICS_V4_PV) this.pv;
-			v4Pv.addMetaField(fieldName);
-		}
-	}
+        if (!usePVAccess) {
+            EPICS_V3_PV v3Pv = (EPICS_V3_PV) this.pv;
+            v3AddMetaField(v3Pv, fieldName, configservice, isRuntimeOnly, useDBEProperties);
+        } else {
+            EPICS_V4_PV v4Pv = (EPICS_V4_PV) this.pv;
+            v4Pv.addMetaField(fieldName);
+        }
+    }
 
-	private void v3AddMetaField(EPICS_V3_PV v3Pv,  String fieldName, ConfigService configservice, boolean isRuntimeOnly, boolean useDBEProperties) {
-		if(useDBEProperties) {
-			// For a DBE_PROPERTIES, we use the name of the PV as the name of the channel
-			v3Pv.setDBEroperties();
-			return;
-		}
+    private void v3AddMetaField(
+            EPICS_V3_PV v3Pv,
+            String fieldName,
+            ConfigService configservice,
+            boolean isRuntimeOnly,
+            boolean useDBEProperties) {
+        if (useDBEProperties) {
+            // For a DBE_PROPERTIES, we use the name of the PV as the name of the channel
+            v3Pv.setDBEroperties();
+            return;
+        }
         // This tells the main PV to create the hashmaps for the metafield storage
-		v3Pv.markPVHasMetafields(true);
-		String pvNameForField = PVNames.stripFieldNameFromPVName(this.name) + "." + fieldName;
-		ArchDBRTypes metaFieldDBRType = v3Pv.getArchDBRTypes();
-		if(metaFieldOverrideTypes.containsKey(fieldName)) {
+        v3Pv.markPVHasMetafields(true);
+        String pvNameForField = PVNames.stripFieldNameFromPVName(this.name) + "." + fieldName;
+        ArchDBRTypes metaFieldDBRType = v3Pv.getArchDBRTypes();
+        if (metaFieldOverrideTypes.containsKey(fieldName)) {
             metaFieldDBRType = metaFieldOverrideTypes.get(fieldName);
         }
-		logger.debug("Initializing the metafield for field " + pvNameForField + " as ArchDBRType " + metaFieldDBRType.toString() + " DBE_PROPERTIES is " + false);
-		EPICS_V3_PV metaPV = (EPICS_V3_PV) PVFactory.createPV(pvNameForField, configservice, false, metaFieldDBRType, this.JCACommandThreadID, false, false);
-		metaPV.setMetaFieldParentPV(v3Pv, isRuntimeOnly);
+        logger.debug("Initializing the metafield for field " + pvNameForField + " as ArchDBRType "
+                + metaFieldDBRType.toString() + " DBE_PROPERTIES is " + false);
+        EPICS_V3_PV metaPV = (EPICS_V3_PV) PVFactory.createPV(
+                pvNameForField, configservice, false, metaFieldDBRType, this.JCACommandThreadID, false, false);
+        metaPV.setMetaFieldParentPV(v3Pv, isRuntimeOnly);
         this.metaPVs.put(fieldName, metaPV);
     }
 
@@ -600,7 +614,6 @@ public abstract class ArchiveChannel {
         }
 
         if (SampleBuffer.isInErrorState()) need_write_error_sample = true;
-
     }
 
     /**
@@ -685,8 +698,7 @@ public abstract class ArchiveChannel {
      * @return - Can return null if this PV has no meta fields.
      */
     public HashMap<String, String> getCurrentCopyOfMetaFields() {
-        if (this.pv != null)
-            return pv.getLatestMetadata();
+        if (this.pv != null) return pv.getLatestMetadata();
         return null;
     }
 
@@ -791,8 +803,7 @@ public abstract class ArchiveChannel {
                     ArchiveChannel.this.pv.updateTotalMetaInfo();
                 } catch (Throwable t) {
                     logger.error(
-                            "Exception issuing request to update total meta Info for pv "
-                                    + ArchiveChannel.this.name,
+                            "Exception issuing request to update total meta Info for pv " + ArchiveChannel.this.name,
                             t);
                 }
             });

--- a/src/main/org/epics/archiverappliance/engine/model/ArchiveChannel.java
+++ b/src/main/org/epics/archiverappliance/engine/model/ArchiveChannel.java
@@ -369,7 +369,7 @@ public abstract class ArchiveChannel {
         }
         // This tells the main PV to create the hashmaps for the metafield storage
         v3Pv.markPVHasMetafields(true);
-        String pvNameForField = PVNames.stripFieldNameFromPVName(this.name) + "." + fieldName;
+        String pvNameForField = PVNames.channelNamePVName(this.name) + "." + fieldName;
         ArchDBRTypes metaFieldDBRType = v3Pv.getArchDBRTypes();
         if (metaFieldOverrideTypes.containsKey(fieldName)) {
             metaFieldDBRType = metaFieldOverrideTypes.get(fieldName);

--- a/src/main/org/epics/archiverappliance/engine/pv/EPICS_V3_PV.java
+++ b/src/main/org/epics/archiverappliance/engine/pv/EPICS_V3_PV.java
@@ -47,979 +47,1015 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * EPICS ChannelAccess implementation of the PV interface.
- * 
+ *
  * @see PV
  * @author Kay Kasemir
  * @version Initial version:CSS
  * @version 4-Jun-2012, Luofeng Li:added codes to support for the new archiver
  */
 public class EPICS_V3_PV implements PV, ControllingPV, ConnectionListener, MonitorListener {
-	private static final Logger logger = LogManager.getLogger(EPICS_V3_PV.class.getName());
-	
-	/**
-	 * Use plain mode?
-	 * @see EPICS_V3_PV(String, boolean)
-	 */
-	final private boolean plain;
+    private static final Logger logger = LogManager.getLogger(EPICS_V3_PV.class.getName());
 
-	/** Channel name. */
-	final private String name;
-	
-	/**the meta info for this pv*/
-	private MetaInfo totalMetaInfo = new MetaInfo();
-	
-	/**
-	 * If this pv is a meta field, then the metafield parent PV is where the data for this metafield is stored.
-	 **/
-	private EPICS_V3_PV parentPVForMetaField = null;
-	
-	/**
-	 * If this pv has many meta fields archived, allarchiveFieldsData includes the meta field names and their values.
-	 * allarchiveFieldsData is updated when meta field changes
-	 * if this pv doesn't have meta field archived, this  is always  null.
-	 */
-	private ConcurrentHashMap<String, String> allarchiveFieldsData = null;
-	
-	/** Runtime fields that are not archived/stored are stored here */
-	private final ConcurrentHashMap<String, String> runTimeFieldsData = new ConcurrentHashMap<String, String>();
-	
-	/** if this pv has many meta fields archived,changedarchiveFieldsData includes the changed meta values and the field names*/
-	private ConcurrentHashMap<String, String> changedarchiveFieldsData = null;
-	
-	/**we save all meta field once every day and lastTimeStampWhenSavingarchiveFields is when we save all last meta fields*/
-	private long archiveFieldsSavedAtEpSec = 0;
-	
-	/**this pv is meta field  or not*/
-	private boolean isarchiveFieldsField = false;
-	
-	/** Store the value for this only in the runtime and not into the stores...*/
-	private boolean isruntimeFieldField = false;
-	
-	/**
-	 * Establish the monitor using a DBE_PROPERTY mask. DBE_PROPERTY events are also processed a little differently.
-	 */
-	private boolean isDBEProperties = false;
-	
-	private PVConnectionState state = PVConnectionState.Idle;
-	
-	/**
-	 *  Sourced from org/csstudio/platform/libs/epics/EpicsPlugin.java 
-	 *  @author Original author unknown
-	 *  @author Kay Kasemir
-	 *  @author Sergei Chevtsov
-	 */
-	public enum MonitorMask {
-		/** Listen to changes in value beyond 'MDEL' threshold or alarm state*/
-		VALUE(1 | 4),
+    /**
+     * Use plain mode?
+     * @see EPICS_V3_PV(String, boolean)
+     */
+    private final boolean plain;
 
-		/** Listen to changes in value beyond 'ADEL' archive limit */
-		ARCHIVE(2 | 4),
+    /** Channel name. */
+    private final String name;
 
-		/** Listen to changes in alarm state */
-		ALARM(4),
-		
-		/** Listen to changes in property  */
-		PROPERTY(8);
+    /**the meta info for this pv*/
+    private MetaInfo totalMetaInfo = new MetaInfo();
 
-		final private int mask;
+    /**
+     * If this pv is a meta field, then the metafield parent PV is where the data for this metafield is stored.
+     **/
+    private EPICS_V3_PV parentPVForMetaField = null;
 
-		private MonitorMask(final int mask) {
-			this.mask = mask;
-		}
+    /**
+     * If this pv has many meta fields archived, allarchiveFieldsData includes the meta field names and their values.
+     * allarchiveFieldsData is updated when meta field changes
+     * if this pv doesn't have meta field archived, this  is always  null.
+     */
+    private ConcurrentHashMap<String, String> allarchiveFieldsData = null;
 
-		/** @return Mask bits used in underlying CA call */
-		public int getMask() {
-			return mask;
-		}
-	}
+    /** Runtime fields that are not archived/stored are stored here */
+    private final ConcurrentHashMap<String, String> runTimeFieldsData = new ConcurrentHashMap<String, String>();
 
+    /** if this pv has many meta fields archived,changedarchiveFieldsData includes the changed meta values and the field names*/
+    private ConcurrentHashMap<String, String> changedarchiveFieldsData = null;
 
-	/**configservice used by this pv*/
-	final private ConfigService configservice;
-	
-	/** PVListeners of this PV */
-	final private CopyOnWriteArrayList<PVListener> listeners = new CopyOnWriteArrayList<PVListener>();
-	
-	/** JCA channel. LOCK <code>this</code> on change. */
-	private RefCountedChannel channel_ref = null;
-	
-	/**
-	 * Either <code>null</code>, or the subscription identifier. LOCK
-	 * <code>this</code> on change
-	 */
-	private Monitor subscription = null;
-	
-	private Monitor dbePropertiesSubscription = null;
-	
-	/**
-	 * isConnected? <code>true</code> if we are currently connected (based on
-	 * the most recent connection callback).
-	 * <p>
-	 * EPICS_V3_PV also runs notifyAll() on <code>this</code> whenever the
-	 * connected flag changes to <code>true</code>.
-	 */
-	private volatile boolean connected = false;
-	
-	/**
-	 * isRunning? <code>true</code> if we want to receive value updates.
-	 */
-	private volatile boolean running = false;
-	
-	/**the DBRTimeEvent constructor for this pv*/
-	private Constructor<? extends DBRTimeEvent> con;
-	
-	/**the current DBRTimeEvent*/
-	private DBRTimeEvent dbrtimeevent;
-	
-	/**the ArchDBRTypes of this pv*/
-	private ArchDBRTypes archDBRType = null;
-	
-	/**
-	 * The JCA command thread that processes actions for this PV.
-	 * This should be inherited from the ArchiveChannel.
-	 */
-	private int jcaCommandThreadId;
+    /**we save all meta field once every day and lastTimeStampWhenSavingarchiveFields is when we save all last meta fields*/
+    private long archiveFieldsSavedAtEpSec = 0;
 
-	/**
-	 * The pvs' list who are controlled by this pv to stop or start archiving
-	 **/
-	private ArrayList<String> controlledPVList = null;
+    /**this pv is meta field  or not*/
+    private boolean isarchiveFieldsField = false;
 
-	/**
-	 * The current status of all pvs who are controlled by this pv.
-	 * if true, all pvs are archiving.
-	 * else , all pvs are not
-	 **/
-	private boolean enableAllPV = true;
+    /** Store the value for this only in the runtime and not into the stores...*/
+    private boolean isruntimeFieldField = false;
 
-	/**Does this pv have one meta field archived?*/
-	private boolean hasMetaField = false;
-	
-	/**
-	 * The server time when we last received a monitor event.
-	 */
-	private long lastMonitorSecs = 0;
-	
-	/**
-	 * Misc bucket for catching various transient errors that we are aware of. Probably not all that useful.
-	 */
-	private long transientErrorCount = 0;
+    /**
+     * Establish the monitor using a DBE_PROPERTY mask. DBE_PROPERTY events are also processed a little differently.
+     */
+    private boolean isDBEProperties = false;
 
-	/**
-	 * the ioc host name where this pv is 
-	 */
-	private String hostName;
-    
-	@Override
-	public String getHostName(){
-		return hostName;
-	}
+    private PVConnectionState state = PVConnectionState.Idle;
 
-	/**
-	 * 
-	 * @return the status of all pvs controlled by this pv
-	 */
-	@Override
-	public boolean isEnableAllPV() {
-		return enableAllPV;
-	}
-        
-	/**
+    /**
+     *  Sourced from org/csstudio/platform/libs/epics/EpicsPlugin.java
+     *  @author Original author unknown
+     *  @author Kay Kasemir
+     *  @author Sergei Chevtsov
+     */
+    public enum MonitorMask {
+        /** Listen to changes in value beyond 'MDEL' threshold or alarm state*/
+        VALUE(1 | 4),
+
+        /** Listen to changes in value beyond 'ADEL' archive limit */
+        ARCHIVE(2 | 4),
+
+        /** Listen to changes in alarm state */
+        ALARM(4),
+
+        /** Listen to changes in property  */
+        PROPERTY(8);
+
+        private final int mask;
+
+        private MonitorMask(final int mask) {
+            this.mask = mask;
+        }
+
+        /** @return Mask bits used in underlying CA call */
+        public int getMask() {
+            return mask;
+        }
+    }
+
+    /**configservice used by this pv*/
+    private final ConfigService configservice;
+
+    /** PVListeners of this PV */
+    private final CopyOnWriteArrayList<PVListener> listeners = new CopyOnWriteArrayList<PVListener>();
+
+    /** JCA channel. LOCK <code>this</code> on change. */
+    private RefCountedChannel channel_ref = null;
+
+    /**
+     * Either <code>null</code>, or the subscription identifier. LOCK
+     * <code>this</code> on change
+     */
+    private Monitor subscription = null;
+
+    private Monitor dbePropertiesSubscription = null;
+
+    /**
+     * isConnected? <code>true</code> if we are currently connected (based on
+     * the most recent connection callback).
+     * <p>
+     * EPICS_V3_PV also runs notifyAll() on <code>this</code> whenever the
+     * connected flag changes to <code>true</code>.
+     */
+    private volatile boolean connected = false;
+
+    /**
+     * isRunning? <code>true</code> if we want to receive value updates.
+     */
+    private volatile boolean running = false;
+
+    /**the DBRTimeEvent constructor for this pv*/
+    private Constructor<? extends DBRTimeEvent> con;
+
+    /**the current DBRTimeEvent*/
+    private DBRTimeEvent dbrtimeevent;
+
+    /**the ArchDBRTypes of this pv*/
+    private ArchDBRTypes archDBRType = null;
+
+    /**
+     * The JCA command thread that processes actions for this PV.
+     * This should be inherited from the ArchiveChannel.
+     */
+    private int jcaCommandThreadId;
+
+    /**
+     * The pvs' list who are controlled by this pv to stop or start archiving
+     **/
+    private ArrayList<String> controlledPVList = null;
+
+    /**
+     * The current status of all pvs who are controlled by this pv.
+     * if true, all pvs are archiving.
+     * else , all pvs are not
+     **/
+    private boolean enableAllPV = true;
+
+    /**Does this pv have one meta field archived?*/
+    private boolean hasMetaField = false;
+
+    /**
+     * The server time when we last received a monitor event.
+     */
+    private long lastMonitorSecs = 0;
+
+    /**
+     * Misc bucket for catching various transient errors that we are aware of. Probably not all that useful.
+     */
+    private long transientErrorCount = 0;
+
+    /**
+     * the ioc host name where this pv is
+     */
+    private String hostName;
+
+    @Override
+    public String getHostName() {
+        return hostName;
+    }
+
+    /**
+     *
+     * @return the status of all pvs controlled by this pv
+     */
+    @Override
+    public boolean isEnableAllPV() {
+        return enableAllPV;
+    }
+
+    /**
      * @see PV#getArchDBRTypes()
      */
-	@Override
-	public ArchDBRTypes getArchDBRTypes() {
-		return archDBRType;
-	}
+    @Override
+    public ArchDBRTypes getArchDBRTypes() {
+        return archDBRType;
+    }
 
-	/***
-    *get  the meta info for this pv 
-    * @return MetaInfo 
-    */
-	@Override
-	public MetaInfo getTotalMetaInfo() {
-		return totalMetaInfo;
-	}
-	
-	/** Listener to the get... for meta data */
-	private final GetListener meta_get_listener = new GetListener() {
-		@Override
-		public void getCompleted(final GetEvent event) { // This runs in a CA
-															// thread
-			if (event.getStatus().isSuccessful()) {
-				state = PVConnectionState.GotMetaData;
-				final DBR dbr = event.getDBR();
-				totalMetaInfo.applyBasicInfo(EPICS_V3_PV.this.name, dbr, EPICS_V3_PV.this.configservice);
-			} else {
-				logger.error("The meta get listener was not successful for EPICS_V3_PV " + name);
-			}
-			PVContext.scheduleCommand(EPICS_V3_PV.this.name, EPICS_V3_PV.this.jcaCommandThreadId, EPICS_V3_PV.this.channel_ref, "getCompleted", new Runnable() {
-				@Override
-				public void run() {
-					subscribe();
-				}
-			});
-		}
-	};
-   
-	/**
-	 * @param pvName
-	 *            The PV name
-	 */
-	@Override
-	public void addControledPV(String pvName) {
-		controlledPVList.add(pvName);
-	}
-	
-	/**
-	 * Generate an EPICS PV.
-	 * 
-	 * @param name
-	 *            The PV name.
-	 * @param configservice  The config service used by this pv
-	 * @param isControlPV true if this is a pv controlling other pvs  
-	 * @param archDBRTypes ArchDBRTypes
-	 * @param jcaCommandThreadId The JCA Command thread. 
-	 * @param isDBEProperties  &emsp;
-	 */
-	EPICS_V3_PV(final String name, ConfigService configservice, boolean isControlPV, ArchDBRTypes archDBRTypes, int jcaCommandThreadId, boolean isDBEProperties) {
-		this(name, false, configservice, jcaCommandThreadId);
-		this.archDBRType = archDBRTypes;
-		this.isDBEProperties = isDBEProperties;
-		if(archDBRTypes != null) { 
-			this.con = configservice.getArchiverTypeSystem().getJCADBRConstructor(archDBRType);
-		}
-		if (isControlPV) {
-			this.controlledPVList = new ArrayList<String>();
-		}
-	}
-	
-	/**
-	 * Generate an EPICS PV.
-	 * 
-	 * @param name
-	 *            The PV name.
-	 * @param  configservice The config service used by this pv
-	 * @param jcaCommandThreadId The JCA Command thread 
-	 */
-	// isControlPV
-	EPICS_V3_PV(final String name, ConfigService configservice, int jcaCommandThreadId) {
-		this(name, false, configservice, jcaCommandThreadId);
-	}
-	
-	
-	/**
-	 * Generate an EPICS PV.
-	 * 
-	 * @param name
-	 *            The PV name.
-	 * @param plain
-	 *            When <code>true</code>, only the plain value is requested. No
-	 *            time etc. Some PVs only work in plain mode, example:
-	 *            "record.RTYP".
-	 * @param configservice  The config service used by this pv
-	 * @param jcaCommandThreadId  The JCA Command thread 
-	 */
-	private EPICS_V3_PV(final String name, final boolean plain, ConfigService configservice, int jcaCommandThreadId) {
-		this.name = name;
-		this.plain = plain;
-		this.configservice = configservice;
-		this.jcaCommandThreadId = jcaCommandThreadId;
-		PVContext.setConfigservice(configservice);
-	}
-	
-	/** @return Returns the name. */
-	@Override
-	public String getName() {
-		return name;
-	}
-	
-	/** {@inheritDoc} */
-	@Override
-	public void addListener(final PVListener listener) {
-		listeners.add(listener);
-	}
-	
-	/** {@inheritDoc} */
-	@Override
-	public void removeListener(final PVListener listener) {
-		listeners.remove(listener);
-	}
-	
-	/**
-	 * Try to connect to the PV. OK to call more than once.
-	 */
-	private void connect() throws Exception {
-		logger.debug("pv of"+this.name+" connectting");
-		PVContext.scheduleCommand(this.name, this.jcaCommandThreadId, this.channel_ref, "connect", new Runnable() {
-			@Override
-			public void run() {
-				//
-				try {
-					state = PVConnectionState.Connecting;
-					// Already attempted a connection?
-					synchronized (this) {
-						if (channel_ref == null) {
-							channel_ref = PVContext.getChannel(name,EPICS_V3_PV.this.jcaCommandThreadId, EPICS_V3_PV.this);
-						}
-						fireConnectionRequestMade();
-						if (channel_ref.getChannel().getConnectionState() == ConnectionState.CONNECTED) {
-							handleConnected(channel_ref.getChannel());
-						}
-					}
-				} catch (Exception e) {
-					logger.error("exception when connecting pv "+name, e);
-				}
-			}
-		});
-	}
-	
-	/**
-	 * Disconnect from the PV. OK to call more than once.
-	 */
-	private void disconnect() {
-		// Releasing the _last_ channel will close the context,
-		// which waits for the JCA Command thread to exit.
-		// If a connection or update for the channel happens at that time,
-		// the JCA command thread will send notifications to this PV,
-		// which had resulted in dead lock:
-		// This code locked the PV, then tried to join the JCA Command thread.
-		// JCA Command thread tried to lock the PV, so it could not exit.
-		// --> Don't lock while calling into the PVContext.
-		RefCountedChannel channel_ref_copy;
-		synchronized (this) {
-			// Never attempted a connection?
-			if (channel_ref == null)
-				return;
-			channel_ref_copy = channel_ref;
-			channel_ref = null;
-			connected = false;
-		}
-		try {
-			PVContext.releaseChannel(channel_ref_copy, this);
-		} catch (final IllegalStateException ile) {
-			logger.warn("exception when disconnecting pv "+name, ile);			
-		} catch (final Throwable e) {
-			logger.error("exception when disconnecting pv "+name, e);
-		}
-		fireDisconnected();
-	}
-	
-	/** Subscribe for value updates. */
-	private void subscribe() {
-		synchronized (this) {
-			// Prevent multiple subscriptions.
-			if (subscription != null) {
-				logger.error("When trying to establish a subscription, there is already a subscription for " + this.name);
-				return;
-			}
-			// Late callback, channel already closed?
-			final RefCountedChannel ch_ref = channel_ref;
-			if (ch_ref == null) {
-				logger.error("When trying to establish a subscription, the refcounted channel is closed for " + this.name);
-				return;
-			}
-			final Channel channel = ch_ref.getChannel();
-			// final Logger logger = Activator.getLogger();
-			try {
-				if(channel.getConnectionState()!=Channel.CONNECTED){
-					logger.error("When trying to establish a subscription, the CA channel is not connected for " + this.name);
-					return;
-				}
-				//
-				// the RefCountedChannel should maintain a single
-				// subscription to the underlying CAJ/JCA channel.
-				// So even with N PVs for the same channel, it's
-				// only one subscription on the network instead of
-				// N subscriptions.
-				final DBRType type = DBR_Helper.getTimeType(plain, channel.getFieldType());
-				state = PVConnectionState.Subscribing;
-				totalMetaInfo.setStartTime(System.currentTimeMillis());
-				// isnotTimestampDBR
-				if (this.name.endsWith(".RTYP")) {
-					subscription = channel.addMonitor(MonitorMask.ARCHIVE.getMask(), this);
-				} else {
-					if(this.isDBEProperties && dbePropertiesSubscription == null) { 
-						logger.debug("Adding a DBE_PROPERTIES monitor for " + this.name);
-						dbePropertiesSubscription = channel.addMonitor(DBR_Helper.getControlType(channel.getFieldType()),
-								1, MonitorMask.PROPERTY.getMask(), new MonitorListener() {
-									
-									@Override
-									public void monitorChanged(MonitorEvent monitorEvent) {
-										logger.debug("Got a DBE_PROPERTIES event for " + name);
-										processDBEPropertiesMonitorEvent(monitorEvent);
-									}
-								});
-					} 
-					subscription = channel.addMonitor(type,
-							channel.getElementCount(), MonitorMask.ARCHIVE.getMask(), this);
-				}
-			} catch (final Exception ex) {
-				logger.error("exception when subscribing pv "+name, ex);
-			}
-		}
-	}
-	
-	/** Unsubscribe from value updates. */
-	private void unsubscribe() {
-		Monitor sub_copy;
-		// Atomic access
-		synchronized (this) {
-			sub_copy = subscription;
-			subscription = null;
-		}
-		if (sub_copy == null) {
-			return;
-		}
-		try {
-			sub_copy.clear();
-		} catch(IllegalStateException ile) { 
-			logger.warn("Illegal state exception when unsubscribing pv "+ name, ile);
-		} catch (final Exception ex) {
-			logger.error("exception when unsubscribing pv "+ name, ex);
-		}
-	}
-	
-	/** {@inheritDoc} */
-	@Override
-	public void start() throws Exception {
-		if (running) {
-			return;
-		}
-		running = true;
-		connect();
-	}
-	
-	/** {@inheritDoc} */
-	@Override
-	public boolean isRunning() {
-		return running;
-	}
-	
-	/** {@inheritDoc} */
-	@Override
-	public boolean isConnected() {
-		return connected;
-	}
+    /***
+     *get  the meta info for this pv
+     * @return MetaInfo
+     */
+    @Override
+    public MetaInfo getTotalMetaInfo() {
+        return totalMetaInfo;
+    }
 
-	/**
-	 * @return
-	 */
-	@Override
-	public PVConnectionState connectionState() {
-		return this.state;
-	}
+    /** Listener to the get... for meta data */
+    private final GetListener meta_get_listener = new GetListener() {
+        @Override
+        public void getCompleted(final GetEvent event) { // This runs in a CA
+            // thread
+            if (event.getStatus().isSuccessful()) {
+                state = PVConnectionState.GotMetaData;
+                final DBR dbr = event.getDBR();
+                totalMetaInfo.applyBasicInfo(EPICS_V3_PV.this.name, dbr, EPICS_V3_PV.this.configservice);
+            } else {
+                logger.error("The meta get listener was not successful for EPICS_V3_PV " + name);
+            }
+            PVContext.scheduleCommand(
+                    EPICS_V3_PV.this.name,
+                    EPICS_V3_PV.this.jcaCommandThreadId,
+                    EPICS_V3_PV.this.channel_ref,
+                    "getCompleted",
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            subscribe();
+                        }
+                    });
+        }
+    };
 
-	/** {@inheritDoc} */
-	@Override
-	public void stop() {
-		running = false;
-		PVContext.scheduleCommand(this.name, this.jcaCommandThreadId, this.channel_ref, "stop", () -> {
-			logger.debug("Stopping channel " + EPICS_V3_PV.this.name);
-			unsubscribe();
-			disconnect();
-		});
-	}
-	
-	/** ConnectionListener interface. */
-	@Override
-	public void connectionChanged(final ConnectionEvent ev) {
-		logger.debug("Connection changed for pv " + this.name);
-		// This runs in a CA thread
-		if (ev.isConnected()) { // Transfer to JCACommandThread to avoid
-								// deadlocks
-								// The connect event can actually happen 'right
-								// away'
-								// when the channel is created, before we even
-								// get to assign
-								// the channel_ref. So use the channel from the
-								// event, not
-								// the channel_ref which might still be null.
-								//
-			// EngineContext.getInstance().getScheduler().execute(new Runnable()
-			PVContext.scheduleCommand(this.name, this.jcaCommandThreadId, this.channel_ref, "Connection changed connected", new Runnable() {
-				@Override
-				public void run() {
-					handleConnected((Channel) ev.getSource());
-				}
-			});
-		} else {
-			state = PVConnectionState.Disconnected;
-			connected = false;
-			PVContext.scheduleCommand(this.name, this.jcaCommandThreadId, this.channel_ref, "Connection changed disconnected", new Runnable() {
-				@Override
-				public void run() {
-					unsubscribe();
-					fireDisconnected();
-				}
-			});
-		}
-	}
-	
-	/**
-	 * PV is connected. Get meta info, or subscribe right away.
-	 */
-	private void handleConnected(final Channel channel) {
-		try { 
-			if(channel.getConnectionState()!=Channel.CONNECTED){
-				logger.error("While processing a handleConnected for " + this.name + "; the channel is not in a connected state.");
-				return;
-			}
-		} catch(Exception ex) { 
-			logger.error("Exception handling connection state change for " + this.name, ex);
-			return;
-		}
-		if (state == PVConnectionState.Connected) {
-			logger.error("While processing a handleConnected for " + this.name + "; the state is already in a connected state.");
-			return;
-		}
-		state = PVConnectionState.Connected;
-		hostName=channel.getHostName();
-		totalMetaInfo.setHostName(hostName);
-		for (final PVListener listener : listeners) {
-			listener.pvConnected(this);
-		}
-		// If we're "running", we need to get the meta data and
-		// then subscribe.
-		// Otherwise, we're done.
-		if (!running) {
-			logger.warn("While processing a handleConnected for " + this.name + " the channel is not running.");
-			connected = true;
-			// meta = null;
-			synchronized (this) {
-				this.notifyAll();
-			}
-			return;
-		}
-		
-		// else: running, get meta data, then subscribe
-		try {
-			DBRType type = channel.getFieldType();
-			if (!(plain || type.isSTRING())) {
-				state = PVConnectionState.GettingMetadata;
-				if (type.isDOUBLE() || type.isFLOAT())
-					type = DBRType.CTRL_DOUBLE;
-				else if (type.isENUM())
-					type = DBRType.LABELS_ENUM;
-				else if (type.isINT())
-					type = DBRType.CTRL_INT;
-				else
-					type = DBRType.CTRL_SHORT;
-				channel.get(type, 1, meta_get_listener);
-				return;
-			}
-		} catch (final Exception ex) {
-			logger.error("exception when handleConnect "+name, ex);
-			return;
-		}
-		// Meta info is not requested, not available for this type,
-		// or there was an error in the get call.
-		// So reset it, then just move on to the subscription.
-		// meta = null;
-		subscribe();
-	}
-	
-	/** MonitorListener interface. */
-	@Override
-	public void monitorChanged(final MonitorEvent ev) {
-		this.lastMonitorSecs = TimeUtils.getCurrentEpochSeconds();
-		this.dbrtimeevent = null; // Now that this is private; we should be able to set this to null on each monitor event
+    /**
+     * @param pvName
+     *            The PV name
+     */
+    @Override
+    public void addControledPV(String pvName) {
+        controlledPVList.add(pvName);
+    }
 
-		// This runs in a CA thread.
+    /**
+     * Generate an EPICS PV.
+     *
+     * @param name
+     *            The PV name.
+     * @param configservice  The config service used by this pv
+     * @param isControlPV true if this is a pv controlling other pvs
+     * @param archDBRTypes ArchDBRTypes
+     * @param jcaCommandThreadId The JCA Command thread.
+     * @param isDBEProperties  &emsp;
+     */
+    EPICS_V3_PV(
+            final String name,
+            ConfigService configservice,
+            boolean isControlPV,
+            ArchDBRTypes archDBRTypes,
+            int jcaCommandThreadId,
+            boolean isDBEProperties) {
+        this(name, false, configservice, jcaCommandThreadId);
+        this.archDBRType = archDBRTypes;
+        this.isDBEProperties = isDBEProperties;
+        if (archDBRTypes != null) {
+            this.con = configservice.getArchiverTypeSystem().getJCADBRConstructor(archDBRType);
+        }
+        if (isControlPV) {
+            this.controlledPVList = new ArrayList<String>();
+        }
+    }
 
-		if (!running) {
-			logger.error("Ignoring monitor events that arrive after stop for " + this.name);
-			this.transientErrorCount++;
-			return;
-		}
-		if (subscription == null) {
-			logger.error("Ignoring monitor events that arrive after we clean up the subscription for " + this.name);
-			this.transientErrorCount++;
-			return;
-		}
-		if (ev.getStatus() == null || !ev.getStatus().isSuccessful()) {
-			logger.error("Ignoring monitor events that have an invalid CA status for " + this.name);
-			this.transientErrorCount++;
-			return;
-		}
-		if (controlledPVList != null) {
-			// this pv is control pv.
-			try {
-				updateAllControlPVEnablement(ev);
-			} catch (Exception e) {
-				logger.error(
-						"exception in monitor changed function when updatinng controlled pvs' enablement for " + this.name,
-						e);
-			}
-			logger.warn("This " + this.name + " is a PV that controls other PV's.");
-			return;
-		}
-		state = PVConnectionState.GotMonitor;
-		if (!connected)
-			connected = true;
-		try {
-			try {
-				DBR dbr = ev.getDBR();
-				if (dbr == null) {
-					logger.error("Ignoring monitor events that does not have a valid DBR for " + this.name);
-					return;
-				}
-				if (this.name.endsWith(".RTYP")) {
-					String rtypName = (((DBR_String) dbr).getStringValue())[0];
-					dbrtimeevent = new POJOEvent(ArchDBRTypes.DBR_SCALAR_STRING, TimeUtils.now(), new ScalarStringSampleValue(rtypName), 0, 0);
-					fireValueUpdate(dbrtimeevent);
-					return;
-				}
-				// dbr.printInfo();
+    /**
+     * Generate an EPICS PV.
+     *
+     * @param name
+     *            The PV name.
+     * @param  configservice The config service used by this pv
+     * @param jcaCommandThreadId The JCA Command thread
+     */
+    // isControlPV
+    EPICS_V3_PV(final String name, ConfigService configservice, int jcaCommandThreadId) {
+        this(name, false, configservice, jcaCommandThreadId);
+    }
 
-				ArchDBRTypes generatedDBRType = JCA2ArchDBRType.valueOf(dbr);
-				if (archDBRType == null) {
-					archDBRType = generatedDBRType;
-					con = configservice.getArchiverTypeSystem().getJCADBRConstructor(archDBRType);
-				} else {
-					assert(con != null);
-					if(generatedDBRType != archDBRType) { 
-						logger.warn("The type of PV " + this.name + " has changed from " + archDBRType + " to " + generatedDBRType);
-						fireDroppedSampleTypeChange(generatedDBRType);
-						return;
-					}
-				}
-				dbrtimeevent = con.newInstance(dbr);
-				totalMetaInfo.computeRate(dbrtimeevent);
-				dbr = null;
-			} catch (Exception e) {
-				logger.error(
-						"exception in monitor changed function when converting DBR to dbrtimeevent for pv " + this.name,
-						e);
-				this.transientErrorCount++;
-			}
-			
-			updataMetaDataInParentPV(dbrtimeevent);
-			fireValueUpdate(dbrtimeevent);
-		} catch (final Exception ex) {
-			logger.error("exception in monitor changed for pv " + this.name, ex);
-			this.transientErrorCount++;
-		}
-	}
+    /**
+     * Generate an EPICS PV.
+     *
+     * @param name
+     *            The PV name.
+     * @param plain
+     *            When <code>true</code>, only the plain value is requested. No
+     *            time etc. Some PVs only work in plain mode, example:
+     *            "record.RTYP".
+     * @param configservice  The config service used by this pv
+     * @param jcaCommandThreadId  The JCA Command thread
+     */
+    private EPICS_V3_PV(final String name, final boolean plain, ConfigService configservice, int jcaCommandThreadId) {
+        this.name = name;
+        this.plain = plain;
+        this.configservice = configservice;
+        this.jcaCommandThreadId = jcaCommandThreadId;
+        PVContext.setConfigservice(configservice);
+    }
 
-	
-	/** Notify all listeners. */
-	private void fireValueUpdate(DBRTimeEvent ev) {
-		for (final PVListener listener : listeners) {
-			listener.pvValueUpdate(this, ev);
-		}
-	}
-	
-	/** Notify all listeners. */
-	private void fireDisconnected() {
-		for (final PVListener listener : listeners) {
-			listener.pvDisconnected(this);
-		}
-	}
-	
-	/** Notify all listeners. */
-	private void fireConnectionRequestMade() {
-		for (final PVListener listener : listeners) {
-			listener.pvConnectionRequestMade(this);
-		}
-	}
-	
-	private void fireDroppedSampleTypeChange(ArchDBRTypes newCAType) { 
-		for (final PVListener listener : listeners) {
-			listener.sampleDroppedTypeChange(this,  newCAType);
-		}
-	}
+    /** @return Returns the name. */
+    @Override
+    public String getName() {
+        return name;
+    }
 
+    /** {@inheritDoc} */
+    @Override
+    public void addListener(final PVListener listener) {
+        listeners.add(listener);
+    }
 
-	
-	@Override
-	public String toString() {
-		return "EPICS_V3_PV '" + name + "'";
-	}
-   
-	/***
-	 * if  this is a pv control other pvs,  when  this pv's value changes, it will stop or restart all controlled pvs.
-	 * @param ev  
-	 * @throws Exception error when update all controlled pv's archiving status
-	 */
-	private void updateAllControlPVEnablement(MonitorEvent ev) throws Exception {
-		final DBR dbr = ev.getDBR();
-		boolean enable = DBR_Helper.decodeBooleanValue(dbr);
-		ArrayList<String> copyOfControlledPVList = new ArrayList<String>(controlledPVList);
-		if (enable) {
-			enableAllPV = true;
-			for (String pvName : copyOfControlledPVList) {
-				logger.debug(pvName+" will be resumed");
-				ArchiveEngine.resumeArchivingPV(pvName, configservice);
-			}
-		} else {
-			enableAllPV = false;
-			for (String pvName : copyOfControlledPVList) {
-				logger.debug(pvName+" will be paused");
-				ArchiveEngine.pauseArchivingPV(pvName, configservice);
-			}
-		}
-	}
+    /** {@inheritDoc} */
+    @Override
+    public void removeListener(final PVListener listener) {
+        listeners.remove(listener);
+    }
 
-	/***
-	 * Set the "parent" PV for this meta field pv. The data from this PV is stored as a metafield in the parentPV.
-	 * @param parentPV - Store data from this PV as a metafield in the parentPV.
-	 * @param isRuntimeOnly - Only store values in the runtime hashMaps.
-	 */
-	public void setMetaFieldParentPV(EPICS_V3_PV parentPV, boolean isRuntimeOnly) {
-		this.parentPVForMetaField = parentPV;
-		isarchiveFieldsField = true;
-		this.isruntimeFieldField = isRuntimeOnly;
-	}
+    /**
+     * Try to connect to the PV. OK to call more than once.
+     */
+    private void connect() throws Exception {
+        logger.debug("pv of" + this.name + " connectting");
+        PVContext.scheduleCommand(this.name, this.jcaCommandThreadId, this.channel_ref, "connect", new Runnable() {
+            @Override
+            public void run() {
+                //
+                try {
+                    state = PVConnectionState.Connecting;
+                    // Already attempted a connection?
+                    synchronized (this) {
+                        if (channel_ref == null) {
+                            channel_ref =
+                                    PVContext.getChannel(name, EPICS_V3_PV.this.jcaCommandThreadId, EPICS_V3_PV.this);
+                        }
+                        fireConnectionRequestMade();
+                        if (channel_ref.getChannel().getConnectionState() == ConnectionState.CONNECTED) {
+                            handleConnected(channel_ref.getChannel());
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.error("exception when connecting pv " + name, e);
+                }
+            }
+        });
+    }
 
-	/**
-	 * update the meta field value in the parent pv.
-	 * @param dbrtimeevent DBRTimeEvent
-	 */
-	private void updataMetaDataInParentPV(final DBRTimeEvent dbrtimeevent) {
-		if (isarchiveFieldsField) { 
-			parentPVForMetaField.updataMetaFieldValue(this.name, "" + dbrtimeevent.getSampleValue().toString());
-		}
-	}
+    /**
+     * Disconnect from the PV. OK to call more than once.
+     */
+    private void disconnect() {
+        // Releasing the _last_ channel will close the context,
+        // which waits for the JCA Command thread to exit.
+        // If a connection or update for the channel happens at that time,
+        // the JCA command thread will send notifications to this PV,
+        // which had resulted in dead lock:
+        // This code locked the PV, then tried to join the JCA Command thread.
+        // JCA Command thread tried to lock the PV, so it could not exit.
+        // --> Don't lock while calling into the PVContext.
+        RefCountedChannel channel_ref_copy;
+        synchronized (this) {
+            // Never attempted a connection?
+            if (channel_ref == null) return;
+            channel_ref_copy = channel_ref;
+            channel_ref = null;
+            connected = false;
+        }
+        try {
+            PVContext.releaseChannel(channel_ref_copy, this);
+        } catch (final IllegalStateException ile) {
+            logger.warn("exception when disconnecting pv " + name, ile);
+        } catch (final Throwable e) {
+            logger.error("exception when disconnecting pv " + name, e);
+        }
+        fireDisconnected();
+    }
 
-	/***
-	 * Update the value in the parent pv hashmaps for this field
-	 * @param pvName  this meta field pv 's name - this is the full PV names - for example, a:b:c.HIHI
-	 * @param fieldValue - this meta field pv's value as a string.
-	 */
-	public void updataMetaFieldValue(String pvName, String fieldValue) {
-		String[] strs = pvName.split("\\.");
-		String fieldName = strs[strs.length - 1];
-		if(isruntimeFieldField) { 
-			logger.debug("Not storing value change for runtime field " + fieldName);
-			runTimeFieldsData.put(fieldName, fieldValue);
-		} else { 
-			logger.debug("Storing value change for meta field " + fieldName);
-			allarchiveFieldsData.put(fieldName, fieldValue);
-			changedarchiveFieldsData.put(fieldName, fieldValue);
-		}
-	}
+    /** Subscribe for value updates. */
+    private void subscribe() {
+        synchronized (this) {
+            // Prevent multiple subscriptions.
+            if (subscription != null) {
+                logger.error(
+                        "When trying to establish a subscription, there is already a subscription for " + this.name);
+                return;
+            }
+            // Late callback, channel already closed?
+            final RefCountedChannel ch_ref = channel_ref;
+            if (ch_ref == null) {
+                logger.error(
+                        "When trying to establish a subscription, the refcounted channel is closed for " + this.name);
+                return;
+            }
+            final Channel channel = ch_ref.getChannel();
+            // final Logger logger = Activator.getLogger();
+            try {
+                if (channel.getConnectionState() != Channel.CONNECTED) {
+                    logger.error("When trying to establish a subscription, the CA channel is not connected for "
+                            + this.name);
+                    return;
+                }
+                //
+                // the RefCountedChannel should maintain a single
+                // subscription to the underlying CAJ/JCA channel.
+                // So even with N PVs for the same channel, it's
+                // only one subscription on the network instead of
+                // N subscriptions.
+                final DBRType type = DBR_Helper.getTimeType(plain, channel.getFieldType());
+                state = PVConnectionState.Subscribing;
+                totalMetaInfo.setStartTime(System.currentTimeMillis());
+                // isnotTimestampDBR
+                if (this.name.endsWith(".RTYP")) {
+                    subscription = channel.addMonitor(MonitorMask.ARCHIVE.getMask(), this);
+                } else {
+                    if (this.isDBEProperties && dbePropertiesSubscription == null) {
+                        logger.debug("Adding a DBE_PROPERTIES monitor for " + this.name);
+                        dbePropertiesSubscription = channel.addMonitor(
+                                DBR_Helper.getControlType(channel.getFieldType()),
+                                1,
+                                MonitorMask.PROPERTY.getMask(),
+                                new MonitorListener() {
 
-	/***
-	 * Making this PV as having metafields or not
-	 * If the PV has metafields, then internal state is created to maintain the latest values of these metafields.
-	 * @param hasMetaField  &emsp;
-	 */
-	public void markPVHasMetafields(boolean hasMetaField) {
-		if (hasMetaField) {
-			allarchiveFieldsData = new ConcurrentHashMap<String, String>();
-			changedarchiveFieldsData = new ConcurrentHashMap<String, String>();
-		}
-		this.hasMetaField = hasMetaField;
-	}
-	
-	@Override
-	public void getLowLevelChannelInfo(List<Map<String, String>> statuses) {
-		// Commented out when using JCA. This seems to work in CAJ but not in JCA.
-/*		if(channel_ref != null) { 
-			ByteArrayOutputStream os = new ByteArrayOutputStream();
-			PrintStream out = new PrintStream(os);
-			channel_ref.getChannel().printInfo(out);
-			out.close();
-			return os.toString();
-		}		
-*/
-		class AddDetail {
-			private final List<Map<String, String>> statuses;
-			AddDetail(List<Map<String, String>> statuses) {
-				this.statuses = statuses;
-			}
-			void addKV(String k, String v) {
-				HashMap<String, String> h = new HashMap<String, String>();
-				h.put("name", k);
-				h.put("value", v == null ? "N/A" : v);
-				h.put("source", "CA");
-				this.statuses.add(h);
-			}
-		}
-		
-		AddDetail ad = new AddDetail(statuses);
-		ad.addKV("PV connection state machine state", state.toString());
-		ad.addKV("Last monitor received at", TimeUtils.convertToHumanReadableString(this.lastMonitorSecs));
-		ad.addKV("Last monitor had a valid DBR?", Boolean.toString(this.dbrtimeevent != null));
-		if(this.dbrtimeevent != null) {
-			ad.addKV("Last monitor event timestamp", TimeUtils.convertToHumanReadableString(this.dbrtimeevent.getEventTimeStamp()));			
-		}
-		ad.addKV("Various transient errors", Long.toString(transientErrorCount));
-		
-		ad.addKV("Do we have a CA channel?", Boolean.toString(this.channel_ref != null && this.channel_ref.getChannel() != null));
-		ad.addKV("Do we have a subscription?", Boolean.toString(this.subscription != null));
-		if (this.channel_ref != null && this.channel_ref.getChannel() != null && (this.channel_ref.getChannel() instanceof CAJChannel cajChannel)) {
-			ad.addKV("CAJ Searches", Integer.toString(cajChannel.getSearchTries()));
-			ad.addKV("CAJ channel ID (CID)", Integer.toString(cajChannel.getChannelID()));
-			ad.addKV("CAJ server channel ID (SID)", Integer.toString(cajChannel.getServerChannelID()));
-			if(this.subscription != null && this.subscription instanceof CAJMonitor) {
-				ad.addKV("CAJ subscription ID", Integer.toString(((CAJMonitor)subscription).getSID()));
-			}
-			ad.addKV("CAJ connection state", cajChannel.getConnectionState().getName());
-		}		
-		ad.addKV("Daily metadata last saved at", TimeUtils.convertToHumanReadableString(archiveFieldsSavedAtEpSec));
-		ad.addKV("Do we use DBE_Properties?", Boolean.toString(isDBEProperties));		
-		ad.addKV("Do we have a DBE Properties subscription?", Boolean.toString(this.dbePropertiesSubscription != null));
-		ad.addKV("The internal connected bool", Boolean.toString(this.connected));
-		ad.addKV("The internal running bool", Boolean.toString(this.running));
-		ad.addKV("Do we have a valid DBR Type constructor", Boolean.toString(con != null));
-		ad.addKV("The CAJ command thread id", Integer.toString(jcaCommandThreadId));
-		ad.addKV("Any other PV's being controlled?", Boolean.toString(this.controlledPVList != null));
-		if(this.controlledPVList != null) {
-			ad.addKV("Number of other PV's being controlled", Integer.toString(this.controlledPVList.size()));
-			ad.addKV("Status of controlled PVs", Boolean.toString(this.enableAllPV));
-		}
-		ad.addKV("Has metafields?", Boolean.toString(this.hasMetaField));
-		ad.addKV("Hostname of PV from CA", this.hostName);
-		
-		return;
-	}
-	
-	
-	@Override
-	public void updateTotalMetaInfo() throws IllegalStateException, CAException {
-		GetListener getListener = event -> {
-			// This runs in a CA thread
-			if (event.getStatus().isSuccessful()) {
-				final DBR dbr = event.getDBR();
-				logger.debug("Updating metadata (EGU/PREC etc) for pv " + EPICS_V3_PV.this.name);
-				totalMetaInfo.applyBasicInfo(EPICS_V3_PV.this.name, dbr, EPICS_V3_PV.this.configservice);
-			} else {
-				logger.error("The meta get listener was not successful for EPICS_V3_PV " + name);
-			}
-		};
-		if(channel_ref != null) { 
-			if(channel_ref.getChannel().getConnectionState() == ConnectionState.CONNECTED) { 
-				DBRType type = channel_ref.getChannel().getFieldType();
-				if (!(plain || type.isSTRING())) {
-					if (type.isDOUBLE() || type.isFLOAT())
-						type = DBRType.CTRL_DOUBLE;
-					else if (type.isENUM())
-						type = DBRType.LABELS_ENUM;
-					else if (type.isINT())
-						type = DBRType.CTRL_INT;
-					else
-						type = DBRType.CTRL_SHORT;
-					channel_ref.getChannel().get(type, 1, getListener);
-				}
-			}
-		}
-	}
-	
-	
-	/**
-	 * Combine the metadata from various sources and return the latest copy.
-	 * @see PV#getLatestMetadata
-	 */
-	@Override
-	public HashMap<String, String> getLatestMetadata() { 
-		HashMap<String, String> retVal = new HashMap<String, String>();
-		// The totalMetaInfo is updated once every 24hours...
-		MetaInfo metaInfo = this.getTotalMetaInfo();
-		if(metaInfo != null) {
-			metaInfo.addToDict(retVal);
-		}
-		// Add the latest value of the fields we are monitoring.
-		if(allarchiveFieldsData != null) { 
-			retVal.putAll(allarchiveFieldsData);
-		}
-		retVal.putAll(runTimeFieldsData);
+                                    @Override
+                                    public void monitorChanged(MonitorEvent monitorEvent) {
+                                        logger.debug("Got a DBE_PROPERTIES event for " + name);
+                                        processDBEPropertiesMonitorEvent(monitorEvent);
+                                    }
+                                });
+                    }
+                    subscription =
+                            channel.addMonitor(type, channel.getElementCount(), MonitorMask.ARCHIVE.getMask(), this);
+                }
+            } catch (final Exception ex) {
+                logger.error("exception when subscribing pv " + name, ex);
+            }
+        }
+    }
 
-		return retVal;
-	}
-	
-	public void setDBEroperties() { 
-		this.isDBEProperties = true;
-	}
-	
-	private void addUpdateChangedDBEPropertyMetaField(String fieldName, String value) { 
-		String currentValue = this.allarchiveFieldsData.get(fieldName);
-		if(currentValue != null && value != null && !currentValue.equals(value)) { 
-			this.changedarchiveFieldsData.put(fieldName, value);
-		}
-		assert value != null;
-		this.allarchiveFieldsData.put(fieldName, value);
-	}
-	
-	private void processDBEPropertiesMonitorEvent(MonitorEvent monitorEvent) {
-		DBR dbr = monitorEvent.getDBR();
-		if (dbr.isLABELS()) {
-			logger.debug("Updating DBE_PROPERTIES labels for ENUM pv " + name);
-			final DBR_LABELS_Enum labels = (DBR_LABELS_Enum)dbr;
-			addUpdateChangedDBEPropertyMetaField("LABELS", String.join(",", labels.getLabels()));
-		} else if (dbr instanceof DBR_CTRL_Double || dbr instanceof DBR_CTRL_Int) {
-			logger.debug("Updating DBE_PROPERTIES metafields for DBR_CTRL_Double for pv " + name);
-			assert dbr instanceof DBR_CTRL_Double;
-			final DBR_CTRL_Double ctrl = (DBR_CTRL_Double) dbr;
-			// fieldsAvailableFromDBRControl = new String[] {"PREC", "EGU", "HOPR", "LOPR", "HIHI", "HIGH", "LOW", "LOLO", "DRVH", "DRVL" };  
-			addUpdateChangedDBEPropertyMetaField("PREC", Short.toString(ctrl.getPrecision()));
-			addUpdateChangedDBEPropertyMetaField("EGU", ctrl.getUnits());
-			addUpdateChangedDBEPropertyMetaField("HOPR", ctrl.getUpperDispLimit().toString());
-			addUpdateChangedDBEPropertyMetaField("LOPR", ctrl.getLowerDispLimit().toString());
+    /** Unsubscribe from value updates. */
+    private void unsubscribe() {
+        Monitor sub_copy;
+        // Atomic access
+        synchronized (this) {
+            sub_copy = subscription;
+            subscription = null;
+        }
+        if (sub_copy == null) {
+            return;
+        }
+        try {
+            sub_copy.clear();
+        } catch (IllegalStateException ile) {
+            logger.warn("Illegal state exception when unsubscribing pv " + name, ile);
+        } catch (final Exception ex) {
+            logger.error("exception when unsubscribing pv " + name, ex);
+        }
+    }
 
-			addUpdateChangedDBEPropertyMetaField("HIHI", ctrl.getUpperAlarmLimit().toString());
-			addUpdateChangedDBEPropertyMetaField("HIGH", ctrl.getUpperWarningLimit().toString());
-			addUpdateChangedDBEPropertyMetaField("LOW", ctrl.getLowerWarningLimit().toString());
-			addUpdateChangedDBEPropertyMetaField("LOLO", ctrl.getLowerAlarmLimit().toString());
+    /** {@inheritDoc} */
+    @Override
+    public void start() throws Exception {
+        if (running) {
+            return;
+        }
+        running = true;
+        connect();
+    }
 
-			addUpdateChangedDBEPropertyMetaField("DRVH", ctrl.getUpperCtrlLimit().toString());
-			addUpdateChangedDBEPropertyMetaField("DRVL", ctrl.getLowerCtrlLimit().toString());
-		} else {
-			logger.error("In applyBasicInfo, cannot determine dbr type for " + dbr.getClass().getName());
-		}
-	}
+    /** {@inheritDoc} */
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
 
-	@Override
-	public void sampleWrittenIntoStores() {
-		
-	}
-	
-	/**
-	 * save the meta data
-	 */
-	private void saveMetaDataOnceEveryDay(DBRTimeEvent lastEvent) {
-		HashMap<String, String> tempHashMap = new HashMap<String, String>(allarchiveFieldsData);
-		if (!runTimeFieldsData.isEmpty()) {
-			// This should store fields like the description at least once every day.
-			tempHashMap.putAll(runTimeFieldsData);
-		}
-		if(this.totalMetaInfo != null) {
-			if(this.totalMetaInfo.getUnit() != null) { 
-				tempHashMap.put("EGU", this.totalMetaInfo.getUnit());
-			}
-			if(this.totalMetaInfo.getPrecision() != 0) { 
-				tempHashMap.put("PREC", Integer.toString(this.totalMetaInfo.getPrecision()));
-			}
-		}
-		// dbrtimeevent.s
-		lastEvent.setFieldValues(tempHashMap, false);
-		archiveFieldsSavedAtEpSec = TimeUtils.getCurrentEpochSeconds();
-	}
+    /** {@inheritDoc} */
+    @Override
+    public boolean isConnected() {
+        return connected;
+    }
 
+    /**
+     * @return
+     */
+    @Override
+    public PVConnectionState connectionState() {
+        return this.state;
+    }
 
-	@Override
-	public void aboutToWriteBuffer(DBRTimeEvent lastEvent) {
-		// if this pv has meta data , handle here
-		if (hasMetaField) {
-			// //////////handle the field value when it
-			// changes//////////////
-			if (!changedarchiveFieldsData.isEmpty()) {
-				logger.debug("Adding changed field for pv " + name + " with " + changedarchiveFieldsData.size());
-				HashMap<String, String> tempHashMap = new HashMap<>(changedarchiveFieldsData);
-				// dbrtimeevent.s
-				lastEvent.setFieldValues(tempHashMap, true);
-				synchronized(this) {
-					changedarchiveFieldsData.clear();
-				}
-			}
-			if (!allarchiveFieldsData.isEmpty()) {
-				long nowES = TimeUtils.getCurrentEpochSeconds();
-				if ((nowES - archiveFieldsSavedAtEpSec) >= 86400) {
-					saveMetaDataOnceEveryDay(lastEvent);
-				}
-			}
-		}
-		
-	}
+    /** {@inheritDoc} */
+    @Override
+    public void stop() {
+        running = false;
+        PVContext.scheduleCommand(this.name, this.jcaCommandThreadId, this.channel_ref, "stop", () -> {
+            logger.debug("Stopping channel " + EPICS_V3_PV.this.name);
+            unsubscribe();
+            disconnect();
+        });
+    }
+
+    /** ConnectionListener interface. */
+    @Override
+    public void connectionChanged(final ConnectionEvent ev) {
+        logger.debug("Connection changed for pv " + this.name);
+        // This runs in a CA thread
+        if (ev.isConnected()) { // Transfer to JCACommandThread to avoid
+            // deadlocks
+            // The connect event can actually happen 'right
+            // away'
+            // when the channel is created, before we even
+            // get to assign
+            // the channel_ref. So use the channel from the
+            // event, not
+            // the channel_ref which might still be null.
+            //
+            // EngineContext.getInstance().getScheduler().execute(new Runnable()
+            PVContext.scheduleCommand(
+                    this.name,
+                    this.jcaCommandThreadId,
+                    this.channel_ref,
+                    "Connection changed connected",
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            handleConnected((Channel) ev.getSource());
+                        }
+                    });
+        } else {
+            state = PVConnectionState.Disconnected;
+            connected = false;
+            PVContext.scheduleCommand(
+                    this.name,
+                    this.jcaCommandThreadId,
+                    this.channel_ref,
+                    "Connection changed disconnected",
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            unsubscribe();
+                            fireDisconnected();
+                        }
+                    });
+        }
+    }
+
+    /**
+     * PV is connected. Get meta info, or subscribe right away.
+     */
+    private void handleConnected(final Channel channel) {
+        try {
+            if (channel.getConnectionState() != Channel.CONNECTED) {
+                logger.error("While processing a handleConnected for " + this.name
+                        + "; the channel is not in a connected state.");
+                return;
+            }
+        } catch (Exception ex) {
+            logger.error("Exception handling connection state change for " + this.name, ex);
+            return;
+        }
+        if (state == PVConnectionState.Connected) {
+            logger.error("While processing a handleConnected for " + this.name
+                    + "; the state is already in a connected state.");
+            return;
+        }
+        state = PVConnectionState.Connected;
+        hostName = channel.getHostName();
+        totalMetaInfo.setHostName(hostName);
+        for (final PVListener listener : listeners) {
+            listener.pvConnected(this);
+        }
+        // If we're "running", we need to get the meta data and
+        // then subscribe.
+        // Otherwise, we're done.
+        if (!running) {
+            logger.warn("While processing a handleConnected for " + this.name + " the channel is not running.");
+            connected = true;
+            // meta = null;
+            synchronized (this) {
+                this.notifyAll();
+            }
+            return;
+        }
+
+        // else: running, get meta data, then subscribe
+        try {
+            DBRType type = channel.getFieldType();
+            if (!(plain || type.isSTRING())) {
+                state = PVConnectionState.GettingMetadata;
+                if (type.isDOUBLE() || type.isFLOAT()) type = DBRType.CTRL_DOUBLE;
+                else if (type.isENUM()) type = DBRType.LABELS_ENUM;
+                else if (type.isINT()) type = DBRType.CTRL_INT;
+                else type = DBRType.CTRL_SHORT;
+                channel.get(type, 1, meta_get_listener);
+                return;
+            }
+        } catch (final Exception ex) {
+            logger.error("exception when handleConnect " + name, ex);
+            return;
+        }
+        // Meta info is not requested, not available for this type,
+        // or there was an error in the get call.
+        // So reset it, then just move on to the subscription.
+        // meta = null;
+        subscribe();
+    }
+
+    /** MonitorListener interface. */
+    @Override
+    public void monitorChanged(final MonitorEvent ev) {
+        this.lastMonitorSecs = TimeUtils.getCurrentEpochSeconds();
+        this.dbrtimeevent =
+                null; // Now that this is private; we should be able to set this to null on each monitor event
+
+        // This runs in a CA thread.
+
+        if (!running) {
+            logger.error("Ignoring monitor events that arrive after stop for " + this.name);
+            this.transientErrorCount++;
+            return;
+        }
+        if (subscription == null) {
+            logger.error("Ignoring monitor events that arrive after we clean up the subscription for " + this.name);
+            this.transientErrorCount++;
+            return;
+        }
+        if (ev.getStatus() == null || !ev.getStatus().isSuccessful()) {
+            logger.error("Ignoring monitor events that have an invalid CA status for " + this.name);
+            this.transientErrorCount++;
+            return;
+        }
+        if (controlledPVList != null) {
+            // this pv is control pv.
+            try {
+                updateAllControlPVEnablement(ev);
+            } catch (Exception e) {
+                logger.error(
+                        "exception in monitor changed function when updatinng controlled pvs' enablement for "
+                                + this.name,
+                        e);
+            }
+            logger.warn("This " + this.name + " is a PV that controls other PV's.");
+            return;
+        }
+        state = PVConnectionState.GotMonitor;
+        if (!connected) connected = true;
+        try {
+            try {
+                DBR dbr = ev.getDBR();
+                if (dbr == null) {
+                    logger.error("Ignoring monitor events that does not have a valid DBR for " + this.name);
+                    return;
+                }
+                if (this.name.endsWith(".RTYP")) {
+                    String rtypName = (((DBR_String) dbr).getStringValue())[0];
+                    dbrtimeevent = new POJOEvent(
+                            ArchDBRTypes.DBR_SCALAR_STRING,
+                            TimeUtils.now(),
+                            new ScalarStringSampleValue(rtypName),
+                            0,
+                            0);
+                    fireValueUpdate(dbrtimeevent);
+                    return;
+                }
+                // dbr.printInfo();
+
+                ArchDBRTypes generatedDBRType = JCA2ArchDBRType.valueOf(dbr);
+                if (archDBRType == null) {
+                    archDBRType = generatedDBRType;
+                    con = configservice.getArchiverTypeSystem().getJCADBRConstructor(archDBRType);
+                } else {
+                    assert (con != null);
+                    if (generatedDBRType != archDBRType) {
+                        logger.warn("The type of PV " + this.name + " has changed from " + archDBRType + " to "
+                                + generatedDBRType);
+                        fireDroppedSampleTypeChange(generatedDBRType);
+                        return;
+                    }
+                }
+                dbrtimeevent = con.newInstance(dbr);
+                totalMetaInfo.computeRate(dbrtimeevent);
+                dbr = null;
+            } catch (Exception e) {
+                logger.error(
+                        "exception in monitor changed function when converting DBR to dbrtimeevent for pv " + this.name,
+                        e);
+                this.transientErrorCount++;
+            }
+
+            updataMetaDataInParentPV(dbrtimeevent);
+            fireValueUpdate(dbrtimeevent);
+        } catch (final Exception ex) {
+            logger.error("exception in monitor changed for pv " + this.name, ex);
+            this.transientErrorCount++;
+        }
+    }
+
+    /** Notify all listeners. */
+    private void fireValueUpdate(DBRTimeEvent ev) {
+        for (final PVListener listener : listeners) {
+            listener.pvValueUpdate(this, ev);
+        }
+    }
+
+    /** Notify all listeners. */
+    private void fireDisconnected() {
+        for (final PVListener listener : listeners) {
+            listener.pvDisconnected(this);
+        }
+    }
+
+    /** Notify all listeners. */
+    private void fireConnectionRequestMade() {
+        for (final PVListener listener : listeners) {
+            listener.pvConnectionRequestMade(this);
+        }
+    }
+
+    private void fireDroppedSampleTypeChange(ArchDBRTypes newCAType) {
+        for (final PVListener listener : listeners) {
+            listener.sampleDroppedTypeChange(this, newCAType);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "EPICS_V3_PV '" + name + "'";
+    }
+
+    /***
+     * if  this is a pv control other pvs,  when  this pv's value changes, it will stop or restart all controlled pvs.
+     * @param ev
+     * @throws Exception error when update all controlled pv's archiving status
+     */
+    private void updateAllControlPVEnablement(MonitorEvent ev) throws Exception {
+        final DBR dbr = ev.getDBR();
+        boolean enable = DBR_Helper.decodeBooleanValue(dbr);
+        ArrayList<String> copyOfControlledPVList = new ArrayList<String>(controlledPVList);
+        if (enable) {
+            enableAllPV = true;
+            for (String pvName : copyOfControlledPVList) {
+                logger.debug(pvName + " will be resumed");
+                ArchiveEngine.resumeArchivingPV(pvName, configservice);
+            }
+        } else {
+            enableAllPV = false;
+            for (String pvName : copyOfControlledPVList) {
+                logger.debug(pvName + " will be paused");
+                ArchiveEngine.pauseArchivingPV(pvName, configservice);
+            }
+        }
+    }
+
+    /***
+     * Set the "parent" PV for this meta field pv. The data from this PV is stored as a metafield in the parentPV.
+     * @param parentPV - Store data from this PV as a metafield in the parentPV.
+     * @param isRuntimeOnly - Only store values in the runtime hashMaps.
+     */
+    public void setMetaFieldParentPV(EPICS_V3_PV parentPV, boolean isRuntimeOnly) {
+        this.parentPVForMetaField = parentPV;
+        isarchiveFieldsField = true;
+        this.isruntimeFieldField = isRuntimeOnly;
+    }
+
+    /**
+     * update the meta field value in the parent pv.
+     * @param dbrtimeevent DBRTimeEvent
+     */
+    private void updataMetaDataInParentPV(final DBRTimeEvent dbrtimeevent) {
+        if (isarchiveFieldsField) {
+            parentPVForMetaField.updataMetaFieldValue(
+                    this.name, "" + dbrtimeevent.getSampleValue().toString());
+        }
+    }
+
+    /***
+     * Update the value in the parent pv hashmaps for this field
+     * @param pvName  this meta field pv 's name - this is the full PV names - for example, a:b:c.HIHI
+     * @param fieldValue - this meta field pv's value as a string.
+     */
+    public void updataMetaFieldValue(String pvName, String fieldValue) {
+        String[] strs = pvName.split("\\.");
+        String fieldName = strs[strs.length - 1];
+        if (isruntimeFieldField) {
+            logger.debug("Not storing value change for runtime field " + fieldName);
+            runTimeFieldsData.put(fieldName, fieldValue);
+        } else {
+            logger.debug("Storing value change for meta field " + fieldName);
+            allarchiveFieldsData.put(fieldName, fieldValue);
+            changedarchiveFieldsData.put(fieldName, fieldValue);
+        }
+    }
+
+    /***
+     * Making this PV as having metafields or not
+     * If the PV has metafields, then internal state is created to maintain the latest values of these metafields.
+     * @param hasMetaField  &emsp;
+     */
+    public void markPVHasMetafields(boolean hasMetaField) {
+        if (hasMetaField) {
+            allarchiveFieldsData = new ConcurrentHashMap<String, String>();
+            changedarchiveFieldsData = new ConcurrentHashMap<String, String>();
+        }
+        this.hasMetaField = hasMetaField;
+    }
+
+    @Override
+    public void getLowLevelChannelInfo(List<Map<String, String>> statuses) {
+        // Commented out when using JCA. This seems to work in CAJ but not in JCA.
+        /*		if(channel_ref != null) {
+        			ByteArrayOutputStream os = new ByteArrayOutputStream();
+        			PrintStream out = new PrintStream(os);
+        			channel_ref.getChannel().printInfo(out);
+        			out.close();
+        			return os.toString();
+        		}
+        */
+        class AddDetail {
+            private final List<Map<String, String>> statuses;
+
+            AddDetail(List<Map<String, String>> statuses) {
+                this.statuses = statuses;
+            }
+
+            void addKV(String k, String v) {
+                HashMap<String, String> h = new HashMap<String, String>();
+                h.put("name", k);
+                h.put("value", v == null ? "N/A" : v);
+                h.put("source", "CA");
+                this.statuses.add(h);
+            }
+        }
+
+        AddDetail ad = new AddDetail(statuses);
+        ad.addKV("PV connection state machine state", state.toString());
+        ad.addKV("Last monitor received at", TimeUtils.convertToHumanReadableString(this.lastMonitorSecs));
+        ad.addKV("Last monitor had a valid DBR?", Boolean.toString(this.dbrtimeevent != null));
+        if (this.dbrtimeevent != null) {
+            ad.addKV(
+                    "Last monitor event timestamp",
+                    TimeUtils.convertToHumanReadableString(this.dbrtimeevent.getEventTimeStamp()));
+        }
+        ad.addKV("Various transient errors", Long.toString(transientErrorCount));
+
+        ad.addKV(
+                "Do we have a CA channel?",
+                Boolean.toString(this.channel_ref != null && this.channel_ref.getChannel() != null));
+        ad.addKV("Do we have a subscription?", Boolean.toString(this.subscription != null));
+        if (this.channel_ref != null
+                && this.channel_ref.getChannel() != null
+                && (this.channel_ref.getChannel() instanceof CAJChannel cajChannel)) {
+            ad.addKV("CAJ Searches", Integer.toString(cajChannel.getSearchTries()));
+            ad.addKV("CAJ channel ID (CID)", Integer.toString(cajChannel.getChannelID()));
+            ad.addKV("CAJ server channel ID (SID)", Integer.toString(cajChannel.getServerChannelID()));
+            if (this.subscription != null && this.subscription instanceof CAJMonitor) {
+                ad.addKV("CAJ subscription ID", Integer.toString(((CAJMonitor) subscription).getSID()));
+            }
+            ad.addKV("CAJ connection state", cajChannel.getConnectionState().getName());
+        }
+        ad.addKV("Daily metadata last saved at", TimeUtils.convertToHumanReadableString(archiveFieldsSavedAtEpSec));
+        ad.addKV("Do we use DBE_Properties?", Boolean.toString(isDBEProperties));
+        ad.addKV("Do we have a DBE Properties subscription?", Boolean.toString(this.dbePropertiesSubscription != null));
+        ad.addKV("The internal connected bool", Boolean.toString(this.connected));
+        ad.addKV("The internal running bool", Boolean.toString(this.running));
+        ad.addKV("Do we have a valid DBR Type constructor", Boolean.toString(con != null));
+        ad.addKV("The CAJ command thread id", Integer.toString(jcaCommandThreadId));
+        ad.addKV("Any other PV's being controlled?", Boolean.toString(this.controlledPVList != null));
+        if (this.controlledPVList != null) {
+            ad.addKV("Number of other PV's being controlled", Integer.toString(this.controlledPVList.size()));
+            ad.addKV("Status of controlled PVs", Boolean.toString(this.enableAllPV));
+        }
+        ad.addKV("Has metafields?", Boolean.toString(this.hasMetaField));
+        ad.addKV("Hostname of PV from CA", this.hostName);
+
+        return;
+    }
+
+    @Override
+    public void updateTotalMetaInfo() throws IllegalStateException, CAException {
+        GetListener getListener = event -> {
+            // This runs in a CA thread
+            if (event.getStatus().isSuccessful()) {
+                final DBR dbr = event.getDBR();
+                logger.debug("Updating metadata (EGU/PREC etc) for pv " + EPICS_V3_PV.this.name);
+                totalMetaInfo.applyBasicInfo(EPICS_V3_PV.this.name, dbr, EPICS_V3_PV.this.configservice);
+            } else {
+                logger.error("The meta get listener was not successful for EPICS_V3_PV " + name);
+            }
+        };
+        if (channel_ref != null) {
+            if (channel_ref.getChannel().getConnectionState() == ConnectionState.CONNECTED) {
+                DBRType type = channel_ref.getChannel().getFieldType();
+                if (!(plain || type.isSTRING())) {
+                    if (type.isDOUBLE() || type.isFLOAT()) type = DBRType.CTRL_DOUBLE;
+                    else if (type.isENUM()) type = DBRType.LABELS_ENUM;
+                    else if (type.isINT()) type = DBRType.CTRL_INT;
+                    else type = DBRType.CTRL_SHORT;
+                    channel_ref.getChannel().get(type, 1, getListener);
+                }
+            }
+        }
+    }
+
+    /**
+     * Combine the metadata from various sources and return the latest copy.
+     * @see PV#getLatestMetadata
+     */
+    @Override
+    public HashMap<String, String> getLatestMetadata() {
+        HashMap<String, String> retVal = new HashMap<String, String>();
+        // The totalMetaInfo is updated once every 24hours...
+        MetaInfo metaInfo = this.getTotalMetaInfo();
+        if (metaInfo != null) {
+            metaInfo.addToDict(retVal);
+        }
+        // Add the latest value of the fields we are monitoring.
+        if (allarchiveFieldsData != null) {
+            retVal.putAll(allarchiveFieldsData);
+        }
+        retVal.putAll(runTimeFieldsData);
+
+        return retVal;
+    }
+
+    public void setDBEroperties() {
+        this.isDBEProperties = true;
+    }
+
+    private void addUpdateChangedDBEPropertyMetaField(String fieldName, String value) {
+        String currentValue = this.allarchiveFieldsData.get(fieldName);
+        if (currentValue != null && value != null && !currentValue.equals(value)) {
+            this.changedarchiveFieldsData.put(fieldName, value);
+        }
+        assert value != null;
+        this.allarchiveFieldsData.put(fieldName, value);
+    }
+
+    private void processDBEPropertiesMonitorEvent(MonitorEvent monitorEvent) {
+        DBR dbr = monitorEvent.getDBR();
+        if (dbr.isLABELS()) {
+            logger.debug("Updating DBE_PROPERTIES labels for ENUM pv " + name);
+            final DBR_LABELS_Enum labels = (DBR_LABELS_Enum) dbr;
+            addUpdateChangedDBEPropertyMetaField("LABELS", String.join(",", labels.getLabels()));
+        } else if (dbr instanceof DBR_CTRL_Double || dbr instanceof DBR_CTRL_Int) {
+            logger.debug("Updating DBE_PROPERTIES metafields for DBR_CTRL_Double for pv " + name);
+            assert dbr instanceof DBR_CTRL_Double;
+            final DBR_CTRL_Double ctrl = (DBR_CTRL_Double) dbr;
+            // fieldsAvailableFromDBRControl = new String[] {"PREC", "EGU", "HOPR", "LOPR", "HIHI", "HIGH", "LOW",
+            // "LOLO", "DRVH", "DRVL" };
+            addUpdateChangedDBEPropertyMetaField("PREC", Short.toString(ctrl.getPrecision()));
+            addUpdateChangedDBEPropertyMetaField("EGU", ctrl.getUnits());
+            addUpdateChangedDBEPropertyMetaField(
+                    "HOPR", ctrl.getUpperDispLimit().toString());
+            addUpdateChangedDBEPropertyMetaField(
+                    "LOPR", ctrl.getLowerDispLimit().toString());
+
+            addUpdateChangedDBEPropertyMetaField(
+                    "HIHI", ctrl.getUpperAlarmLimit().toString());
+            addUpdateChangedDBEPropertyMetaField(
+                    "HIGH", ctrl.getUpperWarningLimit().toString());
+            addUpdateChangedDBEPropertyMetaField(
+                    "LOW", ctrl.getLowerWarningLimit().toString());
+            addUpdateChangedDBEPropertyMetaField(
+                    "LOLO", ctrl.getLowerAlarmLimit().toString());
+
+            addUpdateChangedDBEPropertyMetaField(
+                    "DRVH", ctrl.getUpperCtrlLimit().toString());
+            addUpdateChangedDBEPropertyMetaField(
+                    "DRVL", ctrl.getLowerCtrlLimit().toString());
+        } else {
+            logger.error("In applyBasicInfo, cannot determine dbr type for "
+                    + dbr.getClass().getName());
+        }
+    }
+
+    @Override
+    public void sampleWrittenIntoStores() {}
+
+    /**
+     * save the meta data
+     */
+    private void saveMetaDataOnceEveryDay(DBRTimeEvent lastEvent) {
+        HashMap<String, String> tempHashMap = new HashMap<String, String>(allarchiveFieldsData);
+        if (!runTimeFieldsData.isEmpty()) {
+            // This should store fields like the description at least once every day.
+            tempHashMap.putAll(runTimeFieldsData);
+        }
+        if (this.totalMetaInfo != null) {
+            if (this.totalMetaInfo.getUnit() != null) {
+                tempHashMap.put("EGU", this.totalMetaInfo.getUnit());
+            }
+            if (this.totalMetaInfo.getPrecision() != 0) {
+                tempHashMap.put("PREC", Integer.toString(this.totalMetaInfo.getPrecision()));
+            }
+        }
+        // dbrtimeevent.s
+        lastEvent.setFieldValues(tempHashMap, false);
+        archiveFieldsSavedAtEpSec = TimeUtils.getCurrentEpochSeconds();
+    }
+
+    @Override
+    public void aboutToWriteBuffer(DBRTimeEvent lastEvent) {
+        // if this pv has meta data , handle here
+        if (hasMetaField) {
+            // //////////handle the field value when it
+            // changes//////////////
+            if (!changedarchiveFieldsData.isEmpty()) {
+                logger.debug("Adding changed field for pv " + name + " with " + changedarchiveFieldsData.size());
+                HashMap<String, String> tempHashMap = new HashMap<>(changedarchiveFieldsData);
+                // dbrtimeevent.s
+                lastEvent.setFieldValues(tempHashMap, true);
+                synchronized (this) {
+                    changedarchiveFieldsData.clear();
+                }
+            }
+            if (!allarchiveFieldsData.isEmpty()) {
+                long nowES = TimeUtils.getCurrentEpochSeconds();
+                if ((nowES - archiveFieldsSavedAtEpSec) >= 86400) {
+                    saveMetaDataOnceEveryDay(lastEvent);
+                }
+            }
+        }
+    }
 }

--- a/src/main/org/epics/archiverappliance/engine/pv/EPICS_V4_PV.java
+++ b/src/main/org/epics/archiverappliance/engine/pv/EPICS_V4_PV.java
@@ -1,13 +1,5 @@
 package org.epics.archiverappliance.engine.pv;
 
-import java.lang.reflect.Constructor;
-import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.TimeUtils;
@@ -22,7 +14,15 @@ import org.epics.pva.client.PVAChannel;
 import org.epics.pva.data.PVAData;
 import org.epics.pva.data.PVAStructure;
 
-public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener {
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class EPICS_V4_PV implements PV, ClientChannelListener, MonitorListener {
     private static final Logger logger = LogManager.getLogger(EPICS_V4_PV.class.getName());
 
     /** Channel name. */
@@ -94,10 +94,15 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
 
     private AutoCloseable subscriptionCloseable = null;
 
-    EPICS_V4_PV(final String name, ConfigService configservice, boolean isControlPV, ArchDBRTypes archDBRTypes, int jcaCommandThreadId) {
+    EPICS_V4_PV(
+            final String name,
+            ConfigService configservice,
+            boolean isControlPV,
+            ArchDBRTypes archDBRTypes,
+            int jcaCommandThreadId) {
         this(name, configservice, jcaCommandThreadId);
         this.archDBRType = archDBRTypes;
-        if(archDBRTypes != null) {
+        if (archDBRTypes != null) {
             this.con = configservice.getArchiverTypeSystem().getV4Constructor(this.archDBRType);
         }
     }
@@ -107,7 +112,6 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
         this.configservice = configservice;
         this.jcaCommandThreadId = jcaCommandThreadId;
     }
-
 
     @Override
     public String getName() {
@@ -131,14 +135,12 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
         }
     }
 
-
     /** Notify all listeners. */
     private void fireValueUpdate(DBRTimeEvent ev) {
         for (final PVListener listener : listeners) {
             listener.pvValueUpdate(this, ev);
         }
     }
-
 
     @Override
     public void start() throws Exception {
@@ -177,17 +179,17 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
         return this.state;
     }
 
-	@Override
-	public ArchDBRTypes getArchDBRTypes() {
-		return archDBRType;
-	}
+    @Override
+    public ArchDBRTypes getArchDBRTypes() {
+        return archDBRType;
+    }
 
     @Override
     public HashMap<String, String> getLatestMetadata() {
         HashMap<String, String> retVal = new HashMap<>();
         // The totalMetaInfo is updated once every 24hours...
         MetaInfo metaInfo = this.totalMetaInfo;
-        if(metaInfo != null) {
+        if (metaInfo != null) {
             metaInfo.addToDict(retVal);
         }
         if (fieldValuesCache != null) {
@@ -198,7 +200,8 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
 
     @Override
     public void updateTotalMetaInfo() throws IllegalStateException {
-        // We should not need to do anyting here as we should get updates on any field change for PVAccess and we do not need to do an explicit get.
+        // We should not need to do anyting here as we should get updates on any field change for PVAccess and we do not
+        // need to do an explicit get.
     }
 
     @Override
@@ -233,18 +236,19 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
         boolean excludeV4Changes = true;
         this.fieldValuesCache = new FieldValuesCache(data, excludeV4Changes);
         this.timeStampBits = this.fieldValuesCache.getTimeStampBits();
-        if(this.timeStampBits.isEmpty()) {
-            logger.error("Cannot determine the timestamp bitset for PV " + this.name + ". This means we may not save any data at all for this PV.");
+        if (this.timeStampBits.isEmpty()) {
+            logger.error("Cannot determine the timestamp bitset for PV " + this.name
+                    + ". This means we may not save any data at all for this PV.");
         } else {
             logger.debug("The timestamp bits for the PV " + this.name + " are " + this.timeStampBits);
         }
 
-        if (archDBRType ==null || con == null ) {
+        if (archDBRType == null || con == null) {
             String structureID = data.formatType();
             logger.info("Type from structure in monitorConnect is " + structureID);
 
             PVAData valueField = data.get("value");
-            if(valueField == null) {
+            if (valueField == null) {
                 archDBRType = ArchDBRTypes.DBR_V4_GENERIC_BYTES;
             } else {
                 logger.info("Value field in monitorConnect is of type " + valueField.getType());
@@ -268,8 +272,7 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
         return lastSaveSecs <= 0 || (nowES - lastSaveSecs) >= periodLengthSecs;
     }
 
-    private DBRTimeEvent fromStructure(PVAStructure data, BitSet changes)
-            throws Exception {
+    private DBRTimeEvent fromStructure(PVAStructure data, BitSet changes) throws Exception {
 
         DBRTimeEvent dbrtimeevent = con.newInstance(data);
         this.totalMetaInfo.computeRate(dbrtimeevent);
@@ -291,8 +294,7 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
 
         state = PVConnectionState.GotMonitor;
 
-        if (!connected)
-            connected = true;
+        if (!connected) connected = true;
 
         if (logger.isDebugEnabled()) {
             logger.debug("Obtained monitor event for pv " + this.name);
@@ -326,7 +328,6 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
         } catch (Exception e) {
             logger.error("exception in monitor changed function when converting DBR to dbrtimeevent", e);
         }
-
     }
 
     private void scheduleCommand(final Runnable command) {
@@ -342,8 +343,10 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
                     state = PVConnectionState.Connecting;
                     synchronized (this) {
                         if (pvaChannel == null) {
-                            pvaChannel = configservice.getEngineContext().getPVAClient().getChannel(name,
-                                    EPICS_V4_PV.this);
+                            pvaChannel = configservice
+                                    .getEngineContext()
+                                    .getPVAClient()
+                                    .getChannel(name, EPICS_V4_PV.this);
                         }
 
                         if (pvaChannel == null) {
@@ -362,16 +365,13 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
         });
     }
 
-
     /**
      * PV is connected. Get meta info, or subscribe right away.
      */
     private void handleConnected() {
-        if (state == PVConnectionState.Connected)
-            return;
+        if (state == PVConnectionState.Connected) return;
 
         state = PVConnectionState.Connected;
-
 
         for (final PVListener listener : listeners) {
             listener.pvConnected(this);
@@ -391,8 +391,7 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
     private void disconnect() {
         PVAChannel channelCopy;
         synchronized (this) {
-            if (pvaChannel == null)
-                return;
+            if (pvaChannel == null) return;
             channelCopy = pvaChannel;
             connected = false;
             pvaChannel = null;
@@ -431,8 +430,9 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
                 logger.error("exception when reading pv", e);
             }
             try {
-                if(pvaChannel.getState() != ClientChannelState.CONNECTED){
-                    logger.error("When trying to establish a subscription, the PVA channel is not connected for " + this.name);
+                if (pvaChannel.getState() != ClientChannelState.CONNECTED) {
+                    logger.error("When trying to establish a subscription, the PVA channel is not connected for "
+                            + this.name);
                     return;
                 }
                 state = PVConnectionState.Subscribing;
@@ -444,7 +444,6 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
             }
         }
     }
-
 
     /** Unsubscribe from value updates. */
     private void unsubscribe() {
@@ -467,13 +466,13 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
         }
     }
 
-    private static HashMap<String, String> metaInfoToStore( MetaInfo totalMetaInfo) {
+    private static HashMap<String, String> metaInfoToStore(MetaInfo totalMetaInfo) {
         HashMap<String, String> tempHashMap = new HashMap<>();
-        if(totalMetaInfo != null) {
-            if(totalMetaInfo.getUnit() != null) {
+        if (totalMetaInfo != null) {
+            if (totalMetaInfo.getUnit() != null) {
                 tempHashMap.put("EGU", totalMetaInfo.getUnit());
             }
-            if(totalMetaInfo.getPrecision() != 0) {
+            if (totalMetaInfo.getPrecision() != 0) {
                 tempHashMap.put("PREC", Integer.toString(totalMetaInfo.getPrecision()));
             }
         }
@@ -481,11 +480,11 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
     }
 
     private static ArchDBRTypes determineDBRType(String structureID, String valueTypeId, String valueFormatType) {
-        if(structureID == null || valueTypeId == null) {
+        if (structureID == null || valueTypeId == null) {
             return ArchDBRTypes.DBR_V4_GENERIC_BYTES;
         }
 
-        switch(valueTypeId) {
+        switch (valueTypeId) {
             case "string[]" -> {
                 return ArchDBRTypes.DBR_WAVEFORM_STRING;
             }
@@ -545,7 +544,6 @@ public class EPICS_V4_PV implements PV,  ClientChannelListener, MonitorListener 
                 return ArchDBRTypes.DBR_V4_GENERIC_BYTES;
             }
         }
-
     }
 
     /***

--- a/src/main/org/epics/archiverappliance/engine/pv/PV.java
+++ b/src/main/org/epics/archiverappliance/engine/pv/PV.java
@@ -16,11 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-
-
-
-
-
 /** A control system PV.
  *  <p>
  *  When 'start'ed, the PV will attempt to connect or
@@ -38,11 +33,9 @@ import java.util.Map;
  * @version Initial version:CSS
  * @version 4-Jun-2012, Luofeng Li:added codes to support for the new archiver
  */
-public interface PV
-{
+public interface PV {
     /** @return Returns the name. */
     public String getName();
-
 
     /** Add a new listener.
      * @param listener PVListener
@@ -50,7 +43,7 @@ public interface PV
      */
     public void addListener(PVListener listener);
 
-    /** Remove a listener. 
+    /** Remove a listener.
      * @param listener PVListener
      */
     public void removeListener(PVListener listener);
@@ -72,59 +65,59 @@ public interface PV
     /** @return Returns <code>true</code> between <code>start()</code> and <code>stop()</code>. */
     public boolean isRunning();
 
-	/**
-	 * @return Returns <code>true</code> when connected. While <code>isRunning</code>, we are subscribed for value
-	 * updates, but we might still be disconnected, at least temporarily.
-	 */
-	public boolean isConnected();
+    /**
+     * @return Returns <code>true</code> when connected. While <code>isRunning</code>, we are subscribed for value
+     * updates, but we might still be disconnected, at least temporarily.
+     */
+    public boolean isConnected();
 
-	/**
-	 * @return Returns <code>true</code> when connected. While <code>isRunning</code>, we are subscribed for value
-	 * updates, but we might still be disconnected, at least temporarily.
-	 */
-	public PVConnectionState connectionState();
-    
-   /***
-    * get the archive DBR types for this pv
-    * @return ArchDBRTypes  &emsp;
-    */
-	ArchDBRTypes getArchDBRTypes();
+    /**
+     * @return Returns <code>true</code> when connected. While <code>isRunning</code>, we are subscribed for value
+     * updates, but we might still be disconnected, at least temporarily.
+     */
+    public PVConnectionState connectionState();
 
-	/**
-	 * Combine the metadata from various sources and return the latest copy.
-	 * @return HashMap   &emsp;
-	 */
-	public HashMap<String, String> getLatestMetadata();
+    /***
+     * get the archive DBR types for this pv
+     * @return ArchDBRTypes  &emsp;
+     */
+    ArchDBRTypes getArchDBRTypes();
 
-	/**
-	 * Do a caget and update the metadata that is cached in the PV.
-	 * @throws IllegalStateException  &emsp;
-	 * @throws CAException  &emsp;
-	 */
-	public void updateTotalMetaInfo() throws IllegalStateException, CAException;
+    /**
+     * Combine the metadata from various sources and return the latest copy.
+     * @return HashMap   &emsp;
+     */
+    public HashMap<String, String> getLatestMetadata();
 
-	/**
-	 * Get the MetaInfo for this PV; used during initial MetaGet phase
-	 * @return MetaInfo  &emsp; 
-	 */
-	public MetaInfo getTotalMetaInfo();
-	
-	public  String getHostName();
+    /**
+     * Do a caget and update the metadata that is cached in the PV.
+     * @throws IllegalStateException  &emsp;
+     * @throws CAException  &emsp;
+     */
+    public void updateTotalMetaInfo() throws IllegalStateException, CAException;
 
-	/**
-	 * Get any low level info as a displayable list; this is typically meant for debugging purposes..
-	 * Add these to as key value pairs to the statuses
-	 */
-	public void getLowLevelChannelInfo(List<Map<String, String>> statuses);
-	
-	/**
-	 * This method is called each time the ArchiveChannel has written changed a DBRTimeEvent into the buffers.
-	 */
-	public void sampleWrittenIntoStores();
-    
-	/**
-	 * This method is called each time the Write thread is about to write a batch of samples. 
-	 * The writer thread passes in the last sample of the previous batch of samples after buffer rotation.
-	 */
-	public void aboutToWriteBuffer(DBRTimeEvent lastEvent);
+    /**
+     * Get the MetaInfo for this PV; used during initial MetaGet phase
+     * @return MetaInfo  &emsp;
+     */
+    public MetaInfo getTotalMetaInfo();
+
+    public String getHostName();
+
+    /**
+     * Get any low level info as a displayable list; this is typically meant for debugging purposes..
+     * Add these to as key value pairs to the statuses
+     */
+    public void getLowLevelChannelInfo(List<Map<String, String>> statuses);
+
+    /**
+     * This method is called each time the ArchiveChannel has written changed a DBRTimeEvent into the buffers.
+     */
+    public void sampleWrittenIntoStores();
+
+    /**
+     * This method is called each time the Write thread is about to write a batch of samples.
+     * The writer thread passes in the last sample of the previous batch of samples after buffer rotation.
+     */
+    public void aboutToWriteBuffer(DBRTimeEvent lastEvent);
 }

--- a/src/main/org/epics/archiverappliance/mgmt/BPLServlet.java
+++ b/src/main/org/epics/archiverappliance/mgmt/BPLServlet.java
@@ -7,15 +7,6 @@
  *******************************************************************************/
 package org.epics.archiverappliance.mgmt;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.LinkedList;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.epics.archiverappliance.common.BPLAction;
 import org.epics.archiverappliance.common.BasicDispatcher;
 import org.epics.archiverappliance.common.ProcessMetricsChartData;
@@ -107,6 +98,14 @@ import org.epics.archiverappliance.mgmt.policy.GetApplianceProps;
 import org.epics.archiverappliance.mgmt.policy.GetPolicyList;
 import org.epics.archiverappliance.mgmt.policy.GetPolicyText;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * The main business logic servlet for mgmt. All BPLActions are registered here.
  * @author mshankar
@@ -114,170 +113,169 @@ import org.epics.archiverappliance.mgmt.policy.GetPolicyText;
  */
 @SuppressWarnings("serial")
 public class BPLServlet extends HttpServlet {
-	private static HashMap<String, Class<? extends BPLAction>> getActions = new HashMap<String, Class<? extends BPLAction>>();
-	private static LinkedList<String> actionsSequenceForDocs = new LinkedList<String>();
-	
-	static {
-		// BPL related to PVs/appliances etc
-		addAction("/getAllPVs", GetAllPVs.class);
-		addAction("/getAllExpandedPVNames", GetAllExpandedPVNames.class);
-		addAction("/getPVStatus", GetPVStatusAction.class);
-		addAction("/getPVTypeInfo", GetPVTypeInfo.class);
-		addAction("/archivePV", ArchivePVAction.class);
-		addAction("/pauseArchivingPV", PauseArchivingPV.class);
-		addAction("/resumeArchivingPV", ResumeArchivingPV.class);
-		addAction("/getStoresForPV", GetStoresForPV.class);
-		addAction("/modifyStoreURLForPV", ModifyStoreURLForPV.class);
-		addAction("/consolidateDataForPV", ConsolidatePBFilesForOnePV.class);
-		addAction("/deletePV", DeletePV.class);
-		addAction("/abortArchivingPV", AbortArchiveRequest.class);
-		addAction("/abortArchivingPVForThisAppliance", AbortArchiveRequestForAppliance.class);
-		addAction("/changeArchivalParameters", ChangeArchivalParamsAction.class);
-		addAction("/getPVDetails", PVDetails.class);
-		addAction("/getApplianceInfo", GetApplianceInfo.class);
-		addAction("/getAppliancesInCluster", GetAppliancesInCluster.class);
-		addAction("/renamePV", RenamePVAction.class);
-		addAction("/reshardPV", ReshardPV.class);
-		addAction("/appendAndAliasPV", AppendAndAliasPV.class);
-		addAction("/addAlias", AddAliasAction.class);
-		addAction("/removeAlias", RemoveAliasAction.class);
-		addAction("/getAllAliases", GetAllAliasesAction.class);
-		addAction("/skipAliasCheck", SkipAliasCheckAction.class);
-		addAction("/changeTypeForPV", ChangeTypeForPV.class);
-		addAction("/mergeInData", MergeInDataFromExternalStore.class);
-		addAction("/resetFailoverCaches", ResetFailoverCaches.class);
-		addAction("/getVersions", GetVersions.class);
-		addAction("/modifyMetaFields", ModifyMetaFieldsAction.class);
-		addAction("/getNamedFlag", NamedFlagsGet.class);
-		addAction("/setNamedFlag", NamedFlagsSet.class);
-		addAction("/getTypeInfoKeys", GetPVTypeInfoKeys.class);
+    private static HashMap<String, Class<? extends BPLAction>> getActions =
+            new HashMap<String, Class<? extends BPLAction>>();
+    private static LinkedList<String> actionsSequenceForDocs = new LinkedList<String>();
 
-		// BPL related to reports
-		addAction("/getNeverConnectedPVs", NeverConnectedPVsAction.class);
-		addAction("/getNeverConnectedPVsForThisAppliance", NeverConnectedPVsForThisAppliance.class);
-		addAction("/getMetaGets", MetaGetsAction.class);
-		addAction("/getCurrentlyDisconnectedPVs", CurrentlyDisconnectedPVs.class);
-		addAction("/getEventRateReport", EventRateReport.class);
-		addAction("/getStorageRateReport", StorageRateReport.class);
-		addAction("/getRecentlyAddedPVs", RecentlyAddedPVs.class);
-		addAction("/getRecentlyAddedPVsForThisInstance", RecentlyAddedPVsforThisInstance.class);
-		addAction("/getRecentlyModifiedPVs", RecentlyChangedPVs.class);
-		addAction("/getRecentlyModifiedPVsForThisInstance", RecentlyChangedPVsforThisInstance.class);
-		addAction("/getStorageMetrics", StorageReport.class);
-		addAction("/getStorageMetricsForAppliance", StorageReportDetails.class);
-		addAction("/getPVsByStorageConsumed", PVsByStorageConsumed.class);
-		addAction("/getLostConnectionsReport", LostConnectionsReport.class);
-		addAction("/getSilentPVsReport", SilentPVReport.class);
-		addAction("/getPVsForThisAppliance", GetPVsForThisAppliance.class);
-		addAction("/getPVsByDroppedEventsTimestamp",DroppedEventsTimestampReport.class);
-		addAction("/getPVsByDroppedEventsBuffer", DroppedEventsBufferOverflowReport.class);
-		addAction("/getPVsByDroppedEventsTypeChange", DroppedEventsTypeChangeReport.class);
-		addAction("/getSlowChangingPVsWithDroppedEvents", SlowChangingPVsWithDroppedEvents.class);
-		addAction("/getPausedPVsReport", PausedPVsReport.class);
-		addAction("/getPausedPVsForThisAppliance", GetPausedPVsForThisAppliance.class);
-		addAction("/getArchivedWaveforms", WaveformPVsAction.class);	
-		addAction("/getTimeSpanReport", TimeSpanReport.class);
-		
-		
-		// Others.
-		addAction("/getPolicyText", GetPolicyText.class);
-		addAction("/exportConfig", ExportConfig.class);
-		addAction("/exportConfigForAppliance", ExportConfigForThisInstance.class);
-		addAction("/getInstanceMetrics", InstanceReport.class);
-		addAction("/getInstanceMetricsForAppliance", InstanceReportDetails.class);
-		addAction("/getApplianceMetrics", ApplianceMetrics.class);
-		addAction("/getApplianceMetricsForAppliance", ApplianceMetricsDetails.class);
-		addAction("/getExternalArchiverServers", ChannelArchiverListView.class);
-		addAction("/addExternalArchiverServer", AddExternalArchiverServer.class);
-		addAction("/addExternalArchiverServerArchives", AddExternalArchiverServerArchives.class);
-		addAction("/removeExternalArchiverServer", RemoveExternalArchiverServer.class);
-		addAction("/test/compareWithChannelArchiver", CompareWithChannelArchiver.class);
-		addAction("/getAggregatedApplianceInfo", AggregatedApplianceInfo.class);
-		addAction("/importDataFromPlugin", ImportDataFromPlugin.class);
-		addAction("/getPolicyList", GetPolicyList.class);		
-		addAction("/getApplianceProperties", GetApplianceProps.class);		
-		addAction("/webAppReady", WebappReady.class);
-		addAction("/getProcessMetrics", ProcessMetricsReport.class);
-		addAction("/getProcessMetricsDataForAppliance", ProcessMetricsChartData.class);
-		addAction("/refreshPVDataFromChannelArchivers", RefreshPVDataFromChannelArchivers.class);
-		addAction("/getMatchingPVsForThisAppliance", GetMatchingPVsForAppliance.class);
-		addAction("/getCreationReportForAppliance", CreationTimeReportForAppliance.class);	
-		addAction("/restartArchivePVWorkflowThreadForThisAppliance", RestartArchiveWorkflowThreadForAppliance.class);
-	}
-	
-	@Override
-	protected void doGet(HttpServletRequest req, HttpServletResponse resp)
-			throws ServletException, IOException {
-		BasicDispatcher.dispatch(req, resp, configService, getActions);
-	}
+    static {
+        // BPL related to PVs/appliances etc
+        addAction("/getAllPVs", GetAllPVs.class);
+        addAction("/getAllExpandedPVNames", GetAllExpandedPVNames.class);
+        addAction("/getPVStatus", GetPVStatusAction.class);
+        addAction("/getPVTypeInfo", GetPVTypeInfo.class);
+        addAction("/archivePV", ArchivePVAction.class);
+        addAction("/pauseArchivingPV", PauseArchivingPV.class);
+        addAction("/resumeArchivingPV", ResumeArchivingPV.class);
+        addAction("/getStoresForPV", GetStoresForPV.class);
+        addAction("/modifyStoreURLForPV", ModifyStoreURLForPV.class);
+        addAction("/consolidateDataForPV", ConsolidatePBFilesForOnePV.class);
+        addAction("/deletePV", DeletePV.class);
+        addAction("/abortArchivingPV", AbortArchiveRequest.class);
+        addAction("/abortArchivingPVForThisAppliance", AbortArchiveRequestForAppliance.class);
+        addAction("/changeArchivalParameters", ChangeArchivalParamsAction.class);
+        addAction("/getPVDetails", PVDetails.class);
+        addAction("/getApplianceInfo", GetApplianceInfo.class);
+        addAction("/getAppliancesInCluster", GetAppliancesInCluster.class);
+        addAction("/renamePV", RenamePVAction.class);
+        addAction("/reshardPV", ReshardPV.class);
+        addAction("/appendAndAliasPV", AppendAndAliasPV.class);
+        addAction("/addAlias", AddAliasAction.class);
+        addAction("/removeAlias", RemoveAliasAction.class);
+        addAction("/getAllAliases", GetAllAliasesAction.class);
+        addAction("/skipAliasCheck", SkipAliasCheckAction.class);
+        addAction("/changeTypeForPV", ChangeTypeForPV.class);
+        addAction("/mergeInData", MergeInDataFromExternalStore.class);
+        addAction("/resetFailoverCaches", ResetFailoverCaches.class);
+        addAction("/getVersions", GetVersions.class);
+        addAction("/modifyMetaFields", ModifyMetaFieldsAction.class);
+        addAction("/getNamedFlag", NamedFlagsGet.class);
+        addAction("/setNamedFlag", NamedFlagsSet.class);
+        addAction("/getTypeInfoKeys", GetPVTypeInfoKeys.class);
 
-	
+        // BPL related to reports
+        addAction("/getNeverConnectedPVs", NeverConnectedPVsAction.class);
+        addAction("/getNeverConnectedPVsForThisAppliance", NeverConnectedPVsForThisAppliance.class);
+        addAction("/getMetaGets", MetaGetsAction.class);
+        addAction("/getCurrentlyDisconnectedPVs", CurrentlyDisconnectedPVs.class);
+        addAction("/getEventRateReport", EventRateReport.class);
+        addAction("/getStorageRateReport", StorageRateReport.class);
+        addAction("/getRecentlyAddedPVs", RecentlyAddedPVs.class);
+        addAction("/getRecentlyAddedPVsForThisInstance", RecentlyAddedPVsforThisInstance.class);
+        addAction("/getRecentlyModifiedPVs", RecentlyChangedPVs.class);
+        addAction("/getRecentlyModifiedPVsForThisInstance", RecentlyChangedPVsforThisInstance.class);
+        addAction("/getStorageMetrics", StorageReport.class);
+        addAction("/getStorageMetricsForAppliance", StorageReportDetails.class);
+        addAction("/getPVsByStorageConsumed", PVsByStorageConsumed.class);
+        addAction("/getLostConnectionsReport", LostConnectionsReport.class);
+        addAction("/getSilentPVsReport", SilentPVReport.class);
+        addAction("/getPVsForThisAppliance", GetPVsForThisAppliance.class);
+        addAction("/getPVsByDroppedEventsTimestamp", DroppedEventsTimestampReport.class);
+        addAction("/getPVsByDroppedEventsBuffer", DroppedEventsBufferOverflowReport.class);
+        addAction("/getPVsByDroppedEventsTypeChange", DroppedEventsTypeChangeReport.class);
+        addAction("/getSlowChangingPVsWithDroppedEvents", SlowChangingPVsWithDroppedEvents.class);
+        addAction("/getPausedPVsReport", PausedPVsReport.class);
+        addAction("/getPausedPVsForThisAppliance", GetPausedPVsForThisAppliance.class);
+        addAction("/getArchivedWaveforms", WaveformPVsAction.class);
+        addAction("/getTimeSpanReport", TimeSpanReport.class);
 
-	private ConfigService configService;
-	@Override
-	public void init() throws ServletException {
-		super.init();
-		configService = (ConfigService) getServletConfig().getServletContext().getAttribute(ConfigService.CONFIG_SERVICE_NAME);
-	}
-	
+        // Others.
+        addAction("/getPolicyText", GetPolicyText.class);
+        addAction("/exportConfig", ExportConfig.class);
+        addAction("/exportConfigForAppliance", ExportConfigForThisInstance.class);
+        addAction("/getInstanceMetrics", InstanceReport.class);
+        addAction("/getInstanceMetricsForAppliance", InstanceReportDetails.class);
+        addAction("/getApplianceMetrics", ApplianceMetrics.class);
+        addAction("/getApplianceMetricsForAppliance", ApplianceMetricsDetails.class);
+        addAction("/getExternalArchiverServers", ChannelArchiverListView.class);
+        addAction("/addExternalArchiverServer", AddExternalArchiverServer.class);
+        addAction("/addExternalArchiverServerArchives", AddExternalArchiverServerArchives.class);
+        addAction("/removeExternalArchiverServer", RemoveExternalArchiverServer.class);
+        addAction("/test/compareWithChannelArchiver", CompareWithChannelArchiver.class);
+        addAction("/getAggregatedApplianceInfo", AggregatedApplianceInfo.class);
+        addAction("/importDataFromPlugin", ImportDataFromPlugin.class);
+        addAction("/getPolicyList", GetPolicyList.class);
+        addAction("/getApplianceProperties", GetApplianceProps.class);
+        addAction("/webAppReady", WebappReady.class);
+        addAction("/getProcessMetrics", ProcessMetricsReport.class);
+        addAction("/getProcessMetricsDataForAppliance", ProcessMetricsChartData.class);
+        addAction("/refreshPVDataFromChannelArchivers", RefreshPVDataFromChannelArchivers.class);
+        addAction("/getMatchingPVsForThisAppliance", GetMatchingPVsForAppliance.class);
+        addAction("/getCreationReportForAppliance", CreationTimeReportForAppliance.class);
+        addAction("/restartArchivePVWorkflowThreadForThisAppliance", RestartArchiveWorkflowThreadForAppliance.class);
+    }
 
-	private static HashMap<String, Class<? extends BPLAction>> postActions = new HashMap<String, Class<? extends BPLAction>>();
-	static {
-		addPostAction("/importChannelArchiverConfiguration", ImportChannelArchiverConfigAction.class);
-		addPostAction("/uploadChannelArchiverConfiguration", UploadChannelArchiverConfigAction.class);
-		addPostAction("/importConfig", ImportConfig.class);
-		addPostAction("/importConfigForAppliance", ImportConfigForAppliance.class);
-		addPostAction("/archivePV", ArchivePVAction.class);
-		addPostAction("/getPVStatus", GetPVStatusAction.class);
-		addPostAction("/pauseArchivingPV", PauseArchivingPV.class);
-		addPostAction("/resumeArchivingPV", ResumeArchivingPV.class);
-		addPostAction("/putPVTypeInfo", PutPVTypeInfo.class);
-		addPostAction("/unarchivedPVs", UnarchivedPVsAction.class);
-		addPostAction("/archivedPVs", ArchivedPVsAction.class);
-		addPostAction("/archivedPVsForThisAppliance", ArchivedPVsForThisApplianceAction.class);
-		addPostAction("/archivedPVsNotInList", ArchivedPVsNotInListAction.class);
-	}
-	
-	@Override
-	protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-		BasicDispatcher.dispatch(req, resp, configService, postActions);
-	}
-	
-	/**
-	 * Add so that we can maintain the sequence of addition as well. 
-	 * @param path
-	 * @param bplClassName
-	 */
-	private static void addAction(String path, Class<? extends BPLAction> bplClassName) { 
-		getActions.put(path, bplClassName);
-		actionsSequenceForDocs.add(path);
-	}
-	
-	private static void addPostAction(String path, Class<? extends BPLAction> bplClassName) { 
-		postActions.put(path, bplClassName);
-		if(!actionsSequenceForDocs.contains(path)) { 
-			actionsSequenceForDocs.add(path);
-		}
-	}
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        BasicDispatcher.dispatch(req, resp, configService, getActions);
+    }
 
-	
-	/**
-	 * The main method here is used only to generate documentation for the scripting guide. 
-	 * No other functionality is provided
-	 * @param args  &emsp;
-	 * @throws IOException  &emsp;
-	 */
-	public static void main(String[] args) throws IOException {
-		System.out.println("#Path mappings for mgmt BPLs");
-		for(String path : actionsSequenceForDocs) { 
-			Class<? extends BPLAction> classObj = getActions.get(path);
-			if(classObj == null) { 
-				classObj = postActions.get(path);
-			}
-			if(classObj == null) { 
-				System.err.println("Invalid registration for " + path);
-			}
-			System.out.println(path + "=" + classObj.getName());
-		}
-	}
+    private ConfigService configService;
+
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        configService =
+                (ConfigService) getServletConfig().getServletContext().getAttribute(ConfigService.CONFIG_SERVICE_NAME);
+    }
+
+    private static HashMap<String, Class<? extends BPLAction>> postActions =
+            new HashMap<String, Class<? extends BPLAction>>();
+
+    static {
+        addPostAction("/importChannelArchiverConfiguration", ImportChannelArchiverConfigAction.class);
+        addPostAction("/uploadChannelArchiverConfiguration", UploadChannelArchiverConfigAction.class);
+        addPostAction("/importConfig", ImportConfig.class);
+        addPostAction("/importConfigForAppliance", ImportConfigForAppliance.class);
+        addPostAction("/archivePV", ArchivePVAction.class);
+        addPostAction("/getPVStatus", GetPVStatusAction.class);
+        addPostAction("/pauseArchivingPV", PauseArchivingPV.class);
+        addPostAction("/resumeArchivingPV", ResumeArchivingPV.class);
+        addPostAction("/putPVTypeInfo", PutPVTypeInfo.class);
+        addPostAction("/unarchivedPVs", UnarchivedPVsAction.class);
+        addPostAction("/archivedPVs", ArchivedPVsAction.class);
+        addPostAction("/archivedPVsForThisAppliance", ArchivedPVsForThisApplianceAction.class);
+        addPostAction("/archivedPVsNotInList", ArchivedPVsNotInListAction.class);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        BasicDispatcher.dispatch(req, resp, configService, postActions);
+    }
+
+    /**
+     * Add so that we can maintain the sequence of addition as well.
+     * @param path
+     * @param bplClassName
+     */
+    private static void addAction(String path, Class<? extends BPLAction> bplClassName) {
+        getActions.put(path, bplClassName);
+        actionsSequenceForDocs.add(path);
+    }
+
+    private static void addPostAction(String path, Class<? extends BPLAction> bplClassName) {
+        postActions.put(path, bplClassName);
+        if (!actionsSequenceForDocs.contains(path)) {
+            actionsSequenceForDocs.add(path);
+        }
+    }
+
+    /**
+     * The main method here is used only to generate documentation for the scripting guide.
+     * No other functionality is provided
+     * @param args  &emsp;
+     * @throws IOException  &emsp;
+     */
+    public static void main(String[] args) throws IOException {
+        System.out.println("#Path mappings for mgmt BPLs");
+        for (String path : actionsSequenceForDocs) {
+            Class<? extends BPLAction> classObj = getActions.get(path);
+            if (classObj == null) {
+                classObj = postActions.get(path);
+            }
+            if (classObj == null) {
+                System.err.println("Invalid registration for " + path);
+            }
+            System.out.println(path + "=" + classObj.getName());
+        }
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/BPLServlet.java
+++ b/src/main/org/epics/archiverappliance/mgmt/BPLServlet.java
@@ -218,7 +218,7 @@ public class BPLServlet extends HttpServlet {
                 (ConfigService) getServletConfig().getServletContext().getAttribute(ConfigService.CONFIG_SERVICE_NAME);
     }
 
-    private static HashMap<String, Class<? extends BPLAction>> postActions =
+    private static final HashMap<String, Class<? extends BPLAction>> postActions =
             new HashMap<String, Class<? extends BPLAction>>();
 
     static {
@@ -227,6 +227,7 @@ public class BPLServlet extends HttpServlet {
         addPostAction("/importConfig", ImportConfig.class);
         addPostAction("/importConfigForAppliance", ImportConfigForAppliance.class);
         addPostAction("/archivePV", ArchivePVAction.class);
+        addPostAction("/deletePV", DeletePV.class);
         addPostAction("/getPVStatus", GetPVStatusAction.class);
         addPostAction("/pauseArchivingPV", PauseArchivingPV.class);
         addPostAction("/resumeArchivingPV", ResumeArchivingPV.class);

--- a/src/main/org/epics/archiverappliance/mgmt/archivepv/ArchivePVState.java
+++ b/src/main/org/epics/archiverappliance/mgmt/archivepv/ArchivePVState.java
@@ -145,7 +145,7 @@ public class ArchivePVState {
                         }
                     }
 
-                    boolean isField = PVNames.isField(pvName);
+                    boolean isField = PVNames.isFieldOrFieldModifier(pvName);
 
                     PVTypeInfo typeInfo = new PVTypeInfo(
                             pvName, metaInfo.getArchDBRTypes(), !metaInfo.isVector(), metaInfo.getCount());
@@ -227,7 +227,7 @@ public class ArchivePVState {
                                 + " based on policy " + thePolicy.getPolicyName());
                     } else {
                         if (isField) {
-                            String pvNameAlone = PVNames.stripFieldNameFromPVName(pvName);
+                            String pvNameAlone = PVNames.channelNamePVName(pvName);
                             ApplianceInfo pvNameAloneAssignedToAppliance = configService.getApplianceForPV(pvNameAlone);
                             if (pvNameAloneAssignedToAppliance != null) {
                                 logger.info("Assinging field " + pvName + " to the same appliance as the pv itself "

--- a/src/main/org/epics/archiverappliance/mgmt/archivepv/ArchivePVState.java
+++ b/src/main/org/epics/archiverappliance/mgmt/archivepv/ArchivePVState.java
@@ -31,420 +31,492 @@ import java.util.List;
  *
  */
 public class ArchivePVState {
-	private static Logger logger = LogManager.getLogger(ArchivePVState.class.getName());
-	public enum ArchivePVStateMachine { START, METAINFO_REQUESTED, METAINFO_GATHERING, METAINFO_OBTAINED, POLICY_COMPUTED, TYPEINFO_STABLE, ARCHIVE_REQUEST_SUBMITTED, ARCHIVING, ABORTED, FINISHED}
+    private static Logger logger = LogManager.getLogger(ArchivePVState.class.getName());
 
-	private ArchivePVStateMachine currentState = ArchivePVStateMachine.START;
-	private String pvName;
-	private String abortReason = "";
-	private ConfigService configService;
-	private List<String> fieldsArchivedAsPartOfStream;
-	private String applianceIdentityAfterCapacityPlanning;
+    public enum ArchivePVStateMachine {
+        START,
+        METAINFO_REQUESTED,
+        METAINFO_GATHERING,
+        METAINFO_OBTAINED,
+        POLICY_COMPUTED,
+        TYPEINFO_STABLE,
+        ARCHIVE_REQUEST_SUBMITTED,
+        ARCHIVING,
+        ABORTED,
+        FINISHED
+    }
+
+    private ArchivePVStateMachine currentState = ArchivePVStateMachine.START;
+    private String pvName;
+    private String abortReason = "";
+    private ConfigService configService;
+    private List<String> fieldsArchivedAsPartOfStream;
+    private String applianceIdentityAfterCapacityPlanning;
     private Instant startOfWorkflow = TimeUtils.now();
     private Instant metaInfoRequestedSubmitted = null;
-	private String myIdentity;
-	private MetaInfo metaInfo = null;
+    private String myIdentity;
+    private MetaInfo metaInfo = null;
 
-	public ArchivePVState(String pvName, ConfigService configService) {
-		this.pvName = pvName;
-		this.configService = configService;
-		this.myIdentity = this.configService.getMyApplianceInfo().getIdentity();
-		try {
-			this.fieldsArchivedAsPartOfStream = configService.getFieldsArchivedAsPartOfStream();
-		} catch(IOException ex) {
-			logger.error("Cannot determine fields that are to be archived as part of stream", ex);
-			this.fieldsArchivedAsPartOfStream = null;
-		}
-	}
+    public ArchivePVState(String pvName, ConfigService configService) {
+        this.pvName = pvName;
+        this.configService = configService;
+        this.myIdentity = this.configService.getMyApplianceInfo().getIdentity();
+        try {
+            this.fieldsArchivedAsPartOfStream = configService.getFieldsArchivedAsPartOfStream();
+        } catch (IOException ex) {
+            logger.error("Cannot determine fields that are to be archived as part of stream", ex);
+            this.fieldsArchivedAsPartOfStream = null;
+        }
+    }
 
-	public synchronized void nextStep() {
-		try { 
-			logger.debug("Archive workflow for pv " + pvName + " in state " + currentState);
-				switch(currentState) {
-				case START: {
-					PubSubEvent pubSubEvent = new PubSubEvent("ComputeMetaInfo", myIdentity + "_" + ConfigService.WAR_FILE.ENGINE, pvName);
-					UserSpecifiedSamplingParams userSpec = configService.getUserSpecifiedSamplingParams(pvName);
-					if(userSpec == null) {
-						logger.error("Unable to find user sepcification of archival parameters for pv " + pvName);
-						currentState = ArchivePVStateMachine.ABORTED;
-						return;
-					}
+    public synchronized void nextStep() {
+        try {
+            logger.debug("Archive workflow for pv " + pvName + " in state " + currentState);
+            switch (currentState) {
+                case START: {
+                    PubSubEvent pubSubEvent = new PubSubEvent(
+                            "ComputeMetaInfo", myIdentity + "_" + ConfigService.WAR_FILE.ENGINE, pvName);
+                    UserSpecifiedSamplingParams userSpec = configService.getUserSpecifiedSamplingParams(pvName);
+                    if (userSpec == null) {
+                        logger.error("Unable to find user sepcification of archival parameters for pv " + pvName);
+                        currentState = ArchivePVStateMachine.ABORTED;
+                        return;
+                    }
 
-					JSONEncoder<UserSpecifiedSamplingParams> encoder = JSONEncoder.getEncoder(UserSpecifiedSamplingParams.class);
-					pubSubEvent.setEventData(encoder.encode(userSpec).toJSONString());
-					configService.getEventBus().post(pubSubEvent);
-					currentState = ArchivePVStateMachine.METAINFO_REQUESTED;
-					return;	
-				}
-				case METAINFO_REQUESTED: {
-					logger.debug("A request to gather metainfo has been published for the PV " + pvName);
-					return;
-				}
-				case METAINFO_GATHERING: {
-					logger.debug("Metainfo has been requested and is being gathered for " + pvName);
-					return;
-				}
-				case METAINFO_OBTAINED: {
-					logger.debug("Metainfo obtained for pv " + pvName);
-					if(metaInfo == null) {
-						logger.error("We are in state METAINFO_OBTAINED but the metainfo object is null");
-						currentState = ArchivePVStateMachine.ABORTED;
-						return;
-					}
+                    JSONEncoder<UserSpecifiedSamplingParams> encoder =
+                            JSONEncoder.getEncoder(UserSpecifiedSamplingParams.class);
+                    pubSubEvent.setEventData(encoder.encode(userSpec).toJSONString());
+                    configService.getEventBus().post(pubSubEvent);
+                    currentState = ArchivePVStateMachine.METAINFO_REQUESTED;
+                    return;
+                }
+                case METAINFO_REQUESTED: {
+                    logger.debug("A request to gather metainfo has been published for the PV " + pvName);
+                    return;
+                }
+                case METAINFO_GATHERING: {
+                    logger.debug("Metainfo has been requested and is being gathered for " + pvName);
+                    return;
+                }
+                case METAINFO_OBTAINED: {
+                    logger.debug("Metainfo obtained for pv " + pvName);
+                    if (metaInfo == null) {
+                        logger.error("We are in state METAINFO_OBTAINED but the metainfo object is null");
+                        currentState = ArchivePVStateMachine.ABORTED;
+                        return;
+                    }
 
-					if(metaInfo.getArchDBRTypes() == null) {
-						logger.error("Invalid/null DBR type for pv " + pvName);
-						currentState = ArchivePVStateMachine.ABORTED;
-						return;
-					}
+                    if (metaInfo.getArchDBRTypes() == null) {
+                        logger.error("Invalid/null DBR type for pv " + pvName);
+                        currentState = ArchivePVStateMachine.ABORTED;
+                        return;
+                    }
 
-					UserSpecifiedSamplingParams userSpec = configService.getUserSpecifiedSamplingParams(pvName);
-					if(userSpec == null) {
-						logger.error("Unable to find user sepcification of archival parameters for pv " + pvName);
-						currentState = ArchivePVStateMachine.ABORTED;
-						return;
-					}
-					
+                    UserSpecifiedSamplingParams userSpec = configService.getUserSpecifiedSamplingParams(pvName);
+                    if (userSpec == null) {
+                        logger.error("Unable to find user sepcification of archival parameters for pv " + pvName);
+                        currentState = ArchivePVStateMachine.ABORTED;
+                        return;
+                    }
 
-					logger.debug("About to compute policy for " + pvName);
-					PolicyConfig thePolicy = configService.computePolicyForPV(pvName, metaInfo, userSpec);
-					if(thePolicy.getSamplingMethod() == SamplingMethod.DONT_ARCHIVE) {
-						logger.error("According to the policy, we must not archive pv as the sampling method is DONT_ARCHIVE for PV " + pvName);
-						currentState = ArchivePVStateMachine.ABORTED;
-						return;
-					} else {
-						logger.info("Policy for pv " + pvName+ " is " + thePolicy.generateStringRepresentation());
-					}
+                    logger.debug("About to compute policy for " + pvName);
+                    PolicyConfig thePolicy = configService.computePolicyForPV(pvName, metaInfo, userSpec);
+                    if (thePolicy.getSamplingMethod() == SamplingMethod.DONT_ARCHIVE) {
+                        logger.error(
+                                "According to the policy, we must not archive pv as the sampling method is DONT_ARCHIVE for PV "
+                                        + pvName);
+                        currentState = ArchivePVStateMachine.ABORTED;
+                        return;
+                    } else {
+                        logger.info("Policy for pv " + pvName + " is " + thePolicy.generateStringRepresentation());
+                    }
 
-					SamplingMethod theSamplingMethod = thePolicy.getSamplingMethod();
-					float theSamplingPeriod = thePolicy.getSamplingPeriod();
-					String controllingPV = thePolicy.getControlPV();
-					if(userSpec.isUserOverrideParams()) {
-						theSamplingMethod = userSpec.userSpecifedsamplingMethod;
-						theSamplingPeriod = userSpec.getUserSpecifedSamplingPeriod();
-						logger.debug("Overriding sampling period  to " + theSamplingPeriod + " and using " + theSamplingMethod);
-						if(userSpec.getControllingPV() != null) { 
-							controllingPV = userSpec.getControllingPV();
-							logger.debug("Overriding controlling PV to " + controllingPV + " from the userspec");
-						}
-					}
-					
-					boolean isField = PVNames.isField(pvName);
-					
-					PVTypeInfo typeInfo = new PVTypeInfo(pvName, metaInfo.getArchDBRTypes(), !metaInfo.isVector(), metaInfo.getCount());
-					typeInfo.absorbMetaInfo(metaInfo);
-					typeInfo.setSamplingMethod(theSamplingMethod);
-					typeInfo.setSamplingPeriod(theSamplingPeriod);
-					typeInfo.setDataStores(thePolicy.getDataStores());
-					typeInfo.setCreationTime(TimeUtils.now());
-					typeInfo.setControllingPV(controllingPV);
-					typeInfo.setUsePVAccess(userSpec.isUsePVAccess());
-					typeInfo.setPolicyName(thePolicy.getPolicyName());
-					
-					if(!isField) {
-						for(String field : thePolicy.getArchiveFields()) {
-							if(fieldsArchivedAsPartOfStream != null && fieldsArchivedAsPartOfStream.contains(field)) {
-								typeInfo.addArchiveField(field);								
-							} else {
-								initiateWorkFlowForNonStreamField(PVNames.normalizePVNameWithField(pvName, field), userSpec); 
-							}
-						}
+                    SamplingMethod theSamplingMethod = thePolicy.getSamplingMethod();
+                    float theSamplingPeriod = thePolicy.getSamplingPeriod();
+                    String controllingPV = thePolicy.getControlPV();
+                    if (userSpec.isUserOverrideParams()) {
+                        theSamplingMethod = userSpec.userSpecifedsamplingMethod;
+                        theSamplingPeriod = userSpec.getUserSpecifedSamplingPeriod();
+                        logger.debug("Overriding sampling period  to " + theSamplingPeriod + " and using "
+                                + theSamplingMethod);
+                        if (userSpec.getControllingPV() != null) {
+                            controllingPV = userSpec.getControllingPV();
+                            logger.debug("Overriding controlling PV to " + controllingPV + " from the userspec");
+                        }
+                    }
 
-						// Copy over any archive fields from the user spec
-						if(userSpec != null && userSpec.wereAnyFieldsSpecified()) {
-							for(String fieldName : userSpec.getArchiveFields()) {
-								if(fieldsArchivedAsPartOfStream != null && fieldsArchivedAsPartOfStream.contains(fieldName)) {
-									typeInfo.addArchiveField(fieldName);
-								} else {
-									initiateWorkFlowForNonStreamField(PVNames.normalizePVNameWithField(pvName, fieldName), userSpec); 
-								}
-							}
-						}
-					}
+                    boolean isField = PVNames.isField(pvName);
 
-					String aliasFieldName = "NAME";
-					if(typeInfo.hasExtraField(aliasFieldName)) {
-						if(userSpec.isSkipAliasCheck()) { 
-							logger.info("Skipping alias check for pv " + pvName + " as the isSkipAliasCheck in userparams is set.");
-						} else { 
+                    PVTypeInfo typeInfo = new PVTypeInfo(
+                            pvName, metaInfo.getArchDBRTypes(), !metaInfo.isVector(), metaInfo.getCount());
+                    typeInfo.absorbMetaInfo(metaInfo);
+                    typeInfo.setSamplingMethod(theSamplingMethod);
+                    typeInfo.setSamplingPeriod(theSamplingPeriod);
+                    typeInfo.setDataStores(thePolicy.getDataStores());
+                    typeInfo.setCreationTime(TimeUtils.now());
+                    typeInfo.setControllingPV(controllingPV);
+                    typeInfo.setUsePVAccess(userSpec.isUsePVAccess());
+                    typeInfo.setPolicyName(thePolicy.getPolicyName());
 
-							String realName = typeInfo.lookupExtraField(aliasFieldName);
-							if(!realName.equals(pvName)) {
-								logger.info("PV " + pvName + " is an alias of " + realName);
-								// It is possible that some implementations use the .NAME field for purposes other than the alias.
-								// In this case, we make sure that the real name matches the PV name by checking that it at least has one or more separators.
-								if(!configService.getPVNameToKeyConverter().containsSiteSeparators(realName)) { 
-									logger.debug("There seem to be no siteNameSpaceSeparators in the real name " + realName + " in workflow for pv " + pvName + ". Archiving under the PV name instead");
-								} else { 
-									convertAliasToRealWorkflow(userSpec, realName);
-									abortReason = "Aborting this pv " + pvName + " (which is an alias) and using the real name " + realName + " instead.";
-									logger.debug(abortReason);
-									currentState = ArchivePVStateMachine.ABORTED;
-									return;
-								}
-							} else { 
-								logger.debug("Name from alias and normalized name are the same");
-							}
-						}
-					}
-										
-					ApplianceInfo applianceInfoForPV = null;
-					
-					if(userSpec.isSkipCapacityPlanning()) { 
-						logger.info("Skipping capacity planning for pv " + pvName + ". Assigning to myself.");
-						applianceInfoForPV = configService.getMyApplianceInfo();
-					} else if (thePolicy.getAppliance() != null) {
-						// Hopefully the poicy is configured correctly and we get a valid appliance
-						applianceInfoForPV = configService.getAppliance(thePolicy.getAppliance());
-						assert(applianceInfoForPV != null);
-						logger.info("Assigning pv " + pvName + " to appliance " + thePolicy.getAppliance() + " based on policy " + thePolicy.getPolicyName());
-					} else { 
-						if(isField) {
-							String pvNameAlone = PVNames.stripFieldNameFromPVName(pvName);
-							ApplianceInfo pvNameAloneAssignedToAppliance = configService.getApplianceForPV(pvNameAlone);
-							if(pvNameAloneAssignedToAppliance != null) {
-								logger.info("Assinging field " + pvName + " to the same appliance as the pv itself " + pvNameAloneAssignedToAppliance.getIdentity());
-								applianceInfoForPV = pvNameAloneAssignedToAppliance;
-							} else {
-								logger.info("Assinging field " + pvName + " to a new appliance");
-								applianceInfoForPV = CapacityPlanningBPL.pickApplianceForPV(pvName, configService, typeInfo);
-							}
-						} else {
-							logger.debug("Not a field " + pvName + " picking a new appliance.");
-							applianceInfoForPV = CapacityPlanningBPL.pickApplianceForPV(pvName, configService, typeInfo);
-						}
-					}
+                    if (!isField) {
+                        for (String field : thePolicy.getArchiveFields()) {
+                            if (fieldsArchivedAsPartOfStream != null && fieldsArchivedAsPartOfStream.contains(field)) {
+                                typeInfo.addArchiveField(field);
+                            } else {
+                                initiateWorkFlowForNonStreamField(
+                                        PVNames.normalizePVNameWithField(pvName, field), userSpec);
+                            }
+                        }
 
-					assert(applianceInfoForPV != null);
-					logger.info("After capacity planning, appliance for pv " + pvName + " is " + applianceInfoForPV.getIdentity());
-					applianceIdentityAfterCapacityPlanning = applianceInfoForPV.getIdentity();
+                        // Copy over any archive fields from the user spec
+                        if (userSpec != null && userSpec.wereAnyFieldsSpecified()) {
+                            for (String fieldName : userSpec.getArchiveFields()) {
+                                if (fieldsArchivedAsPartOfStream != null
+                                        && fieldsArchivedAsPartOfStream.contains(fieldName)) {
+                                    typeInfo.addArchiveField(fieldName);
+                                } else {
+                                    initiateWorkFlowForNonStreamField(
+                                            PVNames.normalizePVNameWithField(pvName, fieldName), userSpec);
+                                }
+                            }
+                        }
+                    }
 
-					try {
-						configService.registerPVToAppliance(pvName, applianceInfoForPV);
-						typeInfo.setApplianceIdentity(applianceIdentityAfterCapacityPlanning);
-						configService.updateTypeInfoForPV(pvName, typeInfo);
-						currentState = ArchivePVStateMachine.POLICY_COMPUTED;
-					} catch(AlreadyRegisteredException ex) {
-						logger.error("PV " + pvName + " is already registered. Aborting this request");
-						currentState = ArchivePVStateMachine.ABORTED;
-					}
-					return;
-				}
-				case POLICY_COMPUTED: {
-					PVTypeInfo typeInfo = configService.getTypeInfoForPV(pvName);
-					if(typeInfo.getApplianceIdentity().equals(applianceIdentityAfterCapacityPlanning)) {
-						currentState = ArchivePVStateMachine.TYPEINFO_STABLE;
-					}
-					return;
-				}
-				case TYPEINFO_STABLE: {
-					PVTypeInfo typeInfo = configService.getTypeInfoForPV(pvName);
-					ArchivePVState.startArchivingPV(pvName, configService, configService.getAppliance(typeInfo.getApplianceIdentity()));
-					registerAliasesIfAny(typeInfo);
-					currentState = ArchivePVStateMachine.ARCHIVE_REQUEST_SUBMITTED;
-					return;
-				}
-				case ARCHIVE_REQUEST_SUBMITTED:
-					// The part in mgmt is basically over; we are waiting for the engine to indicate that it has commenced archiving
-					// Until then, we stay in this state.
-					return;
-				case ARCHIVING: {
-					logger.debug("We are in the Archiving state. So, cancelling the periodic ping of the workflow object for pv " + pvName);
-					configService.archiveRequestWorkflowCompleted(pvName);
-					configService.getMgmtRuntimeState().finishedPVWorkflow(pvName);
-					currentState = ArchivePVStateMachine.FINISHED;
-					return;
-				}
-				case ABORTED: {
-					configService.archiveRequestWorkflowCompleted(pvName);
-					configService.getMgmtRuntimeState().finishedPVWorkflow(pvName);
-					logger.error("Aborting archive request for pv " + pvName + " Reason: " + abortReason);
-					currentState = ArchivePVStateMachine.FINISHED;
-					return;
-				}
-				case FINISHED: {
-					logger.error("Archive state for PV " + this.pvName + " is finished.");
-					return;
-				}
-				default: {
-					logger.error("Invalid state when going thru the archive pv workflow");
-					return;
-				}
-			}
-		} catch(Exception ex) {
-			logger.error("Exception transitioning archive pv state for pv " + pvName + " in state " + currentState, ex);
-		}
-	}
+                    String aliasFieldName = "NAME";
+                    if (typeInfo.hasExtraField(aliasFieldName)) {
+                        if (userSpec.isSkipAliasCheck()) {
+                            logger.info("Skipping alias check for pv " + pvName
+                                    + " as the isSkipAliasCheck in userparams is set.");
+                        } else {
 
-	public boolean hasNotConnectedSoFar() {
-		return this.currentState.equals(ArchivePVState.ArchivePVStateMachine.START) || this.currentState.equals(ArchivePVState.ArchivePVStateMachine.METAINFO_REQUESTED) || this.currentState.equals(ArchivePVState.ArchivePVStateMachine.METAINFO_GATHERING) || this.currentState.equals(ArchivePVState.ArchivePVStateMachine.ABORTED);
-	}
+                            String realName = typeInfo.lookupExtraField(aliasFieldName);
+                            if (!realName.equals(pvName)) {
+                                logger.info("PV " + pvName + " is an alias of " + realName);
+                                // It is possible that some implementations use the .NAME field for purposes other than
+                                // the alias.
+                                // In this case, we make sure that the real name matches the PV name by checking that it
+                                // at least has one or more separators.
+                                if (!configService.getPVNameToKeyConverter().containsSiteSeparators(realName)) {
+                                    logger.debug("There seem to be no siteNameSpaceSeparators in the real name "
+                                            + realName + " in workflow for pv " + pvName
+                                            + ". Archiving under the PV name instead");
+                                } else {
+                                    convertAliasToRealWorkflow(userSpec, realName);
+                                    abortReason = "Aborting this pv " + pvName
+                                            + " (which is an alias) and using the real name " + realName + " instead.";
+                                    logger.debug(abortReason);
+                                    currentState = ArchivePVStateMachine.ABORTED;
+                                    return;
+                                }
+                            } else {
+                                logger.debug("Name from alias and normalized name are the same");
+                            }
+                        }
+                    }
 
-	/**
-	 * Start archiving the PV as specified in the PVTypeInfo in configService.
-	 * This method expects to be called after the PVTypeInfo for this PV has been completely determined and has settled in the cache. 
-	 * @param pvName The name of PV
-	 * @param configService ConfigService
-	 * @param applianceInfoForPV  ApplianceInfo
-	 * @throws IOException  &emsp;
-	 */
-	public static void startArchivingPV(String pvName, ConfigService configService, ApplianceInfo applianceInfoForPV) throws IOException {
-		PVTypeInfo typeInfo = configService.getTypeInfoForPV(pvName);
-		if(typeInfo == null) {
-			logger.error("Unable to find pvTypeInfo for PV" + pvName + ". This is an error; this method should be called after the pvTypeInfo has been determined and settled in the DHT");
-			throw new IOException("Unable to find pvTypeInfo for PV" + pvName);
-		}
-		
-		logger.debug("Setting up archiving of pv " + pvName);
-		PubSubEvent pubSubEvent = new PubSubEvent("StartArchivingPV", applianceInfoForPV.getIdentity()  + "_" + ConfigService.WAR_FILE.ENGINE, pvName);
-		configService.getEventBus().post(pubSubEvent);
-	}
+                    ApplianceInfo applianceInfoForPV = null;
+
+                    if (userSpec.isSkipCapacityPlanning()) {
+                        logger.info("Skipping capacity planning for pv " + pvName + ". Assigning to myself.");
+                        applianceInfoForPV = configService.getMyApplianceInfo();
+                    } else if (thePolicy.getAppliance() != null) {
+                        // Hopefully the poicy is configured correctly and we get a valid appliance
+                        applianceInfoForPV = configService.getAppliance(thePolicy.getAppliance());
+                        assert (applianceInfoForPV != null);
+                        logger.info("Assigning pv " + pvName + " to appliance " + thePolicy.getAppliance()
+                                + " based on policy " + thePolicy.getPolicyName());
+                    } else {
+                        if (isField) {
+                            String pvNameAlone = PVNames.stripFieldNameFromPVName(pvName);
+                            ApplianceInfo pvNameAloneAssignedToAppliance = configService.getApplianceForPV(pvNameAlone);
+                            if (pvNameAloneAssignedToAppliance != null) {
+                                logger.info("Assinging field " + pvName + " to the same appliance as the pv itself "
+                                        + pvNameAloneAssignedToAppliance.getIdentity());
+                                applianceInfoForPV = pvNameAloneAssignedToAppliance;
+                            } else {
+                                logger.info("Assinging field " + pvName + " to a new appliance");
+                                applianceInfoForPV =
+                                        CapacityPlanningBPL.pickApplianceForPV(pvName, configService, typeInfo);
+                            }
+                        } else {
+                            logger.debug("Not a field " + pvName + " picking a new appliance.");
+                            applianceInfoForPV =
+                                    CapacityPlanningBPL.pickApplianceForPV(pvName, configService, typeInfo);
+                        }
+                    }
+
+                    assert (applianceInfoForPV != null);
+                    logger.info("After capacity planning, appliance for pv " + pvName + " is "
+                            + applianceInfoForPV.getIdentity());
+                    applianceIdentityAfterCapacityPlanning = applianceInfoForPV.getIdentity();
+
+                    try {
+                        configService.registerPVToAppliance(pvName, applianceInfoForPV);
+                        typeInfo.setApplianceIdentity(applianceIdentityAfterCapacityPlanning);
+                        configService.updateTypeInfoForPV(pvName, typeInfo);
+                        currentState = ArchivePVStateMachine.POLICY_COMPUTED;
+                    } catch (AlreadyRegisteredException ex) {
+                        logger.error("PV " + pvName + " is already registered. Aborting this request");
+                        currentState = ArchivePVStateMachine.ABORTED;
+                    }
+                    return;
+                }
+                case POLICY_COMPUTED: {
+                    PVTypeInfo typeInfo = configService.getTypeInfoForPV(pvName);
+                    if (typeInfo.getApplianceIdentity().equals(applianceIdentityAfterCapacityPlanning)) {
+                        currentState = ArchivePVStateMachine.TYPEINFO_STABLE;
+                    }
+                    return;
+                }
+                case TYPEINFO_STABLE: {
+                    PVTypeInfo typeInfo = configService.getTypeInfoForPV(pvName);
+                    ArchivePVState.startArchivingPV(
+                            pvName, configService, configService.getAppliance(typeInfo.getApplianceIdentity()));
+                    registerAliasesIfAny(typeInfo);
+                    currentState = ArchivePVStateMachine.ARCHIVE_REQUEST_SUBMITTED;
+                    return;
+                }
+                case ARCHIVE_REQUEST_SUBMITTED:
+                    // The part in mgmt is basically over; we are waiting for the engine to indicate that it has
+                    // commenced archiving
+                    // Until then, we stay in this state.
+                    return;
+                case ARCHIVING: {
+                    logger.debug(
+                            "We are in the Archiving state. So, cancelling the periodic ping of the workflow object for pv "
+                                    + pvName);
+                    configService.archiveRequestWorkflowCompleted(pvName);
+                    configService.getMgmtRuntimeState().finishedPVWorkflow(pvName);
+                    currentState = ArchivePVStateMachine.FINISHED;
+                    return;
+                }
+                case ABORTED: {
+                    configService.archiveRequestWorkflowCompleted(pvName);
+                    configService.getMgmtRuntimeState().finishedPVWorkflow(pvName);
+                    logger.error("Aborting archive request for pv " + pvName + " Reason: " + abortReason);
+                    currentState = ArchivePVStateMachine.FINISHED;
+                    return;
+                }
+                case FINISHED: {
+                    logger.error("Archive state for PV " + this.pvName + " is finished.");
+                    return;
+                }
+                default: {
+                    logger.error("Invalid state when going thru the archive pv workflow");
+                    return;
+                }
+            }
+        } catch (Exception ex) {
+            logger.error("Exception transitioning archive pv state for pv " + pvName + " in state " + currentState, ex);
+        }
+    }
+
+    public boolean hasNotConnectedSoFar() {
+        return this.currentState.equals(ArchivePVState.ArchivePVStateMachine.START)
+                || this.currentState.equals(ArchivePVState.ArchivePVStateMachine.METAINFO_REQUESTED)
+                || this.currentState.equals(ArchivePVState.ArchivePVStateMachine.METAINFO_GATHERING)
+                || this.currentState.equals(ArchivePVState.ArchivePVStateMachine.ABORTED);
+    }
+
+    /**
+     * Start archiving the PV as specified in the PVTypeInfo in configService.
+     * This method expects to be called after the PVTypeInfo for this PV has been completely determined and has settled in the cache.
+     * @param pvName The name of PV
+     * @param configService ConfigService
+     * @param applianceInfoForPV  ApplianceInfo
+     * @throws IOException  &emsp;
+     */
+    public static void startArchivingPV(String pvName, ConfigService configService, ApplianceInfo applianceInfoForPV)
+            throws IOException {
+        PVTypeInfo typeInfo = configService.getTypeInfoForPV(pvName);
+        if (typeInfo == null) {
+            logger.error(
+                    "Unable to find pvTypeInfo for PV" + pvName
+                            + ". This is an error; this method should be called after the pvTypeInfo has been determined and settled in the DHT");
+            throw new IOException("Unable to find pvTypeInfo for PV" + pvName);
+        }
+
+        logger.debug("Setting up archiving of pv " + pvName);
+        PubSubEvent pubSubEvent = new PubSubEvent(
+                "StartArchivingPV", applianceInfoForPV.getIdentity() + "_" + ConfigService.WAR_FILE.ENGINE, pvName);
+        configService.getEventBus().post(pubSubEvent);
+    }
 
     public Instant getStartOfWorkflow() {
-		return startOfWorkflow;
-	}
-	
-	
-	public void metaInfoRequestAcknowledged() { 
-		metaInfoRequestedSubmitted = TimeUtils.now();
-		this.currentState = ArchivePVStateMachine.METAINFO_GATHERING;
-	}
-	
-	public void metaInfoObtained(MetaInfo metaInfo) { 
-		this.metaInfo = metaInfo;
-		this.currentState = ArchivePVStateMachine.METAINFO_OBTAINED;
-	}
-	
-	public void errorGettingMetaInfo() { 
-		abortReason = "Error getting meta info";
-		this.currentState = ArchivePVStateMachine.ABORTED;
-	}	
-	
-	public void confirmedStartedArchivingPV() {
-		this.currentState = ArchivePVStateMachine.ARCHIVING;
-	}
+        return startOfWorkflow;
+    }
 
-	/**
-	 * If the user specified params has any aliases specified, we register the alias now.
-	 * @param typeInfo
-	 */
-	private void registerAliasesIfAny(PVTypeInfo typeInfo) { 
-		// If we are already archiving this PV, use addAlias to add an alias to the appliance hosting the pvTypeInfo
-		String addAliasURL = null;
-		try {
-			UserSpecifiedSamplingParams userSpec = configService.getUserSpecifiedSamplingParams(typeInfo.getPvName());
-			logger.debug("Adding aliases for " + typeInfo.getPvName());
-			if(userSpec != null && userSpec.getAliases() != null && userSpec.getAliases().length > 0) { 
-				logger.debug("Adding " + userSpec.getAliases().length + " aliases for " + typeInfo.getPvName());
-				for(String aliasName : userSpec.getAliases()) {
-					addAliasURL = configService.getAppliance(typeInfo.getApplianceIdentity()).getMgmtURL() + "/addAlias?pv=" 
-							+ URLEncoder.encode(typeInfo.getPvName(), "UTF-8") 
-							+ "&aliasname=" 
-							+ URLEncoder.encode(aliasName, "UTF-8");
-					logger.debug("Adding an alias " + aliasName + " for pv " + typeInfo.getPvName());
-					GetUrlContent.getURLContentAsJSONObject(addAliasURL);
-				}
-			}
-		} catch(Throwable t) { 
-			logger.error("Exception adding alias using URL " + addAliasURL, t);
-		}
-	}
-	
-	/**
-	 * Convert a alias workflow into a workflow entry for a real PV and add the alias as a user specified param. 
-	 * @param userSpec UserSpecifiedSamplingParams 
-	 * @param realName The real name of PV.
-	 */
-	private void convertAliasToRealWorkflow(UserSpecifiedSamplingParams userSpec, String realName) {
-		try {
-			ApplianceInfo applianceForPV = configService.getApplianceForPV(realName);
-			if(applianceForPV != null || configService.doesPVHaveArchiveRequestInWorkflow(realName)) { 
-				logger.debug("We are already archiving or about to archive the real PV " + realName + " which is the alias for " + pvName + ". Aborting this request");
-				if(applianceForPV != null) { 
-					// If we are already archiving this PV, use addAlias to add an alias to this appliance
-					String addAliasURL = null;
-					try { 
-						addAliasURL = applianceForPV.getMgmtURL() + "/addAlias?pv=" 
-								+ URLEncoder.encode(realName, "UTF-8") 
-								+ "&aliasname=" 
-								+ URLEncoder.encode(pvName, "UTF-8")
-								+ "&useThisAppliance=true";
-						GetUrlContent.getURLContentAsJSONObject(addAliasURL);
-					} catch(Throwable t) { 
-						logger.error("Exception adding alias using URL " + addAliasURL, t);
-					}
-				} else if (configService.doesPVHaveArchiveRequestInWorkflow(realName)) { 
-					// Change the UserSpecifiedSamplingParams to include this alias.
-					// We really can't tell which appliance is processing the workflow. 
-					// AddAlias uses getMgmtRuntimeState to see if the PV is in the workflow and then updates the user specified params.
-					// So we call all the appliances.
-					LinkedList<String> addAliasURLs = new LinkedList<String>();
-					for(ApplianceInfo info : configService.getAppliancesInCluster()) {
-						addAliasURLs.add(info.getMgmtURL() + "/addAlias?pv=" + URLEncoder.encode(realName, "UTF-8") + "&aliasname=" + URLEncoder.encode(pvName, "UTF-8"));
-					}
-					for(String addAliasURL : addAliasURLs) {
-						try { 
-							GetUrlContent.getURLContentAsJSONObject(addAliasURL, false);
-						} catch(Throwable t ) { 
-							logger.debug("Exception adding alias for pv" + pvName, t);
-						}
-					}
-					
-				} else { 
-					logger.error("Missed the boat adding alias " + pvName + " for real name " + realName + ". Please try again later.");
-				}
-			} else {
-				logger.debug("We are not archiving the real PV " + realName + " which is the alias for " + pvName + ". Aborting this request and asking to archive " + realName);
-				configService.addAlias(pvName, realName);
-				ByteArrayOutputStream bos = new ByteArrayOutputStream();
-				PrintWriter out = new PrintWriter(bos);
-				ArchivePVAction.archivePV(out, realName, userSpec.isUserOverrideParams(), userSpec.getUserSpecifedsamplingMethod(), userSpec.getUserSpecifedSamplingPeriod(), userSpec.getControllingPV(), userSpec.getPolicyName(), pvName, true, configService, ArchivePVAction.getFieldsAsPartOfStream(configService));
-				out.close();
-			}
-		} catch(Exception ex) { 
-			logger.error("Exception archiving alias " + realName + " in workflow for " + pvName, ex);
-		}
-	}
-	
-	/**
-	 * Add a request for a field that is not to be stored with the stream (aka .VAL).
-	 * This will convert the request to archive this field into a separate pvName.fieldName request after making the necessary checks.
-	 * @throws IOException 
-	 */
-	private void initiateWorkFlowForNonStreamField(String pvWithFieldName, UserSpecifiedSamplingParams userSpec) throws IOException {
-		logger.debug("Converting " + pvWithFieldName + " into a separate request separate from the main PV as it is not to be archived as part of the stream.");
-		if(PVNames.determineAppropriatePVTypeInfo(pvWithFieldName, configService) == null && !configService.doesPVHaveArchiveRequestInWorkflow(pvWithFieldName)) {
-			ByteArrayOutputStream bos = new ByteArrayOutputStream();
-			PrintWriter out = new PrintWriter(bos);
-			ArchivePVAction.archivePV(out, pvWithFieldName, userSpec.isUserOverrideParams(), userSpec.getUserSpecifedsamplingMethod(), userSpec.getUserSpecifedSamplingPeriod(), userSpec.getControllingPV(), userSpec.getPolicyName(), pvName, true, configService, ArchivePVAction.getFieldsAsPartOfStream(configService));
-			out.close();
-		} else {
-			logger.debug("Already have " + pvWithFieldName + " in typeinfo or in pending requests");
-		}
-	}
-	
+    public void metaInfoRequestAcknowledged() {
+        metaInfoRequestedSubmitted = TimeUtils.now();
+        this.currentState = ArchivePVStateMachine.METAINFO_GATHERING;
+    }
 
-	/**
-	 * @return The current archiving state machine state
-	 */
-	public ArchivePVStateMachine getCurrentState() {
-		return currentState;
-	}
+    public void metaInfoObtained(MetaInfo metaInfo) {
+        this.metaInfo = metaInfo;
+        this.currentState = ArchivePVStateMachine.METAINFO_OBTAINED;
+    }
 
-	public String getPvName() {
-		return pvName;
-	}
+    public void errorGettingMetaInfo() {
+        abortReason = "Error getting meta info";
+        this.currentState = ArchivePVStateMachine.ABORTED;
+    }
+
+    public void confirmedStartedArchivingPV() {
+        this.currentState = ArchivePVStateMachine.ARCHIVING;
+    }
+
+    /**
+     * If the user specified params has any aliases specified, we register the alias now.
+     * @param typeInfo
+     */
+    private void registerAliasesIfAny(PVTypeInfo typeInfo) {
+        // If we are already archiving this PV, use addAlias to add an alias to the appliance hosting the pvTypeInfo
+        String addAliasURL = null;
+        try {
+            UserSpecifiedSamplingParams userSpec = configService.getUserSpecifiedSamplingParams(typeInfo.getPvName());
+            logger.debug("Adding aliases for " + typeInfo.getPvName());
+            if (userSpec != null && userSpec.getAliases() != null && userSpec.getAliases().length > 0) {
+                logger.debug("Adding " + userSpec.getAliases().length + " aliases for " + typeInfo.getPvName());
+                for (String aliasName : userSpec.getAliases()) {
+                    addAliasURL = configService
+                                    .getAppliance(typeInfo.getApplianceIdentity())
+                                    .getMgmtURL() + "/addAlias?pv="
+                            + URLEncoder.encode(typeInfo.getPvName(), "UTF-8")
+                            + "&aliasname="
+                            + URLEncoder.encode(aliasName, "UTF-8");
+                    logger.debug("Adding an alias " + aliasName + " for pv " + typeInfo.getPvName());
+                    GetUrlContent.getURLContentAsJSONObject(addAliasURL);
+                }
+            }
+        } catch (Throwable t) {
+            logger.error("Exception adding alias using URL " + addAliasURL, t);
+        }
+    }
+
+    /**
+     * Convert a alias workflow into a workflow entry for a real PV and add the alias as a user specified param.
+     * @param userSpec UserSpecifiedSamplingParams
+     * @param realName The real name of PV.
+     */
+    private void convertAliasToRealWorkflow(UserSpecifiedSamplingParams userSpec, String realName) {
+        try {
+            ApplianceInfo applianceForPV = configService.getApplianceForPV(realName);
+            if (applianceForPV != null || configService.doesPVHaveArchiveRequestInWorkflow(realName)) {
+                logger.debug("We are already archiving or about to archive the real PV " + realName
+                        + " which is the alias for " + pvName + ". Aborting this request");
+                if (applianceForPV != null) {
+                    // If we are already archiving this PV, use addAlias to add an alias to this appliance
+                    String addAliasURL = null;
+                    try {
+                        addAliasURL = applianceForPV.getMgmtURL() + "/addAlias?pv="
+                                + URLEncoder.encode(realName, "UTF-8")
+                                + "&aliasname="
+                                + URLEncoder.encode(pvName, "UTF-8")
+                                + "&useThisAppliance=true";
+                        GetUrlContent.getURLContentAsJSONObject(addAliasURL);
+                    } catch (Throwable t) {
+                        logger.error("Exception adding alias using URL " + addAliasURL, t);
+                    }
+                } else if (configService.doesPVHaveArchiveRequestInWorkflow(realName)) {
+                    // Change the UserSpecifiedSamplingParams to include this alias.
+                    // We really can't tell which appliance is processing the workflow.
+                    // AddAlias uses getMgmtRuntimeState to see if the PV is in the workflow and then updates the user
+                    // specified params.
+                    // So we call all the appliances.
+                    LinkedList<String> addAliasURLs = new LinkedList<String>();
+                    for (ApplianceInfo info : configService.getAppliancesInCluster()) {
+                        addAliasURLs.add(info.getMgmtURL() + "/addAlias?pv=" + URLEncoder.encode(realName, "UTF-8")
+                                + "&aliasname=" + URLEncoder.encode(pvName, "UTF-8"));
+                    }
+                    for (String addAliasURL : addAliasURLs) {
+                        try {
+                            GetUrlContent.getURLContentAsJSONObject(addAliasURL, false);
+                        } catch (Throwable t) {
+                            logger.debug("Exception adding alias for pv" + pvName, t);
+                        }
+                    }
+
+                } else {
+                    logger.error("Missed the boat adding alias " + pvName + " for real name " + realName
+                            + ". Please try again later.");
+                }
+            } else {
+                logger.debug("We are not archiving the real PV " + realName + " which is the alias for " + pvName
+                        + ". Aborting this request and asking to archive " + realName);
+                configService.addAlias(pvName, realName);
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                PrintWriter out = new PrintWriter(bos);
+                ArchivePVAction.archivePV(
+                        out,
+                        realName,
+                        userSpec.isUserOverrideParams(),
+                        userSpec.getUserSpecifedsamplingMethod(),
+                        userSpec.getUserSpecifedSamplingPeriod(),
+                        userSpec.getControllingPV(),
+                        userSpec.getPolicyName(),
+                        pvName,
+                        true,
+                        configService,
+                        ArchivePVAction.getFieldsAsPartOfStream(configService));
+                out.close();
+            }
+        } catch (Exception ex) {
+            logger.error("Exception archiving alias " + realName + " in workflow for " + pvName, ex);
+        }
+    }
+
+    /**
+     * Add a request for a field that is not to be stored with the stream (aka .VAL).
+     * This will convert the request to archive this field into a separate pvName.fieldName request after making the necessary checks.
+     * @throws IOException
+     */
+    private void initiateWorkFlowForNonStreamField(String pvWithFieldName, UserSpecifiedSamplingParams userSpec)
+            throws IOException {
+        logger.debug(
+                "Converting " + pvWithFieldName
+                        + " into a separate request separate from the main PV as it is not to be archived as part of the stream.");
+        if (PVNames.determineAppropriatePVTypeInfo(pvWithFieldName, configService) == null
+                && !configService.doesPVHaveArchiveRequestInWorkflow(pvWithFieldName)) {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            PrintWriter out = new PrintWriter(bos);
+            ArchivePVAction.archivePV(
+                    out,
+                    pvWithFieldName,
+                    userSpec.isUserOverrideParams(),
+                    userSpec.getUserSpecifedsamplingMethod(),
+                    userSpec.getUserSpecifedSamplingPeriod(),
+                    userSpec.getControllingPV(),
+                    userSpec.getPolicyName(),
+                    pvName,
+                    true,
+                    configService,
+                    ArchivePVAction.getFieldsAsPartOfStream(configService));
+            out.close();
+        } else {
+            logger.debug("Already have " + pvWithFieldName + " in typeinfo or in pending requests");
+        }
+    }
+
+    /**
+     * @return The current archiving state machine state
+     */
+    public ArchivePVStateMachine getCurrentState() {
+        return currentState;
+    }
+
+    public String getPvName() {
+        return pvName;
+    }
 
     public Instant getMetaInfoRequestedSubmitted() {
-		return metaInfoRequestedSubmitted;
-	}
+        return metaInfoRequestedSubmitted;
+    }
 
-	public String getAbortReason() {
-		return abortReason;
-	}
+    public String getAbortReason() {
+        return abortReason;
+    }
 
-	public void setAbortReason(String abortReason) {
-		this.abortReason = abortReason;
-	}
-	
+    public void setAbortReason(String abortReason) {
+        this.abortReason = abortReason;
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivePVAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivePVAction.java
@@ -7,19 +7,6 @@
  *******************************************************************************/
 package org.epics.archiverappliance.mgmt.bpl;
 
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.LineNumberReader;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.BPLAction;
@@ -37,6 +24,18 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.json.simple.parser.JSONParser;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * BPL for archiving a PV.
@@ -78,421 +77,473 @@ import org.json.simple.parser.JSONParser;
  *
  */
 public class ArchivePVAction implements BPLAction {
-	public static final Logger logger = LogManager.getLogger(ArchivePVAction.class);
+    public static final Logger logger = LogManager.getLogger(ArchivePVAction.class);
 
-	@Override
-	public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException {
-		if(!configService.hasClusterFinishedInitialization()) {
-			// If you have defined spare appliances in the appliances.xml that will never come up; you should remove them
-			// This seems to be one of the few ways we can prevent split brain clusters from messing up the pv <-> appliance mapping.
-			throw new IOException("Waiting for all the appliances listed in appliances.xml to finish loading up their PVs into the cluster");
-		}
+    @Override
+    public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws IOException {
+        if (!configService.hasClusterFinishedInitialization()) {
+            // If you have defined spare appliances in the appliances.xml that will never come up; you should remove
+            // them
+            // This seems to be one of the few ways we can prevent split brain clusters from messing up the pv <->
+            // appliance mapping.
+            throw new IOException(
+                    "Waiting for all the appliances listed in appliances.xml to finish loading up their PVs into the cluster");
+        }
 
+        String contentType = req.getContentType();
+        if (contentType != null && contentType.equals(MimeTypeConstants.APPLICATION_JSON)) {
+            processJSONRequest(req, resp, configService);
+            return;
+        }
 
-		String contentType = req.getContentType();
-		if(contentType != null && contentType.equals(MimeTypeConstants.APPLICATION_JSON)) {
-			processJSONRequest(req, resp, configService);
-			return;
-		}
+        logger.info("Archiving pv(s) " + req.getParameter("pv"));
+        String[] pvs = req.getParameter("pv").split(",");
+        String samplingPeriodStr = req.getParameter("samplingperiod");
+        boolean samplingPeriodSpecified = samplingPeriodStr != null && !samplingPeriodStr.isEmpty();
+        float samplingPeriod = PolicyConfig.DEFAULT_MONITOR_SAMPLING_PERIOD;
+        if (samplingPeriodSpecified) {
+            samplingPeriod = Float.parseFloat(samplingPeriodStr);
+        }
 
-		logger.info("Archiving pv(s) " + req.getParameter("pv"));
-		String[] pvs = req.getParameter("pv").split(",");
-		String samplingPeriodStr = req.getParameter("samplingperiod");
-		boolean samplingPeriodSpecified = samplingPeriodStr != null && !samplingPeriodStr.equals("");
-		float samplingPeriod = PolicyConfig.DEFAULT_MONITOR_SAMPLING_PERIOD;
-		if(samplingPeriodSpecified) {
-			samplingPeriod = Float.parseFloat(samplingPeriodStr);
-		}
+        String samplingMethodStr = req.getParameter("samplingmethod");
+        SamplingMethod samplingMethod = SamplingMethod.MONITOR;
+        if (samplingMethodStr != null) {
+            samplingMethod = SamplingMethod.valueOf(samplingMethodStr);
+        }
 
-		String samplingMethodStr = req.getParameter("samplingmethod");
-		SamplingMethod samplingMethod = SamplingMethod.MONITOR;
-		if(samplingMethodStr != null) {
-			samplingMethod = SamplingMethod.valueOf(samplingMethodStr);
-		}
+        String controllingPV = req.getParameter("controllingPV");
+        if (controllingPV != null && !controllingPV.isEmpty()) {
+            logger.debug("We are conditionally archiving using controlling PV " + controllingPV);
+        }
 
-		String controllingPV = req.getParameter("controllingPV");
-		if(controllingPV != null && !controllingPV.equals("")) {
-			logger.debug("We are conditionally archiving using controlling PV " + controllingPV);
-		}
+        String policyName = req.getParameter("policy");
+        if (policyName != null && !policyName.isEmpty()) {
+            logger.info("We have a user override for policy " + policyName);
+        }
+        List<String> fieldsAsPartOfStream = ArchivePVAction.getFieldsAsPartOfStream(configService);
 
-		String policyName = req.getParameter("policy");
-		if(policyName != null && !policyName.equals("")) {
-			logger.info("We have a user override for policy " + policyName);
-		}
-		List<String> fieldsAsPartOfStream = ArchivePVAction.getFieldsAsPartOfStream(configService);
+        if (pvs.length < 1) {
+            return;
+        }
 
-		if(pvs.length < 1) { return; }
+        boolean skipCapacityPlanning = false;
+        String applianceId = req.getParameter("appliance");
+        if (applianceId != null) {
+            logger.debug("Appliance specified " + applianceId);
+            skipCapacityPlanning = true;
+            String myIdentity = configService.getMyApplianceInfo().getIdentity();
+            if (!applianceId.equals(myIdentity)) {
+                ApplianceInfo applInfo = configService.getAppliance(applianceId);
+                StringWriter buf = new StringWriter();
+                buf.append(applInfo.getMgmtURL());
+                buf.append("/archivePV?");
+                buf.append(req.getQueryString());
+                String redirectURL = buf.toString();
+                logger.info("Redirecting archivePV request for PV to " + applInfo.getIdentity() + " using URL "
+                        + redirectURL);
+                JSONArray status = GetUrlContent.getURLContentAsJSONArray(redirectURL);
+                resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+                try (PrintWriter out = resp.getWriter()) {
+                    out.println(JSONValue.toJSONString(status));
+                }
+                return;
+            }
+        }
 
+        resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+        try (PrintWriter out = resp.getWriter()) {
+            out.println("[");
+            boolean isFirst = true;
+            for (String pv : pvs) {
+                if (isFirst) {
+                    isFirst = false;
+                } else {
+                    out.println(",");
+                }
+                logger.debug("Calling archivePV for pv " + pv);
+                archivePV(
+                        out,
+                        pv,
+                        samplingPeriodSpecified,
+                        samplingMethod,
+                        samplingPeriod,
+                        controllingPV,
+                        policyName,
+                        null,
+                        skipCapacityPlanning,
+                        configService,
+                        fieldsAsPartOfStream);
+            }
+            out.println("]");
+        }
+    }
 
-		boolean skipCapacityPlanning = false;
-		String applianceId = req.getParameter("appliance");
-		if(applianceId != null) {
-			logger.debug("Appliance specified " + applianceId);
-			skipCapacityPlanning = true;
-			String myIdentity = configService.getMyApplianceInfo().getIdentity();
-			if(!applianceId.equals(myIdentity)) {
-				ApplianceInfo applInfo = configService.getAppliance(applianceId);
-				StringWriter buf = new StringWriter();
-				buf.append(applInfo.getMgmtURL());
-				buf.append("/archivePV?");
-				buf.append(req.getQueryString());
-				String redirectURL = buf.toString();
-				logger.info("Redirecting archivePV request for PV to " + applInfo.getIdentity() + " using URL " + redirectURL);
-				JSONArray status = GetUrlContent.getURLContentAsJSONArray(redirectURL);
-				resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
-				try(PrintWriter out = resp.getWriter()) {
-					out.println(JSONValue.toJSONString(status));
-				}
-				return;
-			}
-		}
+    /**
+     * Performance optimization - pass in fieldsArchivedAsPartOfStream as part of archivePV call.
+     * @param configService ConfigService
+     * @return All Fields as stream
+     */
+    public static List<String> getFieldsAsPartOfStream(ConfigService configService) {
+        List<String> fieldsArchivedAsPartOfStream = new LinkedList<String>();
+        try {
+            fieldsArchivedAsPartOfStream = configService.getFieldsArchivedAsPartOfStream();
+        } catch (IOException ex) {
+            logger.error("Exception fetching standard fields", ex);
+        }
+        return fieldsArchivedAsPartOfStream;
+    }
 
+    /**
+     * Does this pvName imply a connection using PVAccess?
+     * @param pvName  The name of PV.
+     * @param defaultProtocol  The defaultProtocol see org.epics.archiverappliance.mgmt.config.defaultAccessProtocol
+     *                         default is CA
+     * @return boolean True or False
+     */
+    public static boolean usePVAccess(String pvName, String defaultProtocol) {
+        PVNames.EPICSVersion version = PVNames.pvNameVersion(pvName);
+        switch (version) {
+            case DEFAULT -> {
+                return defaultProtocol.equals("PVA");
+            }
+            case V3 -> {
+                return false;
+            }
+            case V4 -> {
+                return true;
+            }
+        }
+        return false;
+    }
 
+    /**
+     * This is the main method for adding PVs into the archiver. All other entry points should eventually call this method.
+     * @param out PrintWriter
+     * @param pvName The name of PV.
+     * @param overridePolicyParams True or False
+     * @param overriddenSamplingMethod  SamplingMethod
+     * @param overRiddenSamplingPeriod  &emsp;
+     * @param controllingPV The PV used for controlling whether we archive this PV or not in conditional archiving.
+     * @param policyName  If you want to override the policy on a per PV basis.
+     * @param alias Optional, any alias that you'd like to register at the same time.
+     * @param skipCapacityPlanning  By default false. However, if you want to skip capacity planning and assign to this appliance, set this to true.
+     * @param configService ConfigService
+     * @param fieldsArchivedAsPartOfStream  &emsp;
+     * @throws IOException  &emsp;
+     */
+    public static void archivePV(
+            PrintWriter out,
+            String pvName,
+            boolean overridePolicyParams,
+            SamplingMethod overriddenSamplingMethod,
+            float overRiddenSamplingPeriod,
+            String controllingPV,
+            String policyName,
+            String alias,
+            boolean skipCapacityPlanning,
+            ConfigService configService,
+            List<String> fieldsArchivedAsPartOfStream)
+            throws IOException {
+        String fieldName = PVNames.getFieldName(pvName);
+        boolean isStandardFieldName = false;
 
+        if (fieldName != null && !fieldName.isEmpty()) {
+            if (fieldName.equals("VAL")) {
+                logger.debug("Treating .VAL as pv Name alone for " + pvName);
+                fieldName = null;
+                pvName = PVNames.stripFieldNameFromPVName(pvName);
+            } else if (fieldsArchivedAsPartOfStream.contains(fieldName)) {
+                logger.debug("Field " + fieldName + " is one of the standard fields for pv " + pvName);
+                pvName = PVNames.stripFieldNameFromPVName(pvName);
+                isStandardFieldName = true;
+            }
+        }
 
-		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
-		try (PrintWriter out = resp.getWriter()) {
-			out.println("[");
-			boolean isFirst = true;
-			for(String pv : pvs) {
-				if(isFirst) { isFirst = false; } else { out.println(","); }
-				logger.debug("Calling archivePV for pv " + pv);
-				archivePV(out, pv, samplingPeriodSpecified, samplingMethod, samplingPeriod, controllingPV, policyName, null, skipCapacityPlanning, configService, fieldsAsPartOfStream);
-			}
-			out.println("]");
-		}
-	}
+        if (!PVNames.isValidPVName(pvName)) {
+            String msg = "PV name fails syntax check " + pvName;
+            logger.error(msg);
+            throw new IOException(msg);
+        }
 
-	/**
-	 * Performance optimization - pass in fieldsArchivedAsPartOfStream as part of archivePV call.
-	 * @param configService ConfigService
-	 * @return All Fields as stream
-	 */
-	public static List<String> getFieldsAsPartOfStream(ConfigService configService) {
-		List<String> fieldsArchivedAsPartOfStream = new LinkedList<String>();
-		try {
-			fieldsArchivedAsPartOfStream = configService.getFieldsArchivedAsPartOfStream();
-		} catch(IOException ex) {
-			logger.error("Exception fetching standard fields", ex);
-		}
-		return fieldsArchivedAsPartOfStream;
-	}
+        // Check for V4 syntax, V3 syntax or default protocol; here's where we lose the prefix
+        String defaultProtocol = configService
+                .getInstallationProperties()
+                .getProperty("org.epics.archiverappliance.mgmt.bpl.ArchivePVAction.defaultAccessProtocol", "CA");
 
+        boolean usePVAccess = usePVAccess(pvName, defaultProtocol);
+        pvName = PVNames.stripPrefixFromName(pvName);
 
-	/**
-	 * Does this pvName imply a connection using PVAccess?
-	 * @param pvName  The name of PV.
-	 * @param defaultProtocol  The defaultProtocol see org.epics.archiverappliance.mgmt.config.defaultAccessProtocol
-	 *                         default is CA
-	 * @return boolean True or False
-	 */
-	public static boolean usePVAccess(String pvName, String defaultProtocol) {
-		PVNames.EPICSVersion version = PVNames.pvNameVersion(pvName);
-		switch (version) {
-			case DEFAULT -> {
-				return defaultProtocol.equals("PVA");
-			}
-			case V3 -> {
-				return false;
-			}
-			case V4 -> {
-				return true;
-			}
-		}
-		return false;
-	}
+        PVTypeInfo typeInfo = configService.getTypeInfoForPV(pvName);
+        if (typeInfo != null) {
+            logger.debug("We are already archiving this pv " + pvName + " and have a typeInfo");
+            if (fieldName != null && !fieldName.isEmpty()) {
+                if (isStandardFieldName) {
+                    logger.debug("Checking to see if field " + fieldName + " is being archived");
+                    if (typeInfo.checkIfFieldAlreadySepcified(fieldName)) {
+                        logger.debug("Field " + fieldName + " is already being archived");
+                    } else {
+                        logger.debug("Adding field " + fieldName + " to a pv that is already being archived");
+                        typeInfo.addArchiveField(fieldName);
+                        typeInfo.setModificationTime(TimeUtils.now());
+                        configService.updateTypeInfoForPV(pvName, typeInfo);
+                        // If we determine we need to kick off a pause/resume; here's where we need to do it.
+                    }
+                }
+            }
 
-	/**
-	 * This is the main method for adding PVs into the archiver. All other entry points should eventually call this method.
-	 * @param out PrintWriter
-	 * @param pvName The name of PV.
-	 * @param overridePolicyParams True or False
-	 * @param overriddenSamplingMethod  SamplingMethod
-	 * @param overRiddenSamplingPeriod  &emsp;
-	 * @param controllingPV The PV used for controlling whether we archive this PV or not in conditional archiving.
-	 * @param policyName  If you want to override the policy on a per PV basis.
-	 * @param alias Optional, any alias that you'd like to register at the same time.
-	 * @param skipCapacityPlanning  By default false. However, if you want to skip capacity planning and assign to this appliance, set this to true.
-	 * @param configService ConfigService
-	 * @param fieldsArchivedAsPartOfStream  &emsp;
-	 * @throws IOException  &emsp;
-	 */
-	public static void archivePV(PrintWriter out, String pvName, boolean overridePolicyParams,
-	                             SamplingMethod overriddenSamplingMethod, float overRiddenSamplingPeriod,
-	                             String controllingPV, String policyName, String alias, boolean skipCapacityPlanning,
-	                             ConfigService configService, List<String> fieldsArchivedAsPartOfStream)
-			throws IOException {
-		String fieldName = PVNames.getFieldName(pvName);
-		boolean isStandardFieldName = false;
+            if (alias != null) {
+                configService.addAlias(alias, pvName);
+            }
 
+            out.println("{ \"pvName\": \"" + pvName + "\", \"status\": \"Already submitted\" }");
+            return;
+        }
 
-		if(fieldName != null && !fieldName.equals("")) {
-			if (fieldName.equals("VAL")) {
-				logger.debug("Treating .VAL as pv Name alone for " + pvName);
-				fieldName = null;
-				pvName = PVNames.stripFieldNameFromPVName(pvName);
-			} else if(fieldsArchivedAsPartOfStream.contains(fieldName)) {
-				logger.debug("Field " + fieldName + " is one of the standard fields for pv " + pvName);
-				pvName = PVNames.stripFieldNameFromPVName(pvName);
-				isStandardFieldName = true;
-			}
-		}
+        boolean requestAlreadyMade = configService.doesPVHaveArchiveRequestInWorkflow(pvName);
+        if (requestAlreadyMade) {
+            UserSpecifiedSamplingParams userParams = configService.getUserSpecifiedSamplingParams(pvName);
+            if (fieldName != null && !fieldName.isEmpty()) {
+                if (isStandardFieldName) {
+                    if (userParams != null && !userParams.checkIfFieldAlreadySepcified(fieldName)) {
+                        logger.debug("Adding field " + fieldName
+                                + " to an existing request. Note we are not updating persistence here.");
+                        userParams.addArchiveField(fieldName);
+                    }
+                }
+            }
 
+            if (alias != null) {
+                logger.debug("Adding alias " + alias + " to user params of " + pvName + "(1)");
+                userParams.addAlias(alias);
+            }
 
-		if(!PVNames.isValidPVName(pvName)) {
-			String msg = "PV name fails syntax check " + pvName;
-			logger.error(msg);
-			throw new IOException(msg);
-		}
+            logger.warn("We have a pending request for pv " + pvName);
+            out.println("{ \"pvName\": \"" + pvName + "\", \"status\": \"Already submitted\" }");
+            return;
+        }
 
-		// Check for V4 syntax, V3 syntax or default protocol; here's where we lose the prefix
-		String defaultProtocol = configService.getInstallationProperties()
-				.getProperty("org.epics.archiverappliance.mgmt.bpl.ArchivePVAction.defaultAccessProtocol", "CA");
+        try {
+            String actualPVName = pvName;
 
-		boolean usePVAccess = usePVAccess(pvName, defaultProtocol);
-		pvName = PVNames.stripPrefixFromName(pvName);
+            if (overridePolicyParams) {
+                String minumumSamplingPeriodStr = configService
+                        .getInstallationProperties()
+                        .getProperty(
+                                "org.epics.archiverappliance.mgmt.bpl.ArchivePVAction.minimumSamplingPeriod", "0.1");
+                float minumumSamplingPeriod = Float.parseFloat(minumumSamplingPeriodStr);
+                if (overRiddenSamplingPeriod < minumumSamplingPeriod) {
+                    logger.warn(
+                            "Enforcing the minumum sampling period of " + minumumSamplingPeriod + " for pv " + pvName);
+                    overRiddenSamplingPeriod = minumumSamplingPeriod;
+                }
+                logger.debug("Overriding policy params with sampling method " + overriddenSamplingMethod
+                        + " and sampling period " + overRiddenSamplingPeriod);
+                UserSpecifiedSamplingParams userSpecifiedSamplingParams = new UserSpecifiedSamplingParams(
+                        overridePolicyParams ? overriddenSamplingMethod : SamplingMethod.MONITOR,
+                        overRiddenSamplingPeriod,
+                        controllingPV,
+                        policyName,
+                        skipCapacityPlanning,
+                        usePVAccess);
+                if (fieldName != null && !fieldName.isEmpty() && isStandardFieldName) {
+                    userSpecifiedSamplingParams.addArchiveField(fieldName);
+                }
+                if (usePVAccess) {
+                    userSpecifiedSamplingParams.setUsePVAccess(usePVAccess);
+                }
 
-		PVTypeInfo typeInfo = configService.getTypeInfoForPV(pvName);
-		if(typeInfo != null) {
-			logger.debug("We are already archiving this pv " + pvName + " and have a typeInfo");
-			if(fieldName != null && !fieldName.equals("")) {
-				if(isStandardFieldName) {
-					logger.debug("Checking to see if field " + fieldName + " is being archived");
-					if(typeInfo.checkIfFieldAlreadySepcified(fieldName)) {
-						logger.debug("Field " + fieldName + " is already being archived");
-					} else {
-						logger.debug("Adding field " + fieldName + " to a pv that is already being archived");
-						typeInfo.addArchiveField(fieldName);
-						typeInfo.setModificationTime(TimeUtils.now());
-						configService.updateTypeInfoForPV(pvName, typeInfo);
-						// If we determine we need to kick off a pause/resume; here's where we need to do it.
-					}
-				}
-			}
+                if (alias != null) {
+                    logger.debug("Adding alias " + alias + " to user params of " + actualPVName + "(2)");
+                    userSpecifiedSamplingParams.addAlias(alias);
+                }
 
-			if(alias != null) {
-				configService.addAlias(alias, pvName);
-			}
+                configService.addToArchiveRequests(actualPVName, userSpecifiedSamplingParams);
+            } else {
+                UserSpecifiedSamplingParams userSpecifiedSamplingParams = new UserSpecifiedSamplingParams();
+                if (fieldName != null && !fieldName.isEmpty() && isStandardFieldName) {
+                    userSpecifiedSamplingParams.addArchiveField(fieldName);
+                }
+                if (usePVAccess) {
+                    userSpecifiedSamplingParams.setUsePVAccess(usePVAccess);
+                }
+                if (skipCapacityPlanning) {
+                    userSpecifiedSamplingParams.setSkipCapacityPlanning(skipCapacityPlanning);
+                }
 
+                if (alias != null) {
+                    logger.debug("Adding alias " + alias + " to user params of " + actualPVName + "(3)");
+                    userSpecifiedSamplingParams.addAlias(alias);
+                }
 
-			out.println("{ \"pvName\": \"" + pvName + "\", \"status\": \"Already submitted\" }");
-			return;
-		}
+                if (policyName != null) {
+                    logger.debug("Overriding the policy to " + policyName + " for pv " + pvName
+                            + " for a default period/method");
+                    userSpecifiedSamplingParams.setPolicyName(policyName);
+                }
 
-		boolean requestAlreadyMade = configService.doesPVHaveArchiveRequestInWorkflow(pvName);
-		if(requestAlreadyMade) {
-			UserSpecifiedSamplingParams userParams = configService.getUserSpecifiedSamplingParams(pvName);
-			if(fieldName != null && !fieldName.equals("")) {
-				if(isStandardFieldName) {
-					if(userParams != null && !userParams.checkIfFieldAlreadySepcified(fieldName)) {
-						logger.debug("Adding field " + fieldName + " to an existing request. Note we are not updating persistence here.");
-						userParams.addArchiveField(fieldName);
-					}
-				}
-			}
+                configService.addToArchiveRequests(actualPVName, userSpecifiedSamplingParams);
+            }
+            // Submit the request to the archive engine.
+            // We have to make this a call into the engine to get over that fact that only the engine can load JCA
+            // libraries
+            configService.getMgmtRuntimeState().startPVWorkflow(pvName);
+            out.println("{ \"pvName\": \"" + pvName + "\", \"status\": \"Archive request submitted\" }");
+        } catch (Exception ex) {
+            logger.error("Exception archiving PV " + pvName, ex);
+            out.println("{ \"pvName\": \"" + pvName + "\", \"status\": \"Exception occured\" }");
+        }
+    }
 
-			if(alias != null) {
-				logger.debug("Adding alias " + alias + " to user params of " + pvName + "(1)");
-				userParams.addAlias(alias);
-			}
+    private void processJSONRequest(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws IOException {
+        logger.debug("Archiving multiple PVs from a JSON POST request");
+        List<String> fieldsAsPartOfStream = ArchivePVAction.getFieldsAsPartOfStream(configService);
+        try (LineNumberReader lineReader =
+                new LineNumberReader(new InputStreamReader(new BufferedInputStream(req.getInputStream())))) {
+            JSONParser parser = new JSONParser();
+            JSONArray pvArchiveParams = (JSONArray) parser.parse(lineReader);
+            logger.debug("PV count " + pvArchiveParams.size());
 
+            String myIdentity = configService.getMyApplianceInfo().getIdentity();
+            if (!allRequestsCanBeSampledOnThisAppliance(pvArchiveParams, myIdentity)) {
+                logger.debug("Breaking down the requests into appliance calls.");
+                breakDownPVRequestsByAssignedAppliance(pvArchiveParams, myIdentity, configService, resp);
+                return;
+            }
 
-			logger.warn("We have a pending request for pv " + pvName);
-			out.println("{ \"pvName\": \"" + pvName + "\", \"status\": \"Already submitted\" }");
-			return;
-		}
+            logger.debug("All calls can be sampled on this appliance.");
 
-		try {
-			String actualPVName = pvName;
+            resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+            try (PrintWriter out = resp.getWriter()) {
+                out.println("[");
 
-			if(overridePolicyParams) {
-				String minumumSamplingPeriodStr = configService.getInstallationProperties().getProperty("org.epics.archiverappliance.mgmt.bpl.ArchivePVAction.minimumSamplingPeriod", "0.1");
-				float minumumSamplingPeriod = Float.parseFloat(minumumSamplingPeriodStr);
-				if(overRiddenSamplingPeriod < minumumSamplingPeriod) {
-					logger.warn("Enforcing the minumum sampling period of " + minumumSamplingPeriod + " for pv " + pvName);
-					overRiddenSamplingPeriod = minumumSamplingPeriod;
-				}
-				logger.debug("Overriding policy params with sampling method " + overriddenSamplingMethod + " and sampling period " + overRiddenSamplingPeriod);
-				UserSpecifiedSamplingParams userSpecifiedSamplingParams = new UserSpecifiedSamplingParams(overridePolicyParams ? overriddenSamplingMethod : SamplingMethod.MONITOR, overRiddenSamplingPeriod, controllingPV, policyName, skipCapacityPlanning, usePVAccess);
-				if(fieldName != null && !fieldName.equals("") && isStandardFieldName) {
-					userSpecifiedSamplingParams.addArchiveField(fieldName);
-				}
-				if(usePVAccess) {
-					userSpecifiedSamplingParams.setUsePVAccess(usePVAccess);
-				}
+                boolean isFirst = true;
+                for (Object pvArchiveParamObj : pvArchiveParams) {
+                    logger.debug("Processing...");
+                    JSONObject pvArchiveParam = (JSONObject) pvArchiveParamObj;
+                    logger.debug("Processing...");
+                    if (isFirst) {
+                        isFirst = false;
+                    } else {
+                        out.println(",");
+                    }
+                    logger.debug("Processing...");
+                    String pvName = (String) pvArchiveParam.get("pv");
+                    logger.debug("Calling archivePV for pv " + pvName);
+                    // By the time we get here, if the appliance is set in the request, we skip capacityPlanning.
+                    boolean skipCapacityPlanning = pvArchiveParam.containsKey("appliance");
+                    if (skipCapacityPlanning) {
+                        logger.debug("Skipping capacity planning for PV " + pvName);
+                    }
+                    SamplingMethod samplingMethod = SamplingMethod.MONITOR;
+                    float samplingPeriod = PolicyConfig.DEFAULT_MONITOR_SAMPLING_PERIOD;
+                    try {
+                        samplingMethod = pvArchiveParam.containsKey("samplingmethod")
+                                ? SamplingMethod.valueOf(((String) pvArchiveParam.get("samplingmethod")).toUpperCase())
+                                : SamplingMethod.MONITOR;
+                        samplingPeriod = pvArchiveParam.containsKey("samplingperiod")
+                                ? Float.parseFloat((String) pvArchiveParam.get("samplingperiod"))
+                                : PolicyConfig.DEFAULT_MONITOR_SAMPLING_PERIOD;
+                    } catch (Exception ex) {
+                        logger.error(
+                                "Cannot parse sampling period and method " + JSONValue.toJSONString(pvArchiveParam));
+                        continue;
+                    }
 
-				if(alias != null) {
-					logger.debug("Adding alias " + alias + " to user params of " + actualPVName + "(2)");
-					userSpecifiedSamplingParams.addAlias(alias);
-				}
+                    ArchivePVAction.archivePV(
+                            out,
+                            pvName,
+                            pvArchiveParam.containsKey("samplingperiod"),
+                            samplingMethod,
+                            samplingPeriod,
+                            (String) pvArchiveParam.get("controllingPV"),
+                            (String) pvArchiveParam.get("policy"),
+                            (String) pvArchiveParam.get("alias"),
+                            skipCapacityPlanning,
+                            configService,
+                            fieldsAsPartOfStream);
+                }
 
-				configService.addToArchiveRequests(actualPVName, userSpecifiedSamplingParams);
-			} else {
-				UserSpecifiedSamplingParams userSpecifiedSamplingParams = new UserSpecifiedSamplingParams();
-				if(fieldName != null && !fieldName.equals("") && isStandardFieldName) {
-					userSpecifiedSamplingParams.addArchiveField(fieldName);
-				}
-				if(usePVAccess) {
-					userSpecifiedSamplingParams.setUsePVAccess(usePVAccess);
-				}
-				if(skipCapacityPlanning) {
-					userSpecifiedSamplingParams.setSkipCapacityPlanning(skipCapacityPlanning);
-				}
+                out.println("]");
+                out.flush();
+            }
+        } catch (Exception ex) {
+            logger.error("Exception processing archiveJSON", ex);
+            throw new IOException(ex);
+        }
+        return;
+    }
 
-				if(alias != null) {
-					logger.debug("Adding alias " + alias + " to user params of " + actualPVName + "(3)");
-					userSpecifiedSamplingParams.addAlias(alias);
-				}
+    /**
+     * Given a JSON array of archive requests, can we process all these requests on this appliance.
+     * We can do this if the applianceID is not specified or if the applianceID is this appliance for all requests.
+     * @param pvArchiveParams JSONArray
+     * @param myIdentity  &emsp;
+     * @return boolean True or False
+     */
+    private boolean allRequestsCanBeSampledOnThisAppliance(JSONArray pvArchiveParams, String myIdentity) {
+        for (Object pvArchiveParamObj : pvArchiveParams) {
+            JSONObject pvArchiveParam = (JSONObject) pvArchiveParamObj;
+            if (pvArchiveParam.containsKey("appliance")
+                    && !pvArchiveParam.get("appliance").equals(myIdentity)) {
+                logger.debug(
+                        "Not all PVs can be sampled on this appliance. We need to break up the request based on appliance");
+                return false;
+            }
+        }
+        logger.debug("All PVs can be sampled on this appliance");
+        return true;
+    }
 
-				if(policyName != null) {
-					logger.debug("Overriding the policy to " + policyName + " for pv " + pvName + " for a default period/method");
-					userSpecifiedSamplingParams.setPolicyName(policyName);
-				}
+    /**
+     * Break down a JSON request for archiving into parts based on appliance and then make the calls to the individual appliances.
+     * All archive requests that do not have an appliance specified will be sampled on this appliance and go thru capacity planning.
+     * @param pvArchiveParams JSONArray
+     * @param myIdentity emsp
+     * @param configService ConfigServic
+     */
+    @SuppressWarnings("unchecked")
+    private void breakDownPVRequestsByAssignedAppliance(
+            JSONArray pvArchiveParams, String myIdentity, ConfigService configService, HttpServletResponse resp)
+            throws IOException {
+        HashMap<String, LinkedList<JSONObject>> archiveRequestsByAppliance =
+                new HashMap<String, LinkedList<JSONObject>>();
+        archiveRequestsByAppliance.put(myIdentity, new LinkedList<JSONObject>());
+        for (Object pvArchiveParamObj : pvArchiveParams) {
+            JSONObject pvArchiveParam = (JSONObject) pvArchiveParamObj;
+            if (pvArchiveParam.containsKey("appliance")) {
+                String assignedAppliance = (String) pvArchiveParam.get("appliance");
+                if (configService.getAppliance(assignedAppliance) == null) {
+                    throw new IOException("Cannot find appliance info for " + assignedAppliance + " for pv "
+                            + pvArchiveParam.get("pv"));
+                }
+                if (!archiveRequestsByAppliance.containsKey(assignedAppliance)) {
+                    archiveRequestsByAppliance.put(assignedAppliance, new LinkedList<JSONObject>());
+                }
+                logger.debug("PV " + pvArchiveParam.get("pv") + " should be sampled on appliance " + assignedAppliance);
+                archiveRequestsByAppliance.get(assignedAppliance).add(pvArchiveParam);
+            } else {
+                logger.debug("PV " + pvArchiveParam.get("pv") + " should be sampled here " + myIdentity);
+                archiveRequestsByAppliance.get(myIdentity).add(pvArchiveParam);
+            }
+        }
 
-				configService.addToArchiveRequests(actualPVName, userSpecifiedSamplingParams);
-			}
-			// Submit the request to the archive engine.
-			// We have to make this a call into the engine to get over that fact that only the engine can load JCA libraries
-			configService.getMgmtRuntimeState().startPVWorkflow(pvName);
-			out.println("{ \"pvName\": \"" + pvName + "\", \"status\": \"Archive request submitted\" }");
-		} catch(Exception ex) {
-			logger.error("Exception archiving PV " + pvName, ex);
-			out.println("{ \"pvName\": \"" + pvName + "\", \"status\": \"Exception occured\" }");
-		}
-	}
-
-
-	private void processJSONRequest(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException {
-		logger.debug("Archiving multiple PVs from a JSON POST request");
-		List<String> fieldsAsPartOfStream = ArchivePVAction.getFieldsAsPartOfStream(configService);
-		try (LineNumberReader lineReader = new LineNumberReader(new InputStreamReader(new BufferedInputStream(req.getInputStream())))) {
-			JSONParser parser=new JSONParser();
-			JSONArray pvArchiveParams = (JSONArray) parser.parse(lineReader);
-			logger.debug("PV count " + pvArchiveParams.size());
-
-			String myIdentity = configService.getMyApplianceInfo().getIdentity();
-			if(!allRequestsCanBeSampledOnThisAppliance(pvArchiveParams, myIdentity)) {
-				logger.debug("Breaking down the requests into appliance calls.");
-				breakDownPVRequestsByAssignedAppliance(pvArchiveParams, myIdentity, configService, resp);
-				return;
-			}
-
-			logger.debug("All calls can be sampled on this appliance.");
-
-			resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
-			try(PrintWriter out = resp.getWriter()) {
-				out.println("[");
-
-				boolean isFirst = true;
-				for(Object pvArchiveParamObj : pvArchiveParams) {
-					logger.debug("Processing...");
-					JSONObject pvArchiveParam = (JSONObject) pvArchiveParamObj;
-					logger.debug("Processing...");
-					if(isFirst) { isFirst = false; } else { out.println(","); }
-					logger.debug("Processing...");
-					String pvName = (String) pvArchiveParam.get("pv");
-					logger.debug("Calling archivePV for pv " + pvName);
-					// By the time we get here, if the appliance is set in the request, we skip capacityPlanning.
-					boolean skipCapacityPlanning = pvArchiveParam.containsKey("appliance");
-					if(skipCapacityPlanning) {
-						logger.debug("Skipping capacity planning for PV " + pvName);
-					}
-					SamplingMethod samplingMethod = SamplingMethod.MONITOR;
-					float samplingPeriod = PolicyConfig.DEFAULT_MONITOR_SAMPLING_PERIOD;
-					try {
-						samplingMethod = pvArchiveParam.containsKey("samplingmethod") ? SamplingMethod.valueOf(((String) pvArchiveParam.get("samplingmethod")).toUpperCase()) : SamplingMethod.MONITOR;
-						samplingPeriod = pvArchiveParam.containsKey("samplingperiod") ? Float.parseFloat((String)pvArchiveParam.get("samplingperiod")) : PolicyConfig.DEFAULT_MONITOR_SAMPLING_PERIOD;
-					} catch(Exception ex) {
-						logger.error("Cannot parse sampling period and method " + JSONValue.toJSONString(pvArchiveParam));
-						continue;						
-					}
-
-					ArchivePVAction.archivePV(out,
-							pvName,
-							pvArchiveParam.containsKey("samplingperiod"),
-							samplingMethod,
-							samplingPeriod,
-											(String) pvArchiveParam.get("controllingPV"),
-											(String) pvArchiveParam.get("policy"),
-											(String) pvArchiveParam.get("alias"),
-											skipCapacityPlanning,
-											configService,
-											fieldsAsPartOfStream);
-				}
-
-				out.println("]");
-				out.flush();
-			}
-		} catch(Exception ex) {
-			logger.error("Exception processing archiveJSON", ex);
-			throw new IOException(ex);
-		}
-		return;
-	}
-
-	/**
-	 * Given a JSON array of archive requests, can we process all these requests on this appliance.
-	 * We can do this if the applianceID is not specified or if the applianceID is this appliance for all requests.
-	 * @param pvArchiveParams JSONArray
-	 * @param myIdentity  &emsp;
-	 * @return boolean True or False
-	 */
-	private boolean allRequestsCanBeSampledOnThisAppliance(JSONArray pvArchiveParams, String myIdentity) {
-		for(Object pvArchiveParamObj : pvArchiveParams) {
-			JSONObject pvArchiveParam = (JSONObject) pvArchiveParamObj;
-			if(pvArchiveParam.containsKey("appliance") && !pvArchiveParam.get("appliance").equals(myIdentity)) {
-				logger.debug("Not all PVs can be sampled on this appliance. We need to break up the request based on appliance");
-				return false;
-			}
-		}
-		logger.debug("All PVs can be sampled on this appliance");
-		return true;
-	}
-
-	/**
-	 * Break down a JSON request for archiving into parts based on appliance and then make the calls to the individual appliances.
-	 * All archive requests that do not have an appliance specified will be sampled on this appliance and go thru capacity planning.
-	 * @param pvArchiveParams JSONArray
-	 * @param myIdentity emsp
-	 * @param configService ConfigServic
-	 */
-	@SuppressWarnings("unchecked")
-	private void breakDownPVRequestsByAssignedAppliance(JSONArray pvArchiveParams, String myIdentity, ConfigService configService, HttpServletResponse resp) throws IOException {
-		HashMap<String, LinkedList<JSONObject>> archiveRequestsByAppliance = new HashMap<String, LinkedList<JSONObject>>();
-		archiveRequestsByAppliance.put(myIdentity, new LinkedList<JSONObject>());
-		for(Object pvArchiveParamObj : pvArchiveParams) {
-			JSONObject pvArchiveParam = (JSONObject) pvArchiveParamObj;
-			if(pvArchiveParam.containsKey("appliance")) {
-				String assignedAppliance = (String) pvArchiveParam.get("appliance");
-				if(configService.getAppliance(assignedAppliance) == null) {
-					throw new IOException("Cannot find appliance info for " + assignedAppliance + " for pv " + pvArchiveParam.get("pv"));
-				}
-				if(!archiveRequestsByAppliance.containsKey(assignedAppliance)) {
-					archiveRequestsByAppliance.put(assignedAppliance, new LinkedList<JSONObject>());
-				}
-				logger.debug("PV " + pvArchiveParam.get("pv") + " should be sampled on appliance " + assignedAppliance);
-				archiveRequestsByAppliance.get(assignedAppliance).add(pvArchiveParam);
-			} else {
-				logger.debug("PV " + pvArchiveParam.get("pv") + " should be sampled here " + myIdentity);
-				archiveRequestsByAppliance.get(myIdentity).add(pvArchiveParam);
-			}
-		}
-
-		// Now we have the requests broken down by appliance.
-		// Route them appropriately and combine the results...
-		JSONArray finalResult = new JSONArray();
-		for(String appliance : archiveRequestsByAppliance.keySet()) {
-			LinkedList<JSONObject> requestsForAppliance = archiveRequestsByAppliance.get(appliance);
-			if(!requestsForAppliance.isEmpty()) {
-				String archiveURL = configService.getAppliance(appliance).getMgmtURL() + "/archivePV";
-				JSONArray archiveResponse = GetUrlContent.postDataAndGetContentAsJSONArray(archiveURL, requestsForAppliance);
-				finalResult.addAll(archiveResponse);
-			}
-		}
-		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
-		try(PrintWriter out = resp.getWriter()) {
-			out.println(JSONValue.toJSONString(finalResult));
-		}
-	}
-
+        // Now we have the requests broken down by appliance.
+        // Route them appropriately and combine the results...
+        JSONArray finalResult = new JSONArray();
+        for (String appliance : archiveRequestsByAppliance.keySet()) {
+            LinkedList<JSONObject> requestsForAppliance = archiveRequestsByAppliance.get(appliance);
+            if (!requestsForAppliance.isEmpty()) {
+                String archiveURL = configService.getAppliance(appliance).getMgmtURL() + "/archivePV";
+                JSONArray archiveResponse =
+                        GetUrlContent.postDataAndGetContentAsJSONArray(archiveURL, requestsForAppliance);
+                finalResult.addAll(archiveResponse);
+            }
+        }
+        resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+        try (PrintWriter out = resp.getWriter()) {
+            out.println(JSONValue.toJSONString(finalResult));
+        }
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivePVAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivePVAction.java
@@ -252,15 +252,15 @@ public class ArchivePVAction implements BPLAction {
             if (fieldName.equals("VAL")) {
                 logger.debug("Treating .VAL as pv Name alone for " + pvName);
                 fieldName = null;
-                pvName = PVNames.stripFieldNameFromPVName(pvName);
+                pvName = PVNames.channelNamePVName(pvName);
             } else if (fieldsArchivedAsPartOfStream.contains(fieldName)) {
                 logger.debug("Field " + fieldName + " is one of the standard fields for pv " + pvName);
-                pvName = PVNames.stripFieldNameFromPVName(pvName);
+                pvName = PVNames.channelNamePVName(pvName);
                 isStandardFieldName = true;
             }
         }
 
-        if (!PVNames.isValidPVName(pvName)) {
+        if (!PVNames.isValidChannelName(pvName)) {
             String msg = "PV name fails syntax check " + pvName;
             logger.error(msg);
             throw new IOException(msg);

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivedPVsAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivedPVsAction.java
@@ -42,7 +42,7 @@ public class ArchivedPVsAction implements BPLAction {
     public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
             throws IOException {
         logger.info("Determining PVs that are archived ");
-        LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
+        LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req);
         LinkedList<String> archivedPVs = new LinkedList<String>();
         for (String pvName : pvNames) {
             PVTypeInfo typeInfo = null;

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivedPVsAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivedPVsAction.java
@@ -7,14 +7,6 @@
  *******************************************************************************/
 package org.epics.archiverappliance.mgmt.bpl;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.Arrays;
-import java.util.LinkedList;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.BPLAction;
@@ -24,66 +16,73 @@ import org.epics.archiverappliance.config.PVTypeInfo;
 import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
 import org.json.simple.JSONValue;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.LinkedList;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * Given a list of PVs, determine those that are being archived.
  * Of course, you can use the status call but that makes calls to the engine etc and can be stressful if you are checking several thousand PVs
  * All this does is check the configservice...
- * 
+ *
  * @epics.BPLAction - Given a list of PVs, determine those that are being archived.
  * @epics.BPLActionParam pv - A list of pv names. Send as a CSV using a POST.
  * @epics.BPLActionEnd
- * 
+ *
  * @author mshankar
  *
  */
 public class ArchivedPVsAction implements BPLAction {
-	private static final Logger logger = LogManager.getLogger(ArchivedPVsAction.class);
+    private static final Logger logger = LogManager.getLogger(ArchivedPVsAction.class);
 
-	@Override
-	public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException {
-		logger.info("Determining PVs that are archived ");
-		LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
-		LinkedList<String> archivedPVs = new LinkedList<String>();
-		for(String pvName : pvNames) {
-			PVTypeInfo typeInfo = null;
-			logger.debug("Check for the name as it came in from the user " + pvName);
-			typeInfo = configService.getTypeInfoForPV(pvName);
-			if(typeInfo != null)  {
-				archivedPVs.add(pvName);
-				continue;
-			}
-			logger.debug("Check for the normalized name");
-			typeInfo = configService.getTypeInfoForPV(PVNames.normalizePVName(pvName));
-			if(typeInfo != null) {
-				archivedPVs.add(pvName);
-				continue;
-			}
-			logger.debug("Check for aliases");
-			String aliasRealName = configService.getRealNameForAlias(PVNames.normalizePVName(pvName));
-			if(aliasRealName != null) { 
-				typeInfo = configService.getTypeInfoForPV(aliasRealName);
-				if(typeInfo != null) {
-					archivedPVs.add(pvName);
-					continue;
-				}
-			}
-			logger.debug("Check for fields");
-			String fieldName = PVNames.getFieldName(pvName);
-			if(fieldName != null) { 
-				typeInfo = configService.getTypeInfoForPV(PVNames.stripFieldNameFromPVName(pvName));
-				if(typeInfo != null) { 
-					if(Arrays.asList(typeInfo.getArchiveFields()).contains(fieldName)) {
-						archivedPVs.add(pvName);
-						continue;
-					}
-				}
-			}
-		}
-		
-		
-		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
-		try (PrintWriter out = resp.getWriter()) {
-			JSONValue.writeJSONString(archivedPVs, out);
-		}
-	}
+    @Override
+    public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws IOException {
+        logger.info("Determining PVs that are archived ");
+        LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
+        LinkedList<String> archivedPVs = new LinkedList<String>();
+        for (String pvName : pvNames) {
+            PVTypeInfo typeInfo = null;
+            logger.debug("Check for the name as it came in from the user " + pvName);
+            typeInfo = configService.getTypeInfoForPV(pvName);
+            if (typeInfo != null) {
+                archivedPVs.add(pvName);
+                continue;
+            }
+            logger.debug("Check for the normalized name");
+            typeInfo = configService.getTypeInfoForPV(PVNames.normalizePVName(pvName));
+            if (typeInfo != null) {
+                archivedPVs.add(pvName);
+                continue;
+            }
+            logger.debug("Check for aliases");
+            String aliasRealName = configService.getRealNameForAlias(PVNames.normalizePVName(pvName));
+            if (aliasRealName != null) {
+                typeInfo = configService.getTypeInfoForPV(aliasRealName);
+                if (typeInfo != null) {
+                    archivedPVs.add(pvName);
+                    continue;
+                }
+            }
+            logger.debug("Check for fields");
+            String fieldName = PVNames.getFieldName(pvName);
+            if (fieldName != null) {
+                typeInfo = configService.getTypeInfoForPV(PVNames.stripFieldNameFromPVName(pvName));
+                if (typeInfo != null) {
+                    if (Arrays.asList(typeInfo.getArchiveFields()).contains(fieldName)) {
+                        archivedPVs.add(pvName);
+                        continue;
+                    }
+                }
+            }
+        }
+
+        resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+        try (PrintWriter out = resp.getWriter()) {
+            JSONValue.writeJSONString(archivedPVs, out);
+        }
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivedPVsAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivedPVsAction.java
@@ -53,13 +53,13 @@ public class ArchivedPVsAction implements BPLAction {
                 continue;
             }
             logger.debug("Check for the normalized name");
-            typeInfo = configService.getTypeInfoForPV(PVNames.normalizePVName(pvName));
+            typeInfo = configService.getTypeInfoForPV(PVNames.normalizeChannelName(pvName));
             if (typeInfo != null) {
                 archivedPVs.add(pvName);
                 continue;
             }
             logger.debug("Check for aliases");
-            String aliasRealName = configService.getRealNameForAlias(PVNames.normalizePVName(pvName));
+            String aliasRealName = configService.getRealNameForAlias(PVNames.normalizeChannelName(pvName));
             if (aliasRealName != null) {
                 typeInfo = configService.getTypeInfoForPV(aliasRealName);
                 if (typeInfo != null) {
@@ -70,7 +70,7 @@ public class ArchivedPVsAction implements BPLAction {
             logger.debug("Check for fields");
             String fieldName = PVNames.getFieldName(pvName);
             if (fieldName != null) {
-                typeInfo = configService.getTypeInfoForPV(PVNames.stripFieldNameFromPVName(pvName));
+                typeInfo = configService.getTypeInfoForPV(PVNames.channelNamePVName(pvName));
                 if (typeInfo != null) {
                     if (Arrays.asList(typeInfo.getArchiveFields()).contains(fieldName)) {
                         archivedPVs.add(pvName);

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivedPVsForThisApplianceAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivedPVsForThisApplianceAction.java
@@ -7,13 +7,6 @@
  *******************************************************************************/
 package org.epics.archiverappliance.mgmt.bpl;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.LinkedList;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.BPLAction;
@@ -21,33 +14,38 @@ import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
 import org.json.simple.JSONValue;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.LinkedList;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * Given a list of PVs, determine those that are being archived.
  * Of course, you can use the status call but that makes calls to the engine etc and can be stressful if you are checking several thousand PVs
  * All this does is check the configservice...
- * 
+ *
  * @author mshankar
  *
  */
 public class ArchivedPVsForThisApplianceAction implements BPLAction {
-	private static final Logger logger = LogManager.getLogger(ArchivedPVsForThisApplianceAction.class);
+    private static final Logger logger = LogManager.getLogger(ArchivedPVsForThisApplianceAction.class);
 
-	@Override
-	public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException {
-		logger.info("Determining PVs that are archived in this appliance");
-		LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
-		LinkedList<String> archivedPVs = new LinkedList<String>();
-		for(String pvName : pvNames) {
-			if(configService.isBeingArchivedOnThisAppliance(pvName)) { 
-				archivedPVs.add(pvName);
-			}
-			
-		}
-		
-		
-		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
-		try (PrintWriter out = resp.getWriter()) {
-			JSONValue.writeJSONString(archivedPVs, out);
-		}
-	}
+    @Override
+    public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws IOException {
+        logger.info("Determining PVs that are archived in this appliance");
+        LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
+        LinkedList<String> archivedPVs = new LinkedList<String>();
+        for (String pvName : pvNames) {
+            if (configService.isBeingArchivedOnThisAppliance(pvName)) {
+                archivedPVs.add(pvName);
+            }
+        }
+
+        resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+        try (PrintWriter out = resp.getWriter()) {
+            JSONValue.writeJSONString(archivedPVs, out);
+        }
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivedPVsForThisApplianceAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivedPVsForThisApplianceAction.java
@@ -35,7 +35,7 @@ public class ArchivedPVsForThisApplianceAction implements BPLAction {
     public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
             throws IOException {
         logger.info("Determining PVs that are archived in this appliance");
-        LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
+        LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req);
         LinkedList<String> archivedPVs = new LinkedList<String>();
         for (String pvName : pvNames) {
             if (configService.isBeingArchivedOnThisAppliance(pvName)) {

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivedPVsNotInListAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivedPVsNotInListAction.java
@@ -7,13 +7,6 @@
  *******************************************************************************/
 package org.epics.archiverappliance.mgmt.bpl;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.LinkedList;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.BPLAction;
@@ -21,40 +14,48 @@ import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
 import org.json.simple.JSONValue;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.LinkedList;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * Given a list of PVs, determine those that are being archived but are not in the incoming list.
- * Useful if you generate a list of PV's to be archived from the IOC configuration somehow and need to make sure that PV's being archived are only those in this list. 
- * 
+ * Useful if you generate a list of PV's to be archived from the IOC configuration somehow and need to make sure that PV's being archived are only those in this list.
+ *
  * @epics.BPLAction - Given a list of PVs, determine those that are being archived but are not in the incoming list.
  * @epics.BPLActionParam pv - A list of pv names. Send as a CSV using a POST, or as a JSON.
  * @epics.BPLActionEnd
- * 
+ *
  * @author mshankar
  *
  */
 public class ArchivedPVsNotInListAction implements BPLAction {
-	private static final Logger logger = LogManager.getLogger(ArchivedPVsNotInListAction.class);
+    private static final Logger logger = LogManager.getLogger(ArchivedPVsNotInListAction.class);
 
-	@Override
-	public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException {
-		logger.info("Determining PVs that are archived but are not in list.");
-		LinkedList<String> incomingPVNamesList = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
-		logger.debug("Incoming list has " + incomingPVNamesList.size() + "PV names");
-		if(incomingPVNamesList.size() <= 0){ 
-			logger.error("Incoming list cannnot be empty for the action " + this.getClass().getName());
-			resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
-			return;			
-		}
-		LinkedList<String> archivedPVsNotInList = new LinkedList<String>();
-		for(String pvName : configService.getAllPVs()) {
-			if(!incomingPVNamesList.contains(pvName)) { 
-				archivedPVsNotInList.add(pvName);
-			}
-		}
-		
-		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
-		try (PrintWriter out = resp.getWriter()) {
-			JSONValue.writeJSONString(archivedPVsNotInList, out);
-		}
-	}
+    @Override
+    public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws IOException {
+        logger.info("Determining PVs that are archived but are not in list.");
+        LinkedList<String> incomingPVNamesList = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
+        logger.debug("Incoming list has " + incomingPVNamesList.size() + "PV names");
+        if (incomingPVNamesList.size() <= 0) {
+            logger.error("Incoming list cannnot be empty for the action "
+                    + this.getClass().getName());
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+        LinkedList<String> archivedPVsNotInList = new LinkedList<String>();
+        for (String pvName : configService.getAllPVs()) {
+            if (!incomingPVNamesList.contains(pvName)) {
+                archivedPVsNotInList.add(pvName);
+            }
+        }
+
+        resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+        try (PrintWriter out = resp.getWriter()) {
+            JSONValue.writeJSONString(archivedPVsNotInList, out);
+        }
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivedPVsNotInListAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivedPVsNotInListAction.java
@@ -38,7 +38,7 @@ public class ArchivedPVsNotInListAction implements BPLAction {
     public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
             throws IOException {
         logger.info("Determining PVs that are archived but are not in list.");
-        LinkedList<String> incomingPVNamesList = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
+        LinkedList<String> incomingPVNamesList = PVsMatchingParameter.getPVNamesFromPostBody(req);
         logger.debug("Incoming list has " + incomingPVNamesList.size() + "PV names");
         if (incomingPVNamesList.size() <= 0) {
             logger.error("Incoming list cannnot be empty for the action "

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/BulkPauseResumeUtils.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/BulkPauseResumeUtils.java
@@ -1,12 +1,5 @@
 package org.epics.archiverappliance.mgmt.bpl;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-
-import javax.servlet.http.HttpServletRequest;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.TimeUtils;
@@ -16,120 +9,130 @@ import org.epics.archiverappliance.config.PVTypeInfo;
 import org.epics.archiverappliance.utils.ui.GetUrlContent;
 import org.json.simple.JSONArray;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * Some utility methods for bulk pause and resume...
  * @author mshankar
  */
 public class BulkPauseResumeUtils {
-	private static Logger logger = LogManager.getLogger(BulkPauseResumeUtils.class);
-	
-	/**
-	 * Get a list of PVNames based on if this is a POST or GET.
-	 * @param req HttpServletRequest 
-	 * @param configService  ConfigService
-	 * @return LinkedList String PV names
-	 * @throws IOException  &emsp;
-	 */
-	public static LinkedList<String> getPVNames(HttpServletRequest req, ConfigService configService) throws IOException {
-		LinkedList<String> pvNames = null;
-		if(req.getMethod().equals("POST")) { 
-			pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
-		} else { 
-			pvNames = PVsMatchingParameter.getMatchingPVs(req, configService, false, -1);
-		}
-		return pvNames;
-	}
-	
-	
-	public static List<HashMap<String, String>> pauseResumeByAppliance(LinkedList<String> pvNames, ConfigService configService, boolean askingToPausePV) throws IOException { 
-		List<HashMap<String, String>> retVal = new LinkedList<HashMap<String, String>>();
-		HashMap<String, HashMap<String, String>> retValMap = new HashMap<String, HashMap<String, String>>();
-		HashMap<String, LinkedList<String>> pvsByAppliance = new HashMap<String, LinkedList<String>>();
-		for(String pvName : pvNames) { 
-			String realName = configService.getRealNameForAlias(pvName);
-			if(realName != null) pvName = realName;
+    private static Logger logger = LogManager.getLogger(BulkPauseResumeUtils.class);
 
-			HashMap<String, String> pvPauseResumeStatus = new HashMap<String, String>();
-			pvPauseResumeStatus.put("pvName", pvName);
-			retVal.add(pvPauseResumeStatus);
-			retValMap.put(pvName, pvPauseResumeStatus);
+    /**
+     * Get a list of PVNames based on if this is a POST or GET.
+     * @param req HttpServletRequest
+     * @param configService  ConfigService
+     * @return LinkedList String PV names
+     * @throws IOException  &emsp;
+     */
+    public static LinkedList<String> getPVNames(HttpServletRequest req, ConfigService configService)
+            throws IOException {
+        LinkedList<String> pvNames = null;
+        if (req.getMethod().equals("POST")) {
+            pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
+        } else {
+            pvNames = PVsMatchingParameter.getMatchingPVs(req, configService, false, -1);
+        }
+        return pvNames;
+    }
 
-			ApplianceInfo info = configService.getApplianceForPV(pvName);
-			if(info == null) {
-				pvPauseResumeStatus.put("validation", "Trying to pause PV " + pvName + " that is not currently being archived.");
-				logger.error(pvPauseResumeStatus.get("validation"));
-				pvPauseResumeStatus.put("validation", "Unable to pause PV " + pvName);
-			} else {
-				PVTypeInfo typeInfo = configService.getTypeInfoForPV(pvName);
-				if(askingToPausePV && typeInfo.isPaused()) {
-					pvPauseResumeStatus.put("validation", "Trying to pause PV " + pvName + " that is already paused.");
-					logger.error(pvPauseResumeStatus.get("validation"));
-					pvPauseResumeStatus.put("validation", "PV " + pvName + " is already paused");
-				} else if(!askingToPausePV && !typeInfo.isPaused()) {
-						pvPauseResumeStatus.put("validation", "Trying to resume PV " + pvName + " that is not paused.");
-						logger.error(pvPauseResumeStatus.get("validation"));
-						pvPauseResumeStatus.put("validation", "PV " + pvName + " is not paused");
-				} else { 
-					logger.debug("Changing the typeinfo for pause/resume for PV " + pvName);
-					typeInfo.setPaused(askingToPausePV);
-					typeInfo.setModificationTime(TimeUtils.now());
-					configService.updateTypeInfoForPV(pvName, typeInfo);
-					pvPauseResumeStatus.put("status", "ok");
-					
-					String applianceForPV = info.getIdentity();
-					if(!pvsByAppliance.containsKey(applianceForPV)) { 
-						pvsByAppliance.put(applianceForPV, new LinkedList<String>());
-					}
-					pvsByAppliance.get(applianceForPV).add(pvName);
-				}
-			}
-		}
+    public static List<HashMap<String, String>> pauseResumeByAppliance(
+            LinkedList<String> pvNames, ConfigService configService, boolean askingToPausePV) throws IOException {
+        List<HashMap<String, String>> retVal = new LinkedList<HashMap<String, String>>();
+        HashMap<String, HashMap<String, String>> retValMap = new HashMap<String, HashMap<String, String>>();
+        HashMap<String, LinkedList<String>> pvsByAppliance = new HashMap<String, LinkedList<String>>();
+        for (String pvName : pvNames) {
+            String realName = configService.getRealNameForAlias(pvName);
+            if (realName != null) pvName = realName;
 
-		for(String appliance : pvsByAppliance.keySet()) { 
-			logger.debug("Optimization; make bulk pause/resume calls to the engine and ETL " + appliance);
-			ApplianceInfo applianceInfo = configService.getAppliance(appliance);
-			String bplUrl = askingToPausePV ? "/pauseArchivingPV" : "/resumeArchivingPV";
-			
-			if(askingToPausePV) { 
-				String ETLPauseURL = applianceInfo.getEtlURL() + bplUrl; 
-				logger.info("Bulk pause/resume ETL using URL " + ETLPauseURL + " for " + pvsByAppliance.get(appliance).size() + " pvs");
-				JSONArray etlResponse = GetUrlContent.postStringListAndGetJSON(ETLPauseURL, "pv", pvsByAppliance.get(appliance));
-				for(Object statusObj : etlResponse) { 
-					@SuppressWarnings("unchecked")
-					HashMap<String, String> response = (HashMap<String, String>) statusObj;
-					String pvName = response.get("pvName");
-					logger.debug("Combining etl reponse for " + pvName);
-					HashMap<String, String> mainResponse = retValMap.get(pvName);
-					if(mainResponse != null) { 
-						for(String key : response.keySet()) {
-							mainResponse.put("etl_" + key, response.get(key));
-						}
-					} else { 
-						logger.error("Cannot find the main response object for pv " + pvName);
-					}
-				}
-			}
-			
+            HashMap<String, String> pvPauseResumeStatus = new HashMap<String, String>();
+            pvPauseResumeStatus.put("pvName", pvName);
+            retVal.add(pvPauseResumeStatus);
+            retValMap.put(pvName, pvPauseResumeStatus);
 
-			String enginePauseURL = applianceInfo.getEngineURL() + bplUrl;
-			logger.info("Bulk pause/resume engine using URL " + enginePauseURL  + " for " + pvsByAppliance.get(appliance).size() + " pvs");
-			JSONArray engineResponse = GetUrlContent.postStringListAndGetJSON(enginePauseURL, "pv", pvsByAppliance.get(appliance));			
-			for(Object statusObj : engineResponse) { 
-				@SuppressWarnings("unchecked")
-				HashMap<String, String> response = (HashMap<String, String>) statusObj;
-				String pvName = response.get("pvName");
-				logger.debug("Combining engine reponse for " + pvName);
-				HashMap<String, String> mainResponse = retValMap.get(pvName);
-				if(mainResponse != null) { 
-					for(String key : response.keySet()) {
-						mainResponse.put("engine_" + key, response.get(key));
-					}
-				} else { 
-					logger.error("Cannot find the main response object for pv " + pvName);
-				}
-			}
-		}
-		return retVal;
-	}
+            ApplianceInfo info = configService.getApplianceForPV(pvName);
+            if (info == null) {
+                pvPauseResumeStatus.put(
+                        "validation", "Trying to pause PV " + pvName + " that is not currently being archived.");
+                logger.error(pvPauseResumeStatus.get("validation"));
+                pvPauseResumeStatus.put("validation", "Unable to pause PV " + pvName);
+            } else {
+                PVTypeInfo typeInfo = configService.getTypeInfoForPV(pvName);
+                if (askingToPausePV && typeInfo.isPaused()) {
+                    pvPauseResumeStatus.put("validation", "Trying to pause PV " + pvName + " that is already paused.");
+                    logger.error(pvPauseResumeStatus.get("validation"));
+                    pvPauseResumeStatus.put("validation", "PV " + pvName + " is already paused");
+                } else if (!askingToPausePV && !typeInfo.isPaused()) {
+                    pvPauseResumeStatus.put("validation", "Trying to resume PV " + pvName + " that is not paused.");
+                    logger.error(pvPauseResumeStatus.get("validation"));
+                    pvPauseResumeStatus.put("validation", "PV " + pvName + " is not paused");
+                } else {
+                    logger.debug("Changing the typeinfo for pause/resume for PV " + pvName);
+                    typeInfo.setPaused(askingToPausePV);
+                    typeInfo.setModificationTime(TimeUtils.now());
+                    configService.updateTypeInfoForPV(pvName, typeInfo);
+                    pvPauseResumeStatus.put("status", "ok");
 
+                    String applianceForPV = info.getIdentity();
+                    if (!pvsByAppliance.containsKey(applianceForPV)) {
+                        pvsByAppliance.put(applianceForPV, new LinkedList<String>());
+                    }
+                    pvsByAppliance.get(applianceForPV).add(pvName);
+                }
+            }
+        }
+
+        for (String appliance : pvsByAppliance.keySet()) {
+            logger.debug("Optimization; make bulk pause/resume calls to the engine and ETL " + appliance);
+            ApplianceInfo applianceInfo = configService.getAppliance(appliance);
+            String bplUrl = askingToPausePV ? "/pauseArchivingPV" : "/resumeArchivingPV";
+
+            if (askingToPausePV) {
+                String ETLPauseURL = applianceInfo.getEtlURL() + bplUrl;
+                logger.info("Bulk pause/resume ETL using URL " + ETLPauseURL + " for "
+                        + pvsByAppliance.get(appliance).size() + " pvs");
+                JSONArray etlResponse =
+                        GetUrlContent.postStringListAndGetJSON(ETLPauseURL, "pv", pvsByAppliance.get(appliance));
+                for (Object statusObj : etlResponse) {
+                    @SuppressWarnings("unchecked")
+                    HashMap<String, String> response = (HashMap<String, String>) statusObj;
+                    String pvName = response.get("pvName");
+                    logger.debug("Combining etl reponse for " + pvName);
+                    HashMap<String, String> mainResponse = retValMap.get(pvName);
+                    if (mainResponse != null) {
+                        for (String key : response.keySet()) {
+                            mainResponse.put("etl_" + key, response.get(key));
+                        }
+                    } else {
+                        logger.error("Cannot find the main response object for pv " + pvName);
+                    }
+                }
+            }
+
+            String enginePauseURL = applianceInfo.getEngineURL() + bplUrl;
+            logger.info("Bulk pause/resume engine using URL " + enginePauseURL + " for "
+                    + pvsByAppliance.get(appliance).size() + " pvs");
+            JSONArray engineResponse =
+                    GetUrlContent.postStringListAndGetJSON(enginePauseURL, "pv", pvsByAppliance.get(appliance));
+            for (Object statusObj : engineResponse) {
+                @SuppressWarnings("unchecked")
+                HashMap<String, String> response = (HashMap<String, String>) statusObj;
+                String pvName = response.get("pvName");
+                logger.debug("Combining engine reponse for " + pvName);
+                HashMap<String, String> mainResponse = retValMap.get(pvName);
+                if (mainResponse != null) {
+                    for (String key : response.keySet()) {
+                        mainResponse.put("engine_" + key, response.get(key));
+                    }
+                } else {
+                    logger.error("Cannot find the main response object for pv " + pvName);
+                }
+            }
+        }
+        return retVal;
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/BulkPauseResumeUtils.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/BulkPauseResumeUtils.java
@@ -33,7 +33,7 @@ public class BulkPauseResumeUtils {
             throws IOException {
         LinkedList<String> pvNames = null;
         if (req.getMethod().equals("POST")) {
-            pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
+            pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req);
         } else {
             pvNames = PVsMatchingParameter.getMatchingPVs(req, configService, false, -1);
         }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/DeletePV.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/DeletePV.java
@@ -1,6 +1,5 @@
 package org.epics.archiverappliance.mgmt.bpl;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.BPLAction;

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/DeletePV.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/DeletePV.java
@@ -1,5 +1,6 @@
 package org.epics.archiverappliance.mgmt.bpl;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.BPLAction;

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/DeletePV.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/DeletePV.java
@@ -1,16 +1,5 @@
 package org.epics.archiverappliance.mgmt.bpl;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.BPLAction;
@@ -23,152 +12,175 @@ import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 /**
- * 
- * @epics.BPLAction - Stop archiving the specified PV. The PV needs to be paused first. 
+ *
+ * @epics.BPLAction - Stop archiving the specified PV. The PV needs to be paused first.
  * @epics.BPLActionParam pv - The name of the pv.
- * @epics.BPLActionParam deleteData - Should we delete the data that has already been recorded. Optional, by default, we do not delete the data for this PV. Can be <code>true</code> or <code>false</code>. 
+ * @epics.BPLActionParam deleteData - Should we delete the data that has already been recorded. Optional, by default, we do not delete the data for this PV. Can be <code>true</code> or <code>false</code>.
  * @epics.BPLActionEnd
- * 
+ *
  * @author mshankar
  *
  */
 public class DeletePV implements BPLAction {
-	private static Logger logger = LogManager.getLogger(DeletePV.class.getName());
+    private static Logger logger = LogManager.getLogger(DeletePV.class.getName());
 
-	@Override
-	public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException {
-		if(req.getMethod().equals("POST")) { 
-			deleteMultiplePVs(req, resp, configService);
-			return;
-		}
-		
-		
-		String pvName = req.getParameter("pv");
-		if(pvName == null || pvName.equals("")) {
-			resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
-			return;
-		}
-		
-		if(pvName.contains(",") || pvName.contains("*") || pvName.contains("?")) { 
-			deleteMultiplePVs(req, resp, configService);
-		} else { 
-			// We only have one PV in the request
-			String strValues = deleteSinglePV(req, resp, configService, null);
-			HashMap<String, Object> infoValues = new HashMap<String, Object>();
-			infoValues.put("validation", strValues);
-			if (strValues.equals("")) infoValues.put("status", "ok");
-			try(PrintWriter out = resp.getWriter()) {
-				out.println(JSONValue.toJSONString(infoValues));
-			}
-		}
-	}
-	
-	private String deleteSinglePV(HttpServletRequest req, HttpServletResponse resp, ConfigService configService, String pvName) throws IOException, UnsupportedEncodingException {
-		String infoValues = "";
-		if(pvName == null) pvName = req.getParameter("pv");
-		if(pvName == null || pvName.equals("")) {
-			resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
-			infoValues = "Bad request";
-			return infoValues;
-		}
+    @Override
+    public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws IOException {
+        if (req.getMethod().equals("POST")) {
+            deleteMultiplePVs(req, resp, configService);
+            return;
+        }
 
-		boolean deleteData = false;
-		String deleteDataStr=req.getParameter("deleteData");
-		if(deleteDataStr!=null && !deleteDataStr.equals("")) {
-			deleteData = Boolean.parseBoolean(deleteDataStr);
-		}
-		
-		// String pvNameFromRequest = pvName;
-		String realName = configService.getRealNameForAlias(pvName);
-		if(realName != null)  {
-			logger.info("The name " + pvName + " is an alias for " + realName + ". Deleting this instead.");
-			pvName = realName;
-		}
+        String pvName = req.getParameter("pv");
+        if (pvName == null || pvName.isEmpty()) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
 
-		ApplianceInfo info = configService.getApplianceForPV(pvName);
-		if(info == null) {
-			logger.debug("Unable to find appliance for PV " + pvName);
-			resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
-			infoValues = "Bad request";
-			return infoValues;
-		}
-		
-		PVTypeInfo typeInfo = configService.getTypeInfoForPV(pvName);
-		if(typeInfo == null) {
-			logger.debug("Unable to find typeinfo for PV...");
-			resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
-			infoValues = "Bad request";
-			return infoValues;
-		}
-		
-		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
-		if(!typeInfo.isPaused()) {
-			infoValues = "We will not stop archiving PV " + pvName + " if it is not paused. Please pause recording first.";
-			logger.error(infoValues);
-			return infoValues;
-		}
-		
-		HashMap<String, String> pvStatus = new HashMap<String, String>();
-		
-		pvStatus.put("Engine start", TimeUtils.convertToHumanReadableString(System.currentTimeMillis()/1000));
+        if (pvName.contains(",") || pvName.contains("*") || pvName.contains("?")) {
+            deleteMultiplePVs(req, resp, configService);
+        } else {
+            // We only have one PV in the request
+            String strValues = deleteSinglePV(req, resp, configService, null);
+            HashMap<String, Object> infoValues = new HashMap<String, Object>();
+            infoValues.put("validation", strValues);
+            if (strValues.isEmpty()) infoValues.put("status", "ok");
+            try (PrintWriter out = resp.getWriter()) {
+                out.println(JSONValue.toJSONString(infoValues));
+            }
+        }
+    }
 
-		String engineDeletePVURL = info.getEngineURL() + "/deletePV" 
-				+ "?pv=" + URLEncoder.encode(pvName, "UTF-8")
-				+ "&deleteData=" + Boolean.toString(deleteData); 
-		logger.info("Stopping archiving pv in engine using URL " + engineDeletePVURL);
-		JSONObject pvEngineStatus = GetUrlContent.getURLContentAsJSONObject(engineDeletePVURL);
-		if(pvEngineStatus == null) {
-			infoValues = "Unknown status from engine when stoppping archiving/deleting PV " + pvName + ".";
-			logger.error(infoValues);
-			return infoValues;
-		}
+    private String deleteSinglePV(
+            HttpServletRequest req, HttpServletResponse resp, ConfigService configService, String pvName)
+            throws IOException, UnsupportedEncodingException {
+        String infoValues = "";
+        if (pvName == null) pvName = req.getParameter("pv");
+        if (pvName == null || pvName.isEmpty()) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            infoValues = "Bad request";
+            return infoValues;
+        }
 
-		pvStatus.put("Engine end", TimeUtils.convertToHumanReadableString(System.currentTimeMillis()/1000));
+        boolean deleteData = false;
+        String deleteDataStr = req.getParameter("deleteData");
+        if (deleteDataStr != null && !deleteDataStr.isEmpty()) {
+            deleteData = Boolean.parseBoolean(deleteDataStr);
+        }
 
-		logger.info("Stopping archiving for PV " + pvName + (deleteData ? " and also deleting existing data" : " but keeping existing data"));
+        // String pvNameFromRequest = pvName;
+        String realName = configService.getRealNameForAlias(pvName);
+        if (realName != null) {
+            logger.info("The name " + pvName + " is an alias for " + realName + ". Deleting this instead.");
+            pvName = realName;
+        }
 
-		pvStatus.put("ETL start", TimeUtils.convertToHumanReadableString(System.currentTimeMillis()/1000));
-		String etlDeletePVURL = info.getEtlURL() + "/deletePV" 
-				+ "?pv=" + URLEncoder.encode(pvName, "UTF-8")
-				+ "&deleteData=" + Boolean.toString(deleteData); 
-		logger.info("Stopping archiving pv in ETL using URL " + etlDeletePVURL);
+        ApplianceInfo info = configService.getApplianceForPV(pvName);
+        if (info == null) {
+            logger.debug("Unable to find appliance for PV " + pvName);
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            infoValues = "Bad request";
+            return infoValues;
+        }
 
-		JSONObject etlStatus = GetUrlContent.getURLContentAsJSONObject(etlDeletePVURL);
-		pvStatus.put("ETL end", TimeUtils.convertToHumanReadableString(System.currentTimeMillis()/1000));
-		GetUrlContent.combineJSONObjects(pvStatus, etlStatus);
-		logger.debug("Removing pv " + pvName + " from the cluster");
-		pvStatus.put("Start removing PV from cluster", TimeUtils.convertToHumanReadableString(System.currentTimeMillis()/1000));
-		configService.removePVFromCluster(pvName);
-		pvStatus.put("Done removing PV from cluster", TimeUtils.convertToHumanReadableString(System.currentTimeMillis()/1000));
-		
-		logger.debug("Removing aliases for pv " + pvName + " from the cluster");
-		pvStatus.put("Start removing aliases from cluster", TimeUtils.convertToHumanReadableString(System.currentTimeMillis()/1000));
-		List<String> aliases = configService.getAllAliases();
-		for(String alias : aliases) { 
-			String realNameForAlias = configService.getRealNameForAlias(alias);
-			if(pvName.equals(realNameForAlias)) { 
-				logger.debug("Removing alias " + alias + " for pv " + pvName);
-				configService.removeAlias(alias, realNameForAlias);
-			}
-		}
-		pvStatus.put("Done removing aliases from cluster", TimeUtils.convertToHumanReadableString(System.currentTimeMillis()/1000));
-		
-		return infoValues;
-	}
-	
-	private void deleteMultiplePVs(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException, UnsupportedEncodingException {
-		String strValues = "";
-		LinkedList<String> pvNames = BulkPauseResumeUtils.getPVNames(req, configService);
-		for(String pvName : pvNames) {
-			strValues += deleteSinglePV(req, resp, configService, pvName) + "\n";
-		}
-		
-		HashMap<String, Object> infoValues = new HashMap<String, Object>();
-		infoValues.put("validation", strValues);
-		if (strValues.trim().equals("")) infoValues.put("status", "ok");
-		try(PrintWriter out = resp.getWriter()) {
-			out.println(JSONValue.toJSONString(infoValues));
-		}
-	}
+        PVTypeInfo typeInfo = configService.getTypeInfoForPV(pvName);
+        if (typeInfo == null) {
+            logger.debug("Unable to find typeinfo for PV...");
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            infoValues = "Bad request";
+            return infoValues;
+        }
+
+        resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+        if (!typeInfo.isPaused()) {
+            infoValues =
+                    "We will not stop archiving PV " + pvName + " if it is not paused. Please pause recording first.";
+            logger.error(infoValues);
+            return infoValues;
+        }
+
+        HashMap<String, String> pvStatus = new HashMap<String, String>();
+
+        pvStatus.put("Engine start", TimeUtils.convertToHumanReadableString(System.currentTimeMillis() / 1000));
+
+        String engineDeletePVURL = info.getEngineURL() + "/deletePV"
+                + "?pv=" + URLEncoder.encode(pvName, "UTF-8")
+                + "&deleteData=" + Boolean.toString(deleteData);
+        logger.info("Stopping archiving pv in engine using URL " + engineDeletePVURL);
+        JSONObject pvEngineStatus = GetUrlContent.getURLContentAsJSONObject(engineDeletePVURL);
+        if (pvEngineStatus == null) {
+            infoValues = "Unknown status from engine when stoppping archiving/deleting PV " + pvName + ".";
+            logger.error(infoValues);
+            return infoValues;
+        }
+
+        pvStatus.put("Engine end", TimeUtils.convertToHumanReadableString(System.currentTimeMillis() / 1000));
+
+        logger.info("Stopping archiving for PV " + pvName
+                + (deleteData ? " and also deleting existing data" : " but keeping existing data"));
+
+        pvStatus.put("ETL start", TimeUtils.convertToHumanReadableString(System.currentTimeMillis() / 1000));
+        String etlDeletePVURL = info.getEtlURL() + "/deletePV"
+                + "?pv=" + URLEncoder.encode(pvName, "UTF-8")
+                + "&deleteData=" + Boolean.toString(deleteData);
+        logger.info("Stopping archiving pv in ETL using URL " + etlDeletePVURL);
+
+        JSONObject etlStatus = GetUrlContent.getURLContentAsJSONObject(etlDeletePVURL);
+        pvStatus.put("ETL end", TimeUtils.convertToHumanReadableString(System.currentTimeMillis() / 1000));
+        GetUrlContent.combineJSONObjects(pvStatus, etlStatus);
+        logger.debug("Removing pv " + pvName + " from the cluster");
+        pvStatus.put(
+                "Start removing PV from cluster",
+                TimeUtils.convertToHumanReadableString(System.currentTimeMillis() / 1000));
+        configService.removePVFromCluster(pvName);
+        pvStatus.put(
+                "Done removing PV from cluster",
+                TimeUtils.convertToHumanReadableString(System.currentTimeMillis() / 1000));
+
+        logger.debug("Removing aliases for pv " + pvName + " from the cluster");
+        pvStatus.put(
+                "Start removing aliases from cluster",
+                TimeUtils.convertToHumanReadableString(System.currentTimeMillis() / 1000));
+        List<String> aliases = configService.getAllAliases();
+        for (String alias : aliases) {
+            String realNameForAlias = configService.getRealNameForAlias(alias);
+            if (pvName.equals(realNameForAlias)) {
+                logger.debug("Removing alias " + alias + " for pv " + pvName);
+                configService.removeAlias(alias, realNameForAlias);
+            }
+        }
+        pvStatus.put(
+                "Done removing aliases from cluster",
+                TimeUtils.convertToHumanReadableString(System.currentTimeMillis() / 1000));
+
+        return infoValues;
+    }
+
+    private void deleteMultiplePVs(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws IOException, UnsupportedEncodingException {
+        String strValues = "";
+        LinkedList<String> pvNames = BulkPauseResumeUtils.getPVNames(req, configService);
+        for (String pvName : pvNames) {
+            strValues += deleteSinglePV(req, resp, configService, pvName) + "\n";
+        }
+
+        HashMap<String, Object> infoValues = new HashMap<String, Object>();
+        infoValues.put("validation", strValues);
+        if (strValues.trim().isEmpty()) infoValues.put("status", "ok");
+        try (PrintWriter out = resp.getWriter()) {
+            out.println(JSONValue.toJSONString(infoValues));
+        }
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/GetAllPVs.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/GetAllPVs.java
@@ -1,12 +1,5 @@
 package org.epics.archiverappliance.mgmt.bpl;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.LinkedList;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.BPLAction;
@@ -14,34 +7,42 @@ import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
 import org.json.simple.JSONValue;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.LinkedList;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 /**
- * 
+ *
  * @epics.BPLAction - Get all the PVs in the cluster. Note this call can return millions of PVs
- * @epics.BPLActionParam pv - An optional argument that can contain a <a href="http://en.wikipedia.org/wiki/Glob_%28programming%29">GLOB</a> wildcard. We will return PVs that match this GLOB. For example, if <code>pv=KLYS*</code>, the server will return all PVs that start with the string <code>KLYS</code>. If both pv and regex are unspecified, we match against all PVs. 
- * @epics.BPLActionParam regex - An optional argument that can contain a <a href="http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">Java regex</a> wildcard. We will return PVs that match this regex. For example, if <code>pv=KLYS*</code>, the server will return all PVs that start with the string <code>KLYS</code>. 
- * @epics.BPLActionParam limit - An optional argument that specifies the number of matched PV's that are retured. If unspecified, we return 500 PV names. To get all the PV names, (potentially in the millions), set limit to &ndash;1. 
+ * @epics.BPLActionParam pv - An optional argument that can contain a <a href="http://en.wikipedia.org/wiki/Glob_%28programming%29">GLOB</a> wildcard. We will return PVs that match this GLOB. For example, if <code>pv=KLYS*</code>, the server will return all PVs that start with the string <code>KLYS</code>. If both pv and regex are unspecified, we match against all PVs.
+ * @epics.BPLActionParam regex - An optional argument that can contain a <a href="http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">Java regex</a> wildcard. We will return PVs that match this regex. For example, if <code>pv=KLYS*</code>, the server will return all PVs that start with the string <code>KLYS</code>.
+ * @epics.BPLActionParam limit - An optional argument that specifies the number of matched PV's that are retured. If unspecified, we return 500 PV names. To get all the PV names, (potentially in the millions), set limit to &ndash;1.
  * @epics.BPLActionEnd
- * 
+ *
  * @author mshankar
  *
  */
 public class GetAllPVs implements BPLAction {
-	private static Logger logger = LogManager.getLogger(GetAllPVs.class.getName());
+    private static Logger logger = LogManager.getLogger(GetAllPVs.class.getName());
 
-	@Override
-	public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException {
-		logger.debug("Getting all pvs for cluster");
-		int defaultLimit = 500;
-		LinkedList<String> pvNames = PVsMatchingParameter.getMatchingPVs(req, configService, defaultLimit);
+    @Override
+    public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws IOException {
+        logger.debug("Getting all pvs for cluster");
+        int defaultLimit = 500;
+        LinkedList<String> pvNames = PVsMatchingParameter.getMatchingPVs(req, configService, defaultLimit);
 
-		
-		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
-		try (PrintWriter out = resp.getWriter()) {
-			out.println(JSONValue.toJSONString(pvNames));
-		} catch(Exception ex) {
-			logger.error("Exception getting all pvs on appliance " + configService.getMyApplianceInfo().getIdentity(), ex);
-			resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-		}
-	}
-
+        resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+        try (PrintWriter out = resp.getWriter()) {
+            out.println(JSONValue.toJSONString(pvNames));
+        } catch (Exception ex) {
+            logger.error(
+                    "Exception getting all pvs on appliance "
+                            + configService.getMyApplianceInfo().getIdentity(),
+                    ex);
+            resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/GetMatchingPVsForAppliance.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/GetMatchingPVsForAppliance.java
@@ -1,14 +1,5 @@
 package org.epics.archiverappliance.mgmt.bpl;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.Set;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.BPLAction;
@@ -16,66 +7,75 @@ import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
 import org.json.simple.JSONValue;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 /**
- * 
+ *
  * @epics.BPLAction - Get matching PV's for this appliance. Specify one of pv or regex. If both are specified, we only apply the pv wildcard. If neither is specified, we return an empty list.
- * @epics.BPLActionParam pv - An optional argument that can contain a <a href="http://en.wikipedia.org/wiki/Glob_%28programming%29">GLOB</a> wildcard. We will return PVs that match this GLOB. For example, if <code>pv=KLYS*</code>, the server will return all PVs that start with the string <code>KLYS</code>. 
- * @epics.BPLActionParam regex - An optional argument that can contain a <a href="http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">Java regex</a> wildcard. We will return PVs that match this regex. For example, if <code>pv=KLYS.*</code>, the server will return all PVs that start with the string <code>KLYS</code>. 
- * @epics.BPLActionParam limit - An optional argument that specifies the number of matched PV's that are returned. If unspecified, we return 500 PV names. To get all the PV names, (potentially in the millions), set limit to -1. 
+ * @epics.BPLActionParam pv - An optional argument that can contain a <a href="http://en.wikipedia.org/wiki/Glob_%28programming%29">GLOB</a> wildcard. We will return PVs that match this GLOB. For example, if <code>pv=KLYS*</code>, the server will return all PVs that start with the string <code>KLYS</code>.
+ * @epics.BPLActionParam regex - An optional argument that can contain a <a href="http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">Java regex</a> wildcard. We will return PVs that match this regex. For example, if <code>pv=KLYS.*</code>, the server will return all PVs that start with the string <code>KLYS</code>.
+ * @epics.BPLActionParam limit - An optional argument that specifies the number of matched PV's that are returned. If unspecified, we return 500 PV names. To get all the PV names, (potentially in the millions), set limit to -1.
  * @epics.BPLActionEnd
- * 
+ *
  * @author mshankar
  *
  */
 public class GetMatchingPVsForAppliance implements BPLAction {
-	private static Logger logger = LogManager.getLogger(GetMatchingPVsForAppliance.class.getName());
+    private static Logger logger = LogManager.getLogger(GetMatchingPVsForAppliance.class.getName());
 
-	@Override
-	public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException {
-		logger.debug("Getting PV's matching wildcard or regex for this appliance.");
-		int limit = 500;
-		String limitParam = req.getParameter("limit");
-		if(limitParam != null) { 
-			limit = Integer.parseInt(limitParam);
-		}
-		
-		String nameToMatch = null;
-		if(req.getParameter("regex") != null) { 
-			nameToMatch = req.getParameter("regex");
-			logger.debug("Finding PV's for regex " + nameToMatch);
-		}
-		
-		if(req.getParameter("pv") != null) { 
-			nameToMatch = req.getParameter("pv");
-			nameToMatch = nameToMatch.replace("*", ".*");
-			nameToMatch = nameToMatch.replace("?", ".");
-			logger.debug("Finding PV's for glob (converted to regex)" + nameToMatch);			
-		}
-		
+    @Override
+    public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws IOException {
+        logger.debug("Getting PV's matching wildcard or regex for this appliance.");
+        int limit = 500;
+        String limitParam = req.getParameter("limit");
+        if (limitParam != null) {
+            limit = Integer.parseInt(limitParam);
+        }
 
-		Set<String> pvNamesMatchingRegex = configService.getPVsForApplianceMatchingRegex(nameToMatch);
-		
-		LinkedList<String> pvNames = new LinkedList<String>();
-		if(limit == -1) { 
-			pvNames.addAll(pvNamesMatchingRegex);
-		} else {
-			int pvCount = 0;
-			for(String matchedName : pvNamesMatchingRegex) { 
-				pvNames.add(matchedName);
-				pvCount++;
-				if(pvCount >= limit) break;
-			}
-		}
+        String nameToMatch = null;
+        if (req.getParameter("regex") != null) {
+            nameToMatch = req.getParameter("regex");
+            logger.debug("Finding PV's for regex " + nameToMatch);
+        }
 
-		
-		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
-		try (PrintWriter out = resp.getWriter()) {
-			Collections.sort(pvNames);
-			out.println(JSONValue.toJSONString(pvNames));
-		} catch(Exception ex) {
-			logger.error("Exception getting all pvs on appliance " + configService.getMyApplianceInfo().getIdentity(), ex);
-			resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-		}
-	}
+        if (req.getParameter("pv") != null) {
+            nameToMatch = req.getParameter("pv");
+            nameToMatch = nameToMatch.replace("*", ".*");
+            nameToMatch = nameToMatch.replace("?", ".");
+            logger.debug("Finding PV's for glob (converted to regex)" + nameToMatch);
+        }
 
+        Set<String> pvNamesMatchingRegex = configService.getPVsForApplianceMatchingRegex(nameToMatch);
+
+        LinkedList<String> pvNames = new LinkedList<String>();
+        if (limit == -1) {
+            pvNames.addAll(pvNamesMatchingRegex);
+        } else {
+            int pvCount = 0;
+            for (String matchedName : pvNamesMatchingRegex) {
+                pvNames.add(matchedName);
+                pvCount++;
+                if (pvCount >= limit) break;
+            }
+        }
+
+        resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+        try (PrintWriter out = resp.getWriter()) {
+            Collections.sort(pvNames);
+            out.println(JSONValue.toJSONString(pvNames));
+        } catch (Exception ex) {
+            logger.error(
+                    "Exception getting all pvs on appliance "
+                            + configService.getMyApplianceInfo().getIdentity(),
+                    ex);
+            resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/GetPVStatusAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/GetPVStatusAction.java
@@ -45,8 +45,22 @@ public class GetPVStatusAction implements BPLAction {
     @Override
     public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
             throws IOException {
+        LinkedList<String> pvNames;
+        if (req.getMethod().equals("POST")) {
+
+            LinkedList<String> postPVNames = BulkPauseResumeUtils.getPVNames(req, configService);
+
+            pvNames = PVsMatchingParameter.getMatchingPVs(
+                    postPVNames,
+                    null,
+                    PVsMatchingParameter.getLimit(-1, PVsMatchingParameter.getRequestParameters(req)),
+                    configService,
+                    true);
+
+        } else {
+            pvNames = PVsMatchingParameter.getMatchingPVs(req, configService, true, -1);
+        }
         logger.info("Getting the status of pv(s) " + req.getParameter("pv"));
-        LinkedList<String> pvNames = PVsMatchingParameter.getMatchingPVs(req, configService, true, -1);
 
         HashMap<String, Map<String, String>> pvStatuses = new LinkedHashMap<>();
         HashMap<String, LinkedList<String>> pvNamesToAskEngineForStatus =

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/GetPVStatusAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/GetPVStatusAction.java
@@ -7,16 +7,6 @@
  *******************************************************************************/
 package org.epics.archiverappliance.mgmt.bpl;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.BPLAction;
@@ -29,165 +19,187 @@ import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * Get the status of a PV.
- * 
+ *
  * @epics.BPLAction - Get the status of a PV.
  * @epics.BPLActionParam pv - The name(s) of the pv for which status is to be determined. If a pv is not being archived, you should get back a simple JSON object with a status string of "Not being archived." You can also pass in GLOB wildcards here and multiple PVs as a comma separated list. If you have more PVs that can fit in a GET, send the pv's as a CSV <code>pv=pv1,pv2,pv3</code> as the body of a POST.
  * @epics.BPLActionEnd
- * 
+ *
  * @author mshankar
  *
  */
 public class GetPVStatusAction implements BPLAction {
-	private static final Logger logger = LogManager.getLogger(GetPVStatusAction.class);
+    private static final Logger logger = LogManager.getLogger(GetPVStatusAction.class);
 
-	@SuppressWarnings("unchecked")
-	@Override
-	public void execute(HttpServletRequest req, HttpServletResponse resp,
-			ConfigService configService) throws IOException {
-		logger.info("Getting the status of pv(s) " + req.getParameter("pv"));
-		LinkedList<String> pvNames = PVsMatchingParameter.getMatchingPVs(req, configService, true, -1);
-		
-		
-		HashMap<String, Map<String, String>> pvStatuses = new LinkedHashMap<>();
-		HashMap<String, LinkedList<String>> pvNamesToAskEngineForStatus = new LinkedHashMap<String, LinkedList<String>>();
-		HashMap<String, PVTypeInfo> typeInfosForEngineRequests = new LinkedHashMap<String, PVTypeInfo>();
+    @SuppressWarnings("unchecked")
+    @Override
+    public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws IOException {
+        logger.info("Getting the status of pv(s) " + req.getParameter("pv"));
+        LinkedList<String> pvNames = PVsMatchingParameter.getMatchingPVs(req, configService, true, -1);
 
-		HashMap<String, LinkedList<String>> realName2NameFromRequest = new LinkedHashMap<String, LinkedList<String>>();
+        HashMap<String, Map<String, String>> pvStatuses = new LinkedHashMap<>();
+        HashMap<String, LinkedList<String>> pvNamesToAskEngineForStatus =
+                new LinkedHashMap<String, LinkedList<String>>();
+        HashMap<String, PVTypeInfo> typeInfosForEngineRequests = new LinkedHashMap<String, PVTypeInfo>();
 
-		getPVStatuses(configService, pvNames, pvStatuses, pvNamesToAskEngineForStatus, typeInfosForEngineRequests, realName2NameFromRequest);
+        HashMap<String, LinkedList<String>> realName2NameFromRequest = new LinkedHashMap<String, LinkedList<String>>();
 
-		JSONArray json = new JSONArray();
-		json.addAll(pvStatuses.values());
+        getPVStatuses(
+                configService,
+                pvNames,
+                pvStatuses,
+                pvNamesToAskEngineForStatus,
+                typeInfosForEngineRequests,
+                realName2NameFromRequest);
 
-		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+        JSONArray json = new JSONArray();
+        json.addAll(pvStatuses.values());
 
-		try (PrintWriter out = resp.getWriter()) {
-			out.print(json.toJSONString());
-		}
-	}
+        resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
 
-	public static void getPVStatuses(ConfigService configService, LinkedList<String> pvNames,
-	                                 HashMap<String, Map<String, String>> pvStatuses, HashMap<String, LinkedList<String>> pvNamesToAskEngineForStatus,
-	                                 HashMap<String, PVTypeInfo> typeInfosForEngineRequests, HashMap<String, LinkedList<String>> realName2NameFromRequest) {
-		for(String pvName : pvNames) {
-			String pvNameFromRequest = pvName;
+        try (PrintWriter out = resp.getWriter()) {
+            out.print(json.toJSONString());
+        }
+    }
 
-			// Get rid of .VAL and the V4 prefix
-			pvName = PVNames.normalizePVName(pvName);
-			pvName = PVNames.stripPrefixFromName(pvName);
-			addInverseNameMapping(pvNameFromRequest, pvName, realName2NameFromRequest);
+    public static void getPVStatuses(
+            ConfigService configService,
+            LinkedList<String> pvNames,
+            HashMap<String, Map<String, String>> pvStatuses,
+            HashMap<String, LinkedList<String>> pvNamesToAskEngineForStatus,
+            HashMap<String, PVTypeInfo> typeInfosForEngineRequests,
+            HashMap<String, LinkedList<String>> realName2NameFromRequest) {
+        for (String pvName : pvNames) {
+            String pvNameFromRequest = pvName;
 
-			PVTypeInfo typeInfoForPV = PVNames.determineAppropriatePVTypeInfo(pvName, configService);
-			if(typeInfoForPV != null) {
-				pvName = typeInfoForPV.getPvName();
-				addInverseNameMapping(pvNameFromRequest, pvName, realName2NameFromRequest);
-				ApplianceInfo info = configService.getAppliance(typeInfoForPV.getApplianceIdentity());
+            // Get rid of .VAL and the V4 prefix
+            pvName = PVNames.normalizePVName(pvName);
+            pvName = PVNames.stripPrefixFromName(pvName);
+            addInverseNameMapping(pvNameFromRequest, pvName, realName2NameFromRequest);
 
-				if(!pvNamesToAskEngineForStatus.containsKey(info.getEngineURL())) {
-					pvNamesToAskEngineForStatus.put(info.getEngineURL(), new LinkedList<String>());
-				}
-				pvNamesToAskEngineForStatus.get(info.getEngineURL()).add(pvName);
-				typeInfosForEngineRequests.put(pvName, typeInfoForPV);
-			} else {
-				Map<String, String> pvStatusInfo = new LinkedHashMap<String, String>();
-				pvStatusInfo.put("pvName", pvNameFromRequest);
-				if (PVNames.determineIfPVInWorkflow(pvName, configService)) {
-					pvStatusInfo.put("status", "Initial sampling");
-				} else {
-					pvStatusInfo.put("status", "Not being archived");
-				}
-				pvStatuses.put(pvNameFromRequest, pvStatusInfo);
-			}
-		}
-		for(String engineURL : pvNamesToAskEngineForStatus.keySet()) {
-			LinkedList<String> pvNamesToAskEngine = pvNamesToAskEngineForStatus.get(engineURL);
-			JSONArray engineStatuses = null;
-			boolean instanceDown = false;
-			try {
-				engineStatuses = GetUrlContent.postStringListAndGetJSON(engineURL + "/status", "pv", pvNamesToAskEngine);
-			} catch(IOException ex) {
-				instanceDown = true;
-				logger.warn("Exception getting status from engine " + engineURL, ex);
-			}
-			// Convert list of statuses from engine to hashmap
-			HashMap<String, JSONObject> computedEngineStatueses = new LinkedHashMap<String, JSONObject>();
-			if(engineStatuses != null) {
-				for(Object engineStatusObj : engineStatuses) {
-					JSONObject engineStatus = (JSONObject) engineStatusObj;
-					computedEngineStatueses.put((String) engineStatus.get("pvName"), engineStatus);
-				}
-			}
-			for(String pvNameToAskEngine : pvNamesToAskEngine) {
-				PVTypeInfo typeInfo = typeInfosForEngineRequests.get(pvNameToAskEngine);
-				JSONObject pvStatus = computedEngineStatueses.get(pvNameToAskEngine);
-				LinkedList<String> pvNamesForResult = new LinkedList<String>();
-				if(pvNames.contains(pvNameToAskEngine)) {
-					// User made a status request using the same name we sent to the engine.
-					pvNamesForResult.add(pvNameToAskEngine);
-				}
-				if(realName2NameFromRequest.containsKey(pvNameToAskEngine)) {
-					// Add all the aliases/field names etc.
-					pvNamesForResult.addAll(realName2NameFromRequest.get(pvNameToAskEngine));
-				}
-				for(String pvNameForResult : pvNamesForResult) {
-					Map<String, String> pvStatusInfo = new LinkedHashMap<String, String>();
-					if(pvStatus != null && !pvStatus.isEmpty()) {
-						logger.debug("Found status from engine for " + pvNameToAskEngine);
-						pvStatus.forEach((k, v) -> {
-							pvStatusInfo.put(String.valueOf(k), String.valueOf(v));
-						});
-						pvStatusInfo.put("appliance", typeInfo.getApplianceIdentity());
-						pvStatusInfo.put("pvName", pvNameForResult);
-						pvStatusInfo.put("pvNameOnly", pvNameToAskEngine);
-						pvStatuses.put(pvNameForResult, pvStatusInfo);
-					} else {
-						logger.debug("Did not find status from engine for " + pvNameToAskEngine);
-						if(typeInfo != null && typeInfo.isPaused()) {
-							HashMap<String, String> tempStatus = new LinkedHashMap<String, String>();
-							tempStatus.put("appliance", typeInfo.getApplianceIdentity());
-							tempStatus.put("pvName", pvNameForResult);
-							tempStatus.put("pvNameOnly", pvNameToAskEngine);
-							tempStatus.put("status", "Paused");
-							pvStatuses.put(pvNameForResult, tempStatus);
-						} else {
-							logger.info("Did not find status from engine for " + pvNameToAskEngine + " adding default status for " + pvNameForResult);
-							Map<String, String> missingPvStatusInfo = new LinkedHashMap<String, String>();
-							missingPvStatusInfo.put("pvName", pvNameForResult);
-							// Here we have a PVTypeInfo but no status from the engine.
-							if(instanceDown) {
-								missingPvStatusInfo.put("status", "Appliance Down");
-								// It could mean that the engine component archiving this PV is down.
-								pvStatuses.put(pvNameForResult, missingPvStatusInfo);
-							} else {
-								missingPvStatusInfo.put("status", "Appliance assigned");
-								// It could be that we are in that transient period between persisting the PVTypeInfo and opening the CA channel.
-								pvStatuses.put(pvNameForResult, missingPvStatusInfo);
-							}
-						}
-					}
-					logger.debug(pvStatuses);
-				}
-			}
-		}
-	}
+            PVTypeInfo typeInfoForPV = PVNames.determineAppropriatePVTypeInfo(pvName, configService);
+            if (typeInfoForPV != null) {
+                pvName = typeInfoForPV.getPvName();
+                addInverseNameMapping(pvNameFromRequest, pvName, realName2NameFromRequest);
+                ApplianceInfo info = configService.getAppliance(typeInfoForPV.getApplianceIdentity());
 
+                if (!pvNamesToAskEngineForStatus.containsKey(info.getEngineURL())) {
+                    pvNamesToAskEngineForStatus.put(info.getEngineURL(), new LinkedList<String>());
+                }
+                pvNamesToAskEngineForStatus.get(info.getEngineURL()).add(pvName);
+                typeInfosForEngineRequests.put(pvName, typeInfoForPV);
+            } else {
+                Map<String, String> pvStatusInfo = new LinkedHashMap<String, String>();
+                pvStatusInfo.put("pvName", pvNameFromRequest);
+                if (PVNames.determineIfPVInWorkflow(pvName, configService)) {
+                    pvStatusInfo.put("status", "Initial sampling");
+                } else {
+                    pvStatusInfo.put("status", "Not being archived");
+                }
+                pvStatuses.put(pvNameFromRequest, pvStatusInfo);
+            }
+        }
+        for (String engineURL : pvNamesToAskEngineForStatus.keySet()) {
+            LinkedList<String> pvNamesToAskEngine = pvNamesToAskEngineForStatus.get(engineURL);
+            JSONArray engineStatuses = null;
+            boolean instanceDown = false;
+            try {
+                engineStatuses =
+                        GetUrlContent.postStringListAndGetJSON(engineURL + "/status", "pv", pvNamesToAskEngine);
+            } catch (IOException ex) {
+                instanceDown = true;
+                logger.warn("Exception getting status from engine " + engineURL, ex);
+            }
+            // Convert list of statuses from engine to hashmap
+            HashMap<String, JSONObject> computedEngineStatueses = new LinkedHashMap<String, JSONObject>();
+            if (engineStatuses != null) {
+                for (Object engineStatusObj : engineStatuses) {
+                    JSONObject engineStatus = (JSONObject) engineStatusObj;
+                    computedEngineStatueses.put((String) engineStatus.get("pvName"), engineStatus);
+                }
+            }
+            for (String pvNameToAskEngine : pvNamesToAskEngine) {
+                PVTypeInfo typeInfo = typeInfosForEngineRequests.get(pvNameToAskEngine);
+                JSONObject pvStatus = computedEngineStatueses.get(pvNameToAskEngine);
+                LinkedList<String> pvNamesForResult = new LinkedList<String>();
+                if (pvNames.contains(pvNameToAskEngine)) {
+                    // User made a status request using the same name we sent to the engine.
+                    pvNamesForResult.add(pvNameToAskEngine);
+                }
+                if (realName2NameFromRequest.containsKey(pvNameToAskEngine)) {
+                    // Add all the aliases/field names etc.
+                    pvNamesForResult.addAll(realName2NameFromRequest.get(pvNameToAskEngine));
+                }
+                for (String pvNameForResult : pvNamesForResult) {
+                    Map<String, String> pvStatusInfo = new LinkedHashMap<String, String>();
+                    if (pvStatus != null && !pvStatus.isEmpty()) {
+                        logger.debug("Found status from engine for " + pvNameToAskEngine);
+                        pvStatus.forEach((k, v) -> {
+                            pvStatusInfo.put(String.valueOf(k), String.valueOf(v));
+                        });
+                        pvStatusInfo.put("appliance", typeInfo.getApplianceIdentity());
+                        pvStatusInfo.put("pvName", pvNameForResult);
+                        pvStatusInfo.put("pvNameOnly", pvNameToAskEngine);
+                        pvStatuses.put(pvNameForResult, pvStatusInfo);
+                    } else {
+                        logger.debug("Did not find status from engine for " + pvNameToAskEngine);
+                        if (typeInfo != null && typeInfo.isPaused()) {
+                            HashMap<String, String> tempStatus = new LinkedHashMap<String, String>();
+                            tempStatus.put("appliance", typeInfo.getApplianceIdentity());
+                            tempStatus.put("pvName", pvNameForResult);
+                            tempStatus.put("pvNameOnly", pvNameToAskEngine);
+                            tempStatus.put("status", "Paused");
+                            pvStatuses.put(pvNameForResult, tempStatus);
+                        } else {
+                            logger.info("Did not find status from engine for " + pvNameToAskEngine
+                                    + " adding default status for " + pvNameForResult);
+                            Map<String, String> missingPvStatusInfo = new LinkedHashMap<String, String>();
+                            missingPvStatusInfo.put("pvName", pvNameForResult);
+                            // Here we have a PVTypeInfo but no status from the engine.
+                            if (instanceDown) {
+                                missingPvStatusInfo.put("status", "Appliance Down");
+                                // It could mean that the engine component archiving this PV is down.
+                                pvStatuses.put(pvNameForResult, missingPvStatusInfo);
+                            } else {
+                                missingPvStatusInfo.put("status", "Appliance assigned");
+                                // It could be that we are in that transient period between persisting the PVTypeInfo
+                                // and opening the CA channel.
+                                pvStatuses.put(pvNameForResult, missingPvStatusInfo);
+                            }
+                        }
+                    }
+                    logger.debug(pvStatuses);
+                }
+            }
+        }
+    }
 
-	/**
-	 * There is a 1-many mapping between the name the user asks for and the internals.
-	 * When sending the data back, we need to take the "real" information and create an entry for each user request.
-	 * This method maintains this list.  
-	 * @param pvNameFromRequest
-	 * @param pvName
-	 * @param realName2NameFromRequest
-	 */
-	private static void addInverseNameMapping(String pvNameFromRequest, String pvName, HashMap<String, LinkedList<String>> realName2NameFromRequest) { 
-		if(!pvName.equals(pvNameFromRequest)) { 
-			if(!realName2NameFromRequest.containsKey(pvName)) { 
-				realName2NameFromRequest.put(pvName, new LinkedList<String>());
-			}
-			realName2NameFromRequest.get(pvName).add(pvNameFromRequest);
-		}
-	}
+    /**
+     * There is a 1-many mapping between the name the user asks for and the internals.
+     * When sending the data back, we need to take the "real" information and create an entry for each user request.
+     * This method maintains this list.
+     * @param pvNameFromRequest
+     * @param pvName
+     * @param realName2NameFromRequest
+     */
+    private static void addInverseNameMapping(
+            String pvNameFromRequest, String pvName, HashMap<String, LinkedList<String>> realName2NameFromRequest) {
+        if (!pvName.equals(pvNameFromRequest)) {
+            if (!realName2NameFromRequest.containsKey(pvName)) {
+                realName2NameFromRequest.put(pvName, new LinkedList<String>());
+            }
+            realName2NameFromRequest.get(pvName).add(pvNameFromRequest);
+        }
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/GetPVStatusAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/GetPVStatusAction.java
@@ -84,7 +84,7 @@ public class GetPVStatusAction implements BPLAction {
             String pvNameFromRequest = pvName;
 
             // Get rid of .VAL and the V4 prefix
-            pvName = PVNames.normalizePVName(pvName);
+            pvName = PVNames.normalizeChannelName(pvName);
             pvName = PVNames.stripPrefixFromName(pvName);
             addInverseNameMapping(pvNameFromRequest, pvName, realName2NameFromRequest);
 

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/PVsMatchingParameter.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/PVsMatchingParameter.java
@@ -1,17 +1,5 @@
 package org.epics.archiverappliance.mgmt.bpl;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.LineNumberReader;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import javax.servlet.http.HttpServletRequest;
-
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -22,165 +10,188 @@ import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * Small utility class for listing PVs that match a parameter
  * @author mshankar
  *
  */
 public class PVsMatchingParameter {
-	private static Logger logger = LogManager.getLogger(PVsMatchingParameter.class.getName());
-	public static LinkedList<String> getMatchingPVs(HttpServletRequest req, ConfigService configService, int defaultLimit) {
-		return getMatchingPVs(req, configService, false, defaultLimit);
-	}
-	/**
-	 * Given a BPL request, get all the matching PVs
-	 * @param req HttpServletRequest 
-	 * @param configService  ConfigService 
-	 * @param includePVSThatDontExist Some BPL requires us to include PVs that don't exist so that they can give explicit status
-	 * @param defaultLimit The default value for the limit if the limit is not specified in the request.
-	 * @return LinkedList Matching PVs
-	 */
-	public static LinkedList<String> getMatchingPVs(HttpServletRequest req, ConfigService configService, boolean includePVSThatDontExist, int defaultLimit) {
-		// The assumption taken previously was that each query parameter will have a single value only.
-		// If this assumption is to be changed then the below simplification would have to be removed.
-		Map<String, String> requestParameters = req.getParameterMap().entrySet().stream().collect(Collectors.toMap((entry) -> {
-			return entry.getKey();
-		}, (entry) -> {
-			return entry.getValue()[0];
-		}));
-		return getMatchingPVs(requestParameters, configService, includePVSThatDontExist, defaultLimit);
-	}
-	
-	/**
-	 * Given a BPL request, get all the matching PVs
-	 * @param requestParameters HttpServletRequest parameter map
-	 * @param configService ConfigService
-	 * @param includePVSThatDontExist Some BPL requires us to include PVs that don't exist so that they can give explicit status
-	 * @param defaultLimit The default value for the limit if the limit is not specified in the request.
-	 * @return LinkedList Matching PVs
-	 */
-	public static LinkedList<String> getMatchingPVs(Map<String, String> requestParameters, ConfigService configService, boolean includePVSThatDontExist, int defaultLimit) {
-		LinkedList<String> pvNames = new LinkedList<String>();
-		int limit = defaultLimit;
-		
-		String limitParam = requestParameters.get("limit");
-		if(limitParam != null) { 
-			limit = Integer.parseInt(limitParam);
-		}
-		
-		if(requestParameters.get("pv") != null) { 
-			String[] pvs = requestParameters.get("pv").split(",");
-			for(String pv : pvs) { 
-				if(pv.contains("*") || pv.contains("?")) {
-					WildcardFileFilter matcher = new WildcardFileFilter(pv); 
-					for(String pvName : configService.getAllPVs()) {
-						if(matcher.accept((new File(pvName)))) {
-							pvNames.add(pvName);
-							if(limit != -1 && pvNames.size() >= limit) { 
-								return pvNames;
-							}
-						}
-					}
-					for(String pvName : configService.getAllAliases()) {
-						if(matcher.accept((new File(pvName)))) {
-							pvNames.add(pvName);
-							if(limit != -1 && pvNames.size() >= limit) { 
-								return pvNames;
-							}
-						}
-					}
-				} else {
-					ApplianceInfo info = configService.getApplianceForPV(pv);
-					if(info != null) { 
-						pvNames.add(pv);
-						if(limit != -1 && pvNames.size() >= limit) { 
-							return pvNames;
-						}
-					} else { 
-						if(includePVSThatDontExist) { 
-							pvNames.add(pv);							
-							if(limit != -1 && pvNames.size() >= limit) { 
-								return pvNames;
-							}
-						}
-					}
-				}
-			}
-		} else { 
-			if(requestParameters.get("regex") != null) { 
-				String regex = requestParameters.get("regex");
-				Pattern pattern = Pattern.compile(regex);
-				for(String pvName : configService.getAllPVs()) {
-					if(pattern.matcher(pvName).matches()) { 
-						pvNames.add(pvName);
-						if(limit != -1 && pvNames.size() >= limit) { 
-							return pvNames;
-						}
-					}
-				}
-				for(String pvName : configService.getAllAliases()) {
-					if(pattern.matcher(pvName).matches()) { 
-						pvNames.add(pvName);
-						if(limit != -1 && pvNames.size() >= limit) { 
-							return pvNames;
-						}
-					}
-				}
-			} else { 
-				for(String pvName : configService.getAllPVs()) {
-					pvNames.add(pvName);
-					if(limit != -1 && pvNames.size() >= limit) { 
-						return pvNames;
-					}
-				}
-				for(String pvName : configService.getAllAliases()) {
-					pvNames.add(pvName);
-					if(limit != -1 && pvNames.size() >= limit) { 
-						return pvNames;
-					}
-				}
-			}
-		}
-		return pvNames;
-	}
-	
-	
-	public static LinkedList<String> getPVNamesFromPostBody(HttpServletRequest req, ConfigService configService) throws IOException {
-		LinkedList<String> pvNames = new LinkedList<String>();
-		String contentType = req.getContentType();
-		if(contentType != null) { 
-			switch(contentType) { 
-			case MimeTypeConstants.APPLICATION_JSON: 
-				try (LineNumberReader lineReader = new LineNumberReader(new InputStreamReader(new BufferedInputStream(req.getInputStream())))) {
-					JSONParser parser=new JSONParser();
-					for(Object pvName : (JSONArray) parser.parse(lineReader)) {
-						pvNames.add((String) pvName);
-					}
-				} catch(ParseException ex) { 
-					throw new IOException(ex);
-				}
-				return pvNames;
-			case MimeTypeConstants.APPLICATION_FORM_URLENCODED: 
-				String[] pvs = req.getParameter("pv").split(",");
-				for(String pv : pvs) {
-					pvNames.add(pv);
-				}
-				return pvNames;
-			case MimeTypeConstants.TEXT_PLAIN:				
-			default:
-				// For the default we assume text/plain which is a list of PV's separated by unix newlines
-				try (LineNumberReader lineReader = new LineNumberReader(new InputStreamReader(new BufferedInputStream(req.getInputStream())))) {
-					String pv = lineReader.readLine();
-					logger.debug("Parsed pv " + pv);
-					while(pv != null) { 
-						pvNames.add(pv);
-						pv = lineReader.readLine();
-					}
-				}
-				return pvNames;
-			}
-		}
+    private static Logger logger = LogManager.getLogger(PVsMatchingParameter.class.getName());
 
-		return pvNames;
-	}
+    public static LinkedList<String> getMatchingPVs(
+            HttpServletRequest req, ConfigService configService, int defaultLimit) {
+        return getMatchingPVs(req, configService, false, defaultLimit);
+    }
+    /**
+     * Given a BPL request, get all the matching PVs
+     * @param req HttpServletRequest
+     * @param configService  ConfigService
+     * @param includePVSThatDontExist Some BPL requires us to include PVs that don't exist so that they can give explicit status
+     * @param defaultLimit The default value for the limit if the limit is not specified in the request.
+     * @return LinkedList Matching PVs
+     */
+    public static LinkedList<String> getMatchingPVs(
+            HttpServletRequest req, ConfigService configService, boolean includePVSThatDontExist, int defaultLimit) {
+        // The assumption taken previously was that each query parameter will have a single value only.
+        // If this assumption is to be changed then the below simplification would have to be removed.
+        Map<String, String> requestParameters = req.getParameterMap().entrySet().stream()
+                .collect(Collectors.toMap(
+                        (entry) -> {
+                            return entry.getKey();
+                        },
+                        (entry) -> {
+                            return entry.getValue()[0];
+                        }));
+        return getMatchingPVs(requestParameters, configService, includePVSThatDontExist, defaultLimit);
+    }
+
+    /**
+     * Given a BPL request, get all the matching PVs
+     * @param requestParameters HttpServletRequest parameter map
+     * @param configService ConfigService
+     * @param includePVSThatDontExist Some BPL requires us to include PVs that don't exist so that they can give explicit status
+     * @param defaultLimit The default value for the limit if the limit is not specified in the request.
+     * @return LinkedList Matching PVs
+     */
+    public static LinkedList<String> getMatchingPVs(
+            Map<String, String> requestParameters,
+            ConfigService configService,
+            boolean includePVSThatDontExist,
+            int defaultLimit) {
+        LinkedList<String> pvNames = new LinkedList<String>();
+        int limit = defaultLimit;
+
+        String limitParam = requestParameters.get("limit");
+        if (limitParam != null) {
+            limit = Integer.parseInt(limitParam);
+        }
+
+        if (requestParameters.get("pv") != null) {
+            String[] pvs = requestParameters.get("pv").split(",");
+            for (String pv : pvs) {
+                if (pv.contains("*") || pv.contains("?")) {
+                    WildcardFileFilter matcher = new WildcardFileFilter(pv);
+                    for (String pvName : configService.getAllPVs()) {
+                        if (matcher.accept((new File(pvName)))) {
+                            pvNames.add(pvName);
+                            if (limit != -1 && pvNames.size() >= limit) {
+                                return pvNames;
+                            }
+                        }
+                    }
+                    for (String pvName : configService.getAllAliases()) {
+                        if (matcher.accept((new File(pvName)))) {
+                            pvNames.add(pvName);
+                            if (limit != -1 && pvNames.size() >= limit) {
+                                return pvNames;
+                            }
+                        }
+                    }
+                } else {
+                    ApplianceInfo info = configService.getApplianceForPV(pv);
+                    if (info != null) {
+                        pvNames.add(pv);
+                        if (limit != -1 && pvNames.size() >= limit) {
+                            return pvNames;
+                        }
+                    } else {
+                        if (includePVSThatDontExist) {
+                            pvNames.add(pv);
+                            if (limit != -1 && pvNames.size() >= limit) {
+                                return pvNames;
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            if (requestParameters.get("regex") != null) {
+                String regex = requestParameters.get("regex");
+                Pattern pattern = Pattern.compile(regex);
+                for (String pvName : configService.getAllPVs()) {
+                    if (pattern.matcher(pvName).matches()) {
+                        pvNames.add(pvName);
+                        if (limit != -1 && pvNames.size() >= limit) {
+                            return pvNames;
+                        }
+                    }
+                }
+                for (String pvName : configService.getAllAliases()) {
+                    if (pattern.matcher(pvName).matches()) {
+                        pvNames.add(pvName);
+                        if (limit != -1 && pvNames.size() >= limit) {
+                            return pvNames;
+                        }
+                    }
+                }
+            } else {
+                for (String pvName : configService.getAllPVs()) {
+                    pvNames.add(pvName);
+                    if (limit != -1 && pvNames.size() >= limit) {
+                        return pvNames;
+                    }
+                }
+                for (String pvName : configService.getAllAliases()) {
+                    pvNames.add(pvName);
+                    if (limit != -1 && pvNames.size() >= limit) {
+                        return pvNames;
+                    }
+                }
+            }
+        }
+        return pvNames;
+    }
+
+    public static LinkedList<String> getPVNamesFromPostBody(HttpServletRequest req, ConfigService configService)
+            throws IOException {
+        LinkedList<String> pvNames = new LinkedList<String>();
+        String contentType = req.getContentType();
+        if (contentType != null) {
+            switch (contentType) {
+                case MimeTypeConstants.APPLICATION_JSON:
+                    try (LineNumberReader lineReader = new LineNumberReader(
+                            new InputStreamReader(new BufferedInputStream(req.getInputStream())))) {
+                        JSONParser parser = new JSONParser();
+                        for (Object pvName : (JSONArray) parser.parse(lineReader)) {
+                            pvNames.add((String) pvName);
+                        }
+                    } catch (ParseException ex) {
+                        throw new IOException(ex);
+                    }
+                    return pvNames;
+                case MimeTypeConstants.APPLICATION_FORM_URLENCODED:
+                    String[] pvs = req.getParameter("pv").split(",");
+                    for (String pv : pvs) {
+                        pvNames.add(pv);
+                    }
+                    return pvNames;
+                case MimeTypeConstants.TEXT_PLAIN:
+                default:
+                    // For the default we assume text/plain which is a list of PV's separated by unix newlines
+                    try (LineNumberReader lineReader = new LineNumberReader(
+                            new InputStreamReader(new BufferedInputStream(req.getInputStream())))) {
+                        String pv = lineReader.readLine();
+                        logger.debug("Parsed pv " + pv);
+                        while (pv != null) {
+                            pvNames.add(pv);
+                            pv = lineReader.readLine();
+                        }
+                    }
+                    return pvNames;
+            }
+        }
+
+        return pvNames;
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/UnarchivedPVsAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/UnarchivedPVsAction.java
@@ -42,8 +42,7 @@ public class UnarchivedPVsAction implements BPLAction {
     public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
             throws IOException {
         logger.info("Determining PVs that are unarchived ");
-        Set<String> pvNamesFromUser =
-                new HashSet<String>(PVsMatchingParameter.getPVNamesFromPostBody(req, configService));
+        Set<String> pvNamesFromUser = new HashSet<String>(PVsMatchingParameter.getPVNamesFromPostBody(req));
 
         Set<String> expandedNames = new HashSet<String>();
         configService.getAllExpandedNames(new Consumer<String>() {

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/UnarchivedPVsAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/UnarchivedPVsAction.java
@@ -7,16 +7,6 @@
  *******************************************************************************/
 package org.epics.archiverappliance.mgmt.bpl;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.Set;
-import java.util.function.Consumer;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.BPLAction;
@@ -24,38 +14,50 @@ import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
 import org.json.simple.JSONValue;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Set;
+import java.util.function.Consumer;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * Given a list of PVs, determine those that are not being archived/have pending requests.
  * Of course, you can use the status call but that makes calls to the engine etc and can be stressful if you are checking several thousand PVs
  * All this does is check the configservice...
- * 
+ *
  * @epics.BPLAction - Given a list of PVs, determine those that are not being archived/have pending requests/have aliases.
  * @epics.BPLActionParam pv - A list of pv names. Send as a CSV using a POST or JSON array.
  * @epics.BPLActionEnd
- * 
+ *
  * @author mshankar
  *
  */
 public class UnarchivedPVsAction implements BPLAction {
-	private static final Logger logger = LogManager.getLogger(UnarchivedPVsAction.class);
+    private static final Logger logger = LogManager.getLogger(UnarchivedPVsAction.class);
 
-	@Override
-	public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException {
-		logger.info("Determining PVs that are unarchived ");
-		Set<String> pvNamesFromUser = new HashSet<String>(PVsMatchingParameter.getPVNamesFromPostBody(req, configService));
+    @Override
+    public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws IOException {
+        logger.info("Determining PVs that are unarchived ");
+        Set<String> pvNamesFromUser =
+                new HashSet<String>(PVsMatchingParameter.getPVNamesFromPostBody(req, configService));
 
-		Set<String> expandedNames = new HashSet<String>(); 
-		configService.getAllExpandedNames(new Consumer<String>(){
-			@Override
-			public void accept(String t) {
-				expandedNames.add(t);
-			} });
-		
-		pvNamesFromUser.removeAll(expandedNames);
-		
-		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
-		try (PrintWriter out = resp.getWriter()) {
-			JSONValue.writeJSONString(new LinkedList<String>(pvNamesFromUser), out);
-		}
-	}
+        Set<String> expandedNames = new HashSet<String>();
+        configService.getAllExpandedNames(new Consumer<String>() {
+            @Override
+            public void accept(String t) {
+                expandedNames.add(t);
+            }
+        });
+
+        pvNamesFromUser.removeAll(expandedNames);
+
+        resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+        try (PrintWriter out = resp.getWriter()) {
+            JSONValue.writeJSONString(new LinkedList<String>(pvNamesFromUser), out);
+        }
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/reports/PVDetails.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/reports/PVDetails.java
@@ -51,7 +51,7 @@ public class PVDetails implements BPLAction {
     public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
             throws IOException {
         String pvNameFromRequest = req.getParameter("pv");
-        String pvName = PVNames.stripFieldNameFromPVName(pvNameFromRequest);
+        String pvName = PVNames.channelNamePVName(pvNameFromRequest);
         // Get rid of the V4 prefix
         pvName = PVNames.stripPrefixFromName(pvName);
 

--- a/src/main/org/epics/archiverappliance/mgmt/pva/actions/PvaGetAllPVs.java
+++ b/src/main/org/epics/archiverappliance/mgmt/pva/actions/PvaGetAllPVs.java
@@ -1,9 +1,5 @@
 package org.epics.archiverappliance.mgmt.pva.actions;
 
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.config.ConfigService;
@@ -12,6 +8,10 @@ import org.epics.archiverappliance.mgmt.bpl.PVsMatchingParameter;
 import org.epics.pva.data.PVAStringArray;
 import org.epics.pva.data.PVAStructure;
 import org.epics.pva.data.nt.*;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
 
 /**
  * Get all the PVs in the cluster. Note this call can return millions of PVs
@@ -51,38 +51,40 @@ import org.epics.pva.data.nt.*;
  * </ul>
  *
  * Based on {@link GetAllPVs}
- * 
+ *
  * @author Kunal Shroff, mshankar
  *
  */
 public class PvaGetAllPVs implements PvaAction {
-	private static final Logger logger = LogManager.getLogger(PvaGetAllPVs.class.getName());
+    private static final Logger logger = LogManager.getLogger(PvaGetAllPVs.class.getName());
 
-	public static final String NAME = "getAllPVs";
+    public static final String NAME = "getAllPVs";
 
-	@Override
-	public String getName() {
-		return NAME;
-	}
+    @Override
+    public String getName() {
+        return NAME;
+    }
 
-	@Override
-	public PVAStructure request(PVAStructure args, ConfigService configService) throws PvaActionException {
-		logger.debug("Getting all pvs for cluster");
-		Map<String, String> searchParameters = new HashMap<String, String>();
-		int defaultLimit = 500;
-		PVAURI uri = PVAURI.fromStructure(args);
-		PVAScalar<PVAStringArray> ntScalarArray = null;
-		try {
-			Map<String, String> queryName = uri.getQuery();
-			if (queryName.containsKey("limit")) {
-				searchParameters.put("limit", queryName.get("limit"));
-			}
-			LinkedList<String> pvNames = PVsMatchingParameter.getMatchingPVs(searchParameters, configService, false, defaultLimit);
-			ntScalarArray = PVAScalar.stringArrayScalarBuilder(pvNames.toArray(new String[pvNames.size()])).name("result").build();
-		} catch (PVAScalarDescriptionNameException | NotValueException | PVAScalarValueNameException e) {
-			throw new ResponseConstructionException(e);
-		}
-		return ntScalarArray;
-	}
-
+    @Override
+    public PVAStructure request(PVAStructure args, ConfigService configService) throws PvaActionException {
+        logger.debug("Getting all pvs for cluster");
+        Map<String, String> searchParameters = new HashMap<String, String>();
+        int defaultLimit = 500;
+        PVAURI uri = PVAURI.fromStructure(args);
+        PVAScalar<PVAStringArray> ntScalarArray = null;
+        try {
+            Map<String, String> queryName = uri.getQuery();
+            if (queryName.containsKey("limit")) {
+                searchParameters.put("limit", queryName.get("limit"));
+            }
+            LinkedList<String> pvNames =
+                    PVsMatchingParameter.getMatchingPVs(searchParameters, configService, false, defaultLimit);
+            ntScalarArray = PVAScalar.stringArrayScalarBuilder(pvNames.toArray(new String[pvNames.size()]))
+                    .name("result")
+                    .build();
+        } catch (PVAScalarDescriptionNameException | NotValueException | PVAScalarValueNameException e) {
+            throw new ResponseConstructionException(e);
+        }
+        return ntScalarArray;
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/pva/actions/PvaGetAllPVs.java
+++ b/src/main/org/epics/archiverappliance/mgmt/pva/actions/PvaGetAllPVs.java
@@ -11,6 +11,7 @@ import org.epics.pva.data.nt.*;
 
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -74,12 +75,13 @@ public class PvaGetAllPVs implements PvaAction {
         PVAScalar<PVAStringArray> ntScalarArray = null;
         try {
             Map<String, String> queryName = uri.getQuery();
+
             if (queryName.containsKey("limit")) {
-                searchParameters.put("limit", queryName.get("limit"));
+                defaultLimit = Integer.parseInt(queryName.get("limit"));
             }
             LinkedList<String> pvNames =
-                    PVsMatchingParameter.getMatchingPVs(searchParameters, configService, false, defaultLimit);
-            ntScalarArray = PVAScalar.stringArrayScalarBuilder(pvNames.toArray(new String[pvNames.size()]))
+                    PVsMatchingParameter.getMatchingPVs(List.of(), null, defaultLimit, configService, false);
+            ntScalarArray = PVAScalar.stringArrayScalarBuilder(pvNames.toArray(new String[0]))
                     .name("result")
                     .build();
         } catch (PVAScalarDescriptionNameException | NotValueException | PVAScalarValueNameException e) {

--- a/src/main/org/epics/archiverappliance/mgmt/pva/actions/PvaGetArchivedPVs.java
+++ b/src/main/org/epics/archiverappliance/mgmt/pva/actions/PvaGetArchivedPVs.java
@@ -82,13 +82,13 @@ public class PvaGetArchivedPVs implements PvaAction {
                 continue;
             }
             logger.debug("Check for the normalized name");
-            typeInfo = configService.getTypeInfoForPV(PVNames.normalizePVName(pvName));
+            typeInfo = configService.getTypeInfoForPV(PVNames.normalizeChannelName(pvName));
             if (typeInfo != null) {
                 map.put(pvName, "Archived");
                 continue;
             }
             logger.debug("Check for aliases");
-            String aliasRealName = configService.getRealNameForAlias(PVNames.normalizePVName(pvName));
+            String aliasRealName = configService.getRealNameForAlias(PVNames.normalizeChannelName(pvName));
             if (aliasRealName != null) {
                 typeInfo = configService.getTypeInfoForPV(aliasRealName);
                 if (typeInfo != null) {
@@ -99,7 +99,7 @@ public class PvaGetArchivedPVs implements PvaAction {
             logger.debug("Check for fields");
             String fieldName = PVNames.getFieldName(pvName);
             if (fieldName != null) {
-                typeInfo = configService.getTypeInfoForPV(PVNames.stripFieldNameFromPVName(pvName));
+                typeInfo = configService.getTypeInfoForPV(PVNames.channelNamePVName(pvName));
                 if (typeInfo != null) {
                     if (Arrays.asList(typeInfo.getArchiveFields()).contains(fieldName)) {
                         map.put(pvName, "Archived");

--- a/src/main/org/epics/archiverappliance/mgmt/pva/actions/PvaGetArchivedPVs.java
+++ b/src/main/org/epics/archiverappliance/mgmt/pva/actions/PvaGetArchivedPVs.java
@@ -7,10 +7,6 @@
  *******************************************************************************/
 package org.epics.archiverappliance.mgmt.pva.actions;
 
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.Map.Entry;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.config.ConfigService;
@@ -21,6 +17,10 @@ import org.epics.pva.data.PVAStringArray;
 import org.epics.pva.data.PVAStructure;
 import org.epics.pva.data.nt.MustBeArrayException;
 import org.epics.pva.data.nt.PVATable;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map.Entry;
 
 /**
  * Given a list of PVs, determine those that are being archived. Of course, you
@@ -59,71 +59,72 @@ import org.epics.pva.data.nt.PVATable;
  *
  */
 public class PvaGetArchivedPVs implements PvaAction {
-	private static final Logger logger = LogManager.getLogger(PvaGetArchivedPVs.class);
-	
-	public static final String NAME = "archivedPVStatus";
+    private static final Logger logger = LogManager.getLogger(PvaGetArchivedPVs.class);
 
-	@Override
-	public String getName() {
-		return NAME;
-	}
+    public static final String NAME = "archivedPVStatus";
 
-	@Override
-	public PVAStructure request(PVAStructure args, ConfigService configService) throws PvaActionException {
-		logger.info("Determining PVs that are archived ");
-		LinkedHashMap<String, String> map = new LinkedHashMap<>();
-		for(String pvName : NTUtil.extractStringArray(PVATable.fromStructure(args).getColumn("pv"))) {
-			PVTypeInfo typeInfo = null;
-			logger.debug("Check for the name as it came in from the user " + pvName);
-			typeInfo = configService.getTypeInfoForPV(pvName);
-			if(typeInfo != null)  {
-				map.put(pvName, "Archived");
-				continue;
-			}
-			logger.debug("Check for the normalized name");
-			typeInfo = configService.getTypeInfoForPV(PVNames.normalizePVName(pvName));
-			if(typeInfo != null) {
-				map.put(pvName, "Archived");
-				continue;
-			}
-			logger.debug("Check for aliases");
-			String aliasRealName = configService.getRealNameForAlias(PVNames.normalizePVName(pvName));
-			if(aliasRealName != null) { 
-				typeInfo = configService.getTypeInfoForPV(aliasRealName);
-				if(typeInfo != null) {
-					map.put(pvName, "Archived");
-					continue;
-				}
-			}
-			logger.debug("Check for fields");
-			String fieldName = PVNames.getFieldName(pvName);
-			if(fieldName != null) { 
-				typeInfo = configService.getTypeInfoForPV(PVNames.stripFieldNameFromPVName(pvName));
-				if(typeInfo != null) { 
-					if(Arrays.asList(typeInfo.getArchiveFields()).contains(fieldName)) {
-						map.put(pvName, "Archived");
-						continue;
-					}
-				}
-			}
-			map.put(pvName, "Not Archived");
-		}
-		String[] pvs = new String[map.size()];
-		String[] statuses = new String[map.size()];
-		int counter = 0;
-		for (Entry<String, String> entry : map.entrySet()) {
-			pvs[counter]= entry.getKey();
-			statuses[counter] = entry.getValue();
-			counter++;
-		}
-		try {
-			return PVATable.PVATableBuilder.aPVATable()
-					.name(NAME)
-					.addColumn(new PVAStringArray("pv", pvs))
-					.addColumn(new PVAStringArray("status", statuses))
-					.build();
-		} catch (MustBeArrayException e) {
-			throw new RuntimeException(e);
-		}
-	}
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public PVAStructure request(PVAStructure args, ConfigService configService) throws PvaActionException {
+        logger.info("Determining PVs that are archived ");
+        LinkedHashMap<String, String> map = new LinkedHashMap<>();
+        for (String pvName :
+                NTUtil.extractStringArray(PVATable.fromStructure(args).getColumn("pv"))) {
+            PVTypeInfo typeInfo = null;
+            logger.debug("Check for the name as it came in from the user " + pvName);
+            typeInfo = configService.getTypeInfoForPV(pvName);
+            if (typeInfo != null) {
+                map.put(pvName, "Archived");
+                continue;
+            }
+            logger.debug("Check for the normalized name");
+            typeInfo = configService.getTypeInfoForPV(PVNames.normalizePVName(pvName));
+            if (typeInfo != null) {
+                map.put(pvName, "Archived");
+                continue;
+            }
+            logger.debug("Check for aliases");
+            String aliasRealName = configService.getRealNameForAlias(PVNames.normalizePVName(pvName));
+            if (aliasRealName != null) {
+                typeInfo = configService.getTypeInfoForPV(aliasRealName);
+                if (typeInfo != null) {
+                    map.put(pvName, "Archived");
+                    continue;
+                }
+            }
+            logger.debug("Check for fields");
+            String fieldName = PVNames.getFieldName(pvName);
+            if (fieldName != null) {
+                typeInfo = configService.getTypeInfoForPV(PVNames.stripFieldNameFromPVName(pvName));
+                if (typeInfo != null) {
+                    if (Arrays.asList(typeInfo.getArchiveFields()).contains(fieldName)) {
+                        map.put(pvName, "Archived");
+                        continue;
+                    }
+                }
+            }
+            map.put(pvName, "Not Archived");
+        }
+        String[] pvs = new String[map.size()];
+        String[] statuses = new String[map.size()];
+        int counter = 0;
+        for (Entry<String, String> entry : map.entrySet()) {
+            pvs[counter] = entry.getKey();
+            statuses[counter] = entry.getValue();
+            counter++;
+        }
+        try {
+            return PVATable.PVATableBuilder.aPVATable()
+                    .name(NAME)
+                    .addColumn(new PVAStringArray("pv", pvs))
+                    .addColumn(new PVAStringArray("status", statuses))
+                    .build();
+        } catch (MustBeArrayException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/pva/actions/PvaGetPVStatus.java
+++ b/src/main/org/epics/archiverappliance/mgmt/pva/actions/PvaGetPVStatus.java
@@ -20,6 +20,7 @@ import org.epics.pva.data.nt.PVATable;
 
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -93,12 +94,13 @@ public class PvaGetPVStatus implements PvaAction {
     public PVAStructure request(PVAStructure args, ConfigService configService) throws PvaActionException {
         Map<String, String> requestParameters = new HashMap<>();
         PVATable table = PVATable.fromStructure(args);
+        List<String> pvs = List.of();
         if (table != null) {
-            requestParameters.put("pv", String.join(",", NTUtil.extractStringList(table.getColumn("pv"))));
+            pvs = NTUtil.extractStringList(table.getColumn("pv"));
         } else {
             throw new IllegalArgumentException("Only supports request args of type NTURI or NTTable ");
         }
-        LinkedList<String> pvNames = PVsMatchingParameter.getMatchingPVs(requestParameters, configService, true, -1);
+        LinkedList<String> pvNames = PVsMatchingParameter.getMatchingPVs(pvs, null, -1, configService, true);
 
         HashMap<String, Map<String, String>> pvStatuses = new HashMap<String, Map<String, String>>();
         HashMap<String, LinkedList<String>> pvNamesToAskEngineForStatus = new HashMap<String, LinkedList<String>>();

--- a/src/main/org/epics/archiverappliance/mgmt/pva/actions/PvaGetPVStatus.java
+++ b/src/main/org/epics/archiverappliance/mgmt/pva/actions/PvaGetPVStatus.java
@@ -61,89 +61,104 @@ import java.util.Map;
  *
  */
 public class PvaGetPVStatus implements PvaAction {
-	private static final Logger logger = LogManager.getLogger(PvaGetPVStatus.class);
-	
-	public static final String NAME = "PVStatus";
-	
-	/**
-	 * There is a 1-many mapping between the name the user asks for and the internals.
-	 * When sending the data back, we need to take the "real" information and create an entry for each user request.
-	 * This method maintains this list.  
-	 * @param pvNameFromRequest
-	 * @param pvName
-	 * @param realName2NameFromRequest
-	 */
-	private static void addInverseNameMapping(String pvNameFromRequest, String pvName, HashMap<String, LinkedList<String>> realName2NameFromRequest) { 
-		if(!pvName.equals(pvNameFromRequest)) { 
-			if(!realName2NameFromRequest.containsKey(pvName)) { 
-				realName2NameFromRequest.put(pvName, new LinkedList<String>());
-			}
-			realName2NameFromRequest.get(pvName).add(pvNameFromRequest);
-		}
-	}
-	@Override
-	public String getName() {
-		return NAME;
-	}
+    private static final Logger logger = LogManager.getLogger(PvaGetPVStatus.class);
 
-	@SuppressWarnings("unchecked")
-	@Override
-	public PVAStructure request(PVAStructure args, ConfigService configService) throws PvaActionException {
-		Map<String, String> requestParameters = new HashMap<>();
-		PVATable table = PVATable.fromStructure(args);
-		if (table != null) {
-			requestParameters.put("pv", String.join(",",
-					NTUtil.extractStringList(table.getColumn("pv"))));
-		} else {
-			throw new IllegalArgumentException("Only supports request args of type NTURI or NTTable ");
-		}
-		LinkedList<String> pvNames = PVsMatchingParameter.getMatchingPVs(requestParameters, configService, true, -1);
+    public static final String NAME = "PVStatus";
 
-		HashMap<String, Map<String, String>> pvStatuses = new HashMap<String, Map<String, String>>();
-		HashMap<String, LinkedList<String>> pvNamesToAskEngineForStatus = new HashMap<String, LinkedList<String>>();
-		HashMap<String, PVTypeInfo> typeInfosForEngineRequests = new HashMap<String, PVTypeInfo>();
-		HashMap<String, LinkedList<String>> realName2NameFromRequest = new HashMap<String, LinkedList<String>>();
+    /**
+     * There is a 1-many mapping between the name the user asks for and the internals.
+     * When sending the data back, we need to take the "real" information and create an entry for each user request.
+     * This method maintains this list.
+     * @param pvNameFromRequest
+     * @param pvName
+     * @param realName2NameFromRequest
+     */
+    private static void addInverseNameMapping(
+            String pvNameFromRequest, String pvName, HashMap<String, LinkedList<String>> realName2NameFromRequest) {
+        if (!pvName.equals(pvNameFromRequest)) {
+            if (!realName2NameFromRequest.containsKey(pvName)) {
+                realName2NameFromRequest.put(pvName, new LinkedList<String>());
+            }
+            realName2NameFromRequest.get(pvName).add(pvNameFromRequest);
+        }
+    }
 
-		GetPVStatusAction.getPVStatuses(configService, pvNames, pvStatuses, pvNamesToAskEngineForStatus, typeInfosForEngineRequests, realName2NameFromRequest);
+    @Override
+    public String getName() {
+        return NAME;
+    }
 
-		LinkedList<String> pv = new LinkedList<>();
-		LinkedList<String> status = new LinkedList<>();
-		LinkedList<String> appliance = new LinkedList<>();
-		LinkedList<String> connectionState = new LinkedList<>();
-		LinkedList<String> lastEvent = new LinkedList<>();
-		LinkedList<String> samplingPeriod = new LinkedList<>();
-		LinkedList<String> isMonitored = new LinkedList<>();
-		LinkedList<String> connectionFirstEstablished = new LinkedList<>();
-		LinkedList<String> connectionLossRegainCount = new LinkedList<>();
-		LinkedList<String> connectionLastRestablished = new LinkedList<>();
-		pvStatuses.entrySet().stream().sorted(Map.Entry.comparingByKey()).forEachOrdered(entry -> {
-			pv.add(entry.getKey());
-			status.add(entry.getValue().get("status"));
-			appliance.add(entry.getValue().get("appliance"));
-			connectionState.add(entry.getValue().get("connectionState"));
-			lastEvent.add(entry.getValue().get("lastEvent"));
-			samplingPeriod.add(entry.getValue().get("samplingPeriod"));
-			isMonitored.add(entry.getValue().get("isMonitored"));
-			connectionFirstEstablished.add(entry.getValue().get("connectionFirstEstablished"));
-			connectionLossRegainCount.add(entry.getValue().get("connectionLossRegainCount"));
-			connectionLastRestablished.add(entry.getValue().get("connectionLastRestablished"));
-		});
-		try {
-			return PVATable.PVATableBuilder.aPVATable()
-					.name("result")
-					.addColumn(new PVAStringArray("pv", pv.toArray(new String[pv.size()])))
-					.addColumn(new PVAStringArray("status", status.toArray(new String[status.size()])))
-					.addColumn(new PVAStringArray("appliance", appliance.toArray(new String[appliance.size()])))
-					.addColumn(new PVAStringArray("connectionState", connectionState.toArray(new String[connectionState.size()])))
-					.addColumn(new PVAStringArray("lastEvent", lastEvent.toArray(new String[lastEvent.size()])))
-					.addColumn(new PVAStringArray("samplingPeriod", samplingPeriod.toArray(new String[samplingPeriod.size()])))
-					.addColumn(new PVAStringArray("isMonitored", isMonitored.toArray(new String[isMonitored.size()])))
-					.addColumn(new PVAStringArray("connectionFirstEstablished", connectionFirstEstablished.toArray(new String[connectionFirstEstablished.size()])))
-					.addColumn(new PVAStringArray("connectionLossRegainCount", connectionLossRegainCount.toArray(new String[connectionLossRegainCount.size()])))
-					.addColumn(new PVAStringArray("connectionLastRestablished", connectionLastRestablished.toArray(new String[connectionLastRestablished.size()])))
-					.build();
-		} catch (MustBeArrayException e) {
-			throw new ResponseConstructionException(e);
-		}
-	}
+    @SuppressWarnings("unchecked")
+    @Override
+    public PVAStructure request(PVAStructure args, ConfigService configService) throws PvaActionException {
+        Map<String, String> requestParameters = new HashMap<>();
+        PVATable table = PVATable.fromStructure(args);
+        if (table != null) {
+            requestParameters.put("pv", String.join(",", NTUtil.extractStringList(table.getColumn("pv"))));
+        } else {
+            throw new IllegalArgumentException("Only supports request args of type NTURI or NTTable ");
+        }
+        LinkedList<String> pvNames = PVsMatchingParameter.getMatchingPVs(requestParameters, configService, true, -1);
+
+        HashMap<String, Map<String, String>> pvStatuses = new HashMap<String, Map<String, String>>();
+        HashMap<String, LinkedList<String>> pvNamesToAskEngineForStatus = new HashMap<String, LinkedList<String>>();
+        HashMap<String, PVTypeInfo> typeInfosForEngineRequests = new HashMap<String, PVTypeInfo>();
+        HashMap<String, LinkedList<String>> realName2NameFromRequest = new HashMap<String, LinkedList<String>>();
+
+        GetPVStatusAction.getPVStatuses(
+                configService,
+                pvNames,
+                pvStatuses,
+                pvNamesToAskEngineForStatus,
+                typeInfosForEngineRequests,
+                realName2NameFromRequest);
+
+        LinkedList<String> pv = new LinkedList<>();
+        LinkedList<String> status = new LinkedList<>();
+        LinkedList<String> appliance = new LinkedList<>();
+        LinkedList<String> connectionState = new LinkedList<>();
+        LinkedList<String> lastEvent = new LinkedList<>();
+        LinkedList<String> samplingPeriod = new LinkedList<>();
+        LinkedList<String> isMonitored = new LinkedList<>();
+        LinkedList<String> connectionFirstEstablished = new LinkedList<>();
+        LinkedList<String> connectionLossRegainCount = new LinkedList<>();
+        LinkedList<String> connectionLastRestablished = new LinkedList<>();
+        pvStatuses.entrySet().stream().sorted(Map.Entry.comparingByKey()).forEachOrdered(entry -> {
+            pv.add(entry.getKey());
+            status.add(entry.getValue().get("status"));
+            appliance.add(entry.getValue().get("appliance"));
+            connectionState.add(entry.getValue().get("connectionState"));
+            lastEvent.add(entry.getValue().get("lastEvent"));
+            samplingPeriod.add(entry.getValue().get("samplingPeriod"));
+            isMonitored.add(entry.getValue().get("isMonitored"));
+            connectionFirstEstablished.add(entry.getValue().get("connectionFirstEstablished"));
+            connectionLossRegainCount.add(entry.getValue().get("connectionLossRegainCount"));
+            connectionLastRestablished.add(entry.getValue().get("connectionLastRestablished"));
+        });
+        try {
+            return PVATable.PVATableBuilder.aPVATable()
+                    .name("result")
+                    .addColumn(new PVAStringArray("pv", pv.toArray(new String[pv.size()])))
+                    .addColumn(new PVAStringArray("status", status.toArray(new String[status.size()])))
+                    .addColumn(new PVAStringArray("appliance", appliance.toArray(new String[appliance.size()])))
+                    .addColumn(new PVAStringArray(
+                            "connectionState", connectionState.toArray(new String[connectionState.size()])))
+                    .addColumn(new PVAStringArray("lastEvent", lastEvent.toArray(new String[lastEvent.size()])))
+                    .addColumn(new PVAStringArray(
+                            "samplingPeriod", samplingPeriod.toArray(new String[samplingPeriod.size()])))
+                    .addColumn(new PVAStringArray("isMonitored", isMonitored.toArray(new String[isMonitored.size()])))
+                    .addColumn(new PVAStringArray(
+                            "connectionFirstEstablished",
+                            connectionFirstEstablished.toArray(new String[connectionFirstEstablished.size()])))
+                    .addColumn(new PVAStringArray(
+                            "connectionLossRegainCount",
+                            connectionLossRegainCount.toArray(new String[connectionLossRegainCount.size()])))
+                    .addColumn(new PVAStringArray(
+                            "connectionLastRestablished",
+                            connectionLastRestablished.toArray(new String[connectionLastRestablished.size()])))
+                    .build();
+        } catch (MustBeArrayException e) {
+            throw new ResponseConstructionException(e);
+        }
+    }
 }

--- a/src/main/org/epics/archiverappliance/mgmt/staticcontent/js/mgmt.js
+++ b/src/main/org/epics/archiverappliance/mgmt/staticcontent/js/mgmt.js
@@ -30,7 +30,7 @@ function getPVQueryParam() {
   return pvQuery;
 }
 
-var patternForPVNames = /^[a-zA-Z0-9:_\-\+\[\]<>;.\/\,\#\{\}\^]+$/;
+const patternForPVNames = /^[a-zA-Z0-9:_\-+\[\];\/,#{}^<>]+$/;
 // Validates pvNames to make sure they are valid - pattern from CA developers guide.
 function validatePVNames() {
   var pvText = $("#archstatpVNames").val();

--- a/src/main/org/epics/archiverappliance/mgmt/staticcontent/js/mgmt.js
+++ b/src/main/org/epics/archiverappliance/mgmt/staticcontent/js/mgmt.js
@@ -1,3 +1,5 @@
+const archstatpVNames = "#archstatpVNames";
+
 /*******************************************************************************
  * Copyright (c) 2011 The Board of Trustees of the Leland Stanford Junior University
  * as Operator of the SLAC National Accelerator Laboratory.
@@ -9,43 +11,40 @@
 // Convert a list of PVs as typed in the #archstatpVNames textarea into a "pv=CSV" type HTTP argument.
 
 function getPVQueryParam() {
-  var pvText = $("#archstatpVNames").val();
+  const pvText = $(archstatpVNames).val();
   // Check for value, non-zero length and non-blanks
   if (!pvText || 0 === pvText.length || /^\s*$/.test(pvText)) {
     alert("No PVs have been specified.");
     return;
   }
-  var pvS = pvText.split("\n");
-  var pvQuery = new String("pv=");
-  var firstLine = true;
-  for (var i = 0; i < pvS.length; i++) {
+  const pvS = pvText.split("\n");
+  const jsonArray = [];
+
+  for (let i = 0; i < pvS.length; i++) {
     if (!pvS[i] || 0 === pvS[i] || /^\s*$/.test(pvS[i])) continue;
-    if (firstLine) {
-      firstLine = false;
-    } else {
-      pvQuery = pvQuery.concat(",");
-    }
-    pvQuery = pvQuery.concat(encodeURIComponent(pvS[i].trim()));
+    jsonArray.push({ pv: pvS[i].trim() });
   }
-  return pvQuery;
+  return JSON.stringify(jsonArray);
 }
 
 const patternForPVNames = /^[a-zA-Z0-9:_\-+\[\];\/,#{}^<>]+$/;
 // Validates pvNames to make sure they are valid - pattern from CA developers guide.
+// Should match pattern in PVNames.isValidPVName
 function validatePVNames() {
-  var pvText = $("#archstatpVNames").val();
+  const pvText = $(archstatpVNames).val();
   // Check for value, non-zero length and non-blanks
   if (!pvText || 0 === pvText.length || /^\s*$/.test(pvText)) {
     alert("No PVs have been specified for archiving.");
     return false;
   }
 
-  var pvS = pvText.split("\n");
-  var message = new String("The following PV names do not match the CA spec");
-  var errors = false;
-  for (var i = 0; i < pvS.length; i++) {
+  const pvS = pvText.split("\n");
+  let message = String("The following PV names do not match the CA spec");
+  let errors = false;
+  for (let i = 0; i < pvS.length; i++) {
     if (!pvS[i] || 0 === pvS[i] || /^\s*$/.test(pvS[i])) continue;
-    if (!patternForPVNames.test(pvS[i].trim())) {
+    let baseName = pvS[i].split(".", 2)[0];
+    if (!patternForPVNames.test(baseName.trim())) {
       message = message.concat("\n" + pvS[i]);
       errors = true;
     }
@@ -65,16 +64,13 @@ function archivePVs() {
   }
   var pvQuery = getPVQueryParam();
   if (!pvQuery) return;
-  var HTTPMethod = "GET";
-  if (pvQuery.length > 2048) {
-    HTTPMethod = "POST";
-  }
 
   $.ajax({
     url: "../bpl/archivePV",
     dataType: "json",
     data: pvQuery,
-    type: HTTPMethod,
+    type: "POST",
+    contentType: "application/json",
     success: function () {
       checkPVStatus();
     },
@@ -209,10 +205,7 @@ function archivePVsWithDetails() {
 
     var pvQuery = getPVQueryParam();
     if (!pvQuery) return;
-    var HTTPMethod = "GET";
-    if (pvQuery.length > 2048) {
-      HTTPMethod = "POST";
-    }
+    HTTPMethod = "POST";
 
     $.ajax({
       url: "../bpl/archivePV",
@@ -315,17 +308,18 @@ var skipAutoRefresh = false;
 
 // Displays the status of the PVs as typed in the #archstatpVNames textarea in the archstats table.
 function checkPVStatus() {
-  var pvNames = $("#archstatpVNames").val();
+  var pvNames = $(archstatpVNames).val();
   if (sessionStorage && pvNames != null) {
-    sessionStorage["archstatpVNames"] = $("#archstatpVNames").val();
+    sessionStorage["archstatpVNames"] = $(archstatpVNames).val();
   }
 
-  var pvQuery = getPVQueryParam();
+  const pvQuery = getPVQueryParam();
   if (!pvQuery) return;
 
-  var jsonurl = "../bpl/getPVStatus?" + pvQuery + "&reporttype=short";
-  var tabledivname = "archstatsdiv";
-  createReportTable(jsonurl, tabledivname, [
+  const json = pvQuery;
+  let url = "../bpl/getPVStatus?reporttype=short";
+  const tabledivname = "archstatsdiv";
+  createReportTable(json, url, tabledivname, [
     { srcAttr: "pvName", label: "PV Name" },
     {
       srcAttr: "status",
@@ -336,7 +330,7 @@ function checkPVStatus() {
         }
         if (
           curdata.status !== undefined &&
-          curdata.status != "Being archived"
+          curdata.status !== "Being archived"
         ) {
           if (!inRefreshPVStatus) {
             inRefreshPVStatus = true;
@@ -398,18 +392,23 @@ function checkPVStatus() {
 function getPVNames() {
   //http://172.21.225.187:17665/mgmt/bpl/getMatchingPVsForThisAppliance?regex=.*&limit=1000
 
-  var pvNames = $("#archstatpVNames").val();
+  var pvNames = $(archstatpVNames).val();
   if (sessionStorage && pvNames != null) {
-    sessionStorage["archstatpVNames"] = $("#archstatpVNames").val();
+    sessionStorage["archstatpVNames"] = $(archstatpVNames).val();
   }
 
-  var pvQuery = getPVQueryParam();
+  const pvQuery = getPVQueryParam();
   if (!pvQuery) return;
 
-  var jsonurl =
-    "../bpl/getMatchingPVsForThisAppliance?" + pvQuery + "&limit=-1";
-  var tabledivname = "archstatsdiv";
-  createReportTable(jsonurl, tabledivname, [
+  let pvName;
+  if (pvQuery.length > 0) {
+    pvName = pvQuery[0].get("pv");
+  } else {
+    return;
+  }
+  const url = "../bpl/getMatchingPVsForThisAppliance?" + pvName + "&limit=-1";
+  const tabledivname = "archstatsdiv";
+  createReportTable([], url, tabledivname, [
     {
       srcAttr: "pvName",
       label: "PV Name",
@@ -1935,35 +1934,26 @@ function reshardPV() {
 
 // Looks up the PVs in #archstatpVNames text area and then replace the text area with the PV names.
 function lookupPVs() {
-  var pvQuery = getPVQueryParam();
+  const pvQuery = getPVQueryParam();
   if (!pvQuery) return;
 
-  var jsonurl = "../bpl/getPVStatus?" + pvQuery + "&reporttype=short";
-  var components = jsonurl.split("?");
-  var urlalone = components[0];
-  var querystring = "";
-  if (components.length > 1) {
-    querystring = components[1];
-  }
-  var HTTPMethod = "GET";
-  if (jsonurl.length > 2048) {
-    HTTPMethod = "POST";
-  }
+  const url = "../bpl/getPVStatus?reporttype=short";
+  let HTTPMethod = "POST";
 
   $.ajax({
-    url: urlalone,
-    data: querystring,
+    url: url,
+    data: pvQuery,
     type: HTTPMethod,
     dataType: "json",
+    contentType: "application/json",
     success: function (data, textStatus, jqXHR) {
-      $("#archstatpVNames").val("");
-      for (var pvInfo in data) {
-        var newval =
-          $("#archstatpVNames").val() + data[pvInfo]["pvName"] + "\n";
-        $("#archstatpVNames").val(newval);
-        var pvNames = $("#archstatpVNames").val();
+      $(archstatpVNames).val("");
+      for (const pvInfo in data) {
+        var newval = $(archstatpVNames).val() + data[pvInfo]["pvName"] + "\n";
+        $(archstatpVNames).val(newval);
+        var pvNames = $(archstatpVNames).val();
         if (sessionStorage && pvNames != null) {
-          sessionStorage["archstatpVNames"] = $("#archstatpVNames").val();
+          sessionStorage["archstatpVNames"] = $(archstatpVNames).val();
         }
       }
     },
@@ -1979,26 +1969,17 @@ function lookupPVs() {
 }
 
 function pauseMultiplePVs() {
-  var pvQuery = getPVQueryParam();
+  const pvQuery = getPVQueryParam();
   if (!pvQuery) return;
 
-  var jsonurl = "../bpl/pauseArchivingPV?" + pvQuery;
-  var components = jsonurl.split("?");
-  var urlalone = components[0];
-  var querystring = "";
-  if (components.length > 1) {
-    querystring = components[1];
-  }
-  var HTTPMethod = "GET";
-  if (jsonurl.length > 2048) {
-    HTTPMethod = "POST";
-  }
+  const url = "../bpl/pauseArchivingPV";
 
   $.ajax({
-    url: urlalone,
-    data: querystring,
-    type: HTTPMethod,
+    url: url,
+    data: pvQuery,
+    type: "POST",
     dataType: "json",
+    contentType: "application/json",
     success: function (data, textStatus, jqXHR) {
       checkPVStatus();
     },
@@ -2017,23 +1998,15 @@ function deleteMultiplePVs() {
   var pvQuery = getPVQueryParam();
   if (!pvQuery) return;
 
-  var jsonurl = "../bpl/deletePV?" + pvQuery;
-  var components = jsonurl.split("?");
-  var urlalone = components[0];
-  var querystring = "";
-  if (components.length > 1) {
-    querystring = components[1];
-  }
-  var HTTPMethod = "GET";
-  if (jsonurl.length > 2048) {
-    HTTPMethod = "POST";
-  }
+  var url = "../bpl/deletePV";
+  var HTTPMethod = "POST";
 
   $.ajax({
-    url: urlalone,
-    data: querystring,
+    url: url,
+    data: pvQuery,
     type: HTTPMethod,
     dataType: "json",
+    contentType: "application/json",
     success: function (data, textStatus, jqXHR) {
       if (
         data.status != null &&
@@ -2061,26 +2034,18 @@ function deleteMultiplePVs() {
 }
 
 function resumeMultiplePVs() {
-  var pvQuery = getPVQueryParam();
+  const pvQuery = getPVQueryParam();
   if (!pvQuery) return;
 
-  var jsonurl = "../bpl/resumeArchivingPV?" + pvQuery;
-  var components = jsonurl.split("?");
-  var urlalone = components[0];
-  var querystring = "";
-  if (components.length > 1) {
-    querystring = components[1];
-  }
-  var HTTPMethod = "GET";
-  if (jsonurl.length > 2048) {
-    HTTPMethod = "POST";
-  }
+  const url = "../bpl/resumeArchivingPV";
+  const HTTPMethod = "POST";
 
   $.ajax({
-    url: urlalone,
-    data: querystring,
+    url: url,
+    data: pvQuery,
     type: HTTPMethod,
     dataType: "json",
+    contentType: "application/json",
     success: function (data, textStatus, jqXHR) {
       checkPVStatus();
     },

--- a/src/main/org/epics/archiverappliance/mgmt/staticcontent/js/reporttable.js
+++ b/src/main/org/epics/archiverappliance/mgmt/staticcontent/js/reporttable.js
@@ -27,7 +27,7 @@
 // 1) initialSort (optional) - This is the column index of the column to sort the data by after fetching the data from the server.
 // 2) initialSortDirection (optional) - This is the direction of the sort. By default, we do a descending sort. If this attribute has the value 'asc', then we do an ascending sort.
 
-function createReportTable(jsonurl, tabledivname, coldefs, rowdefs) {
+function createReportTable(json, url, tabledivname, coldefs, rowdefs) {
   var reporttablediv = $("#" + tabledivname);
   reporttablediv.empty();
   var reportTable = $(
@@ -59,9 +59,9 @@ function createReportTable(jsonurl, tabledivname, coldefs, rowdefs) {
     )
     .append("<tbody>");
   reportTable.data("coldefs", coldefs);
-  if (rowdefs != null && rowdefs != undefined)
-    reportTable.data("rowdefs", rowdefs);
-  reportTable.data("jsonurl", jsonurl);
+  if (rowdefs != null) reportTable.data("rowdefs", rowdefs);
+  reportTable.data("json", json);
+  reportTable.data("url", url);
   reporttablediv.append(reportTable);
 
   getJSONDataAndRefreshTable(reportTable);
@@ -235,23 +235,17 @@ function addSorterToTableTh(reportTable, indexofthelement) {
 }
 
 function getJSONDataAndRefreshTable(reportTable) {
-  var jsonurl = reportTable.data("jsonurl");
-  var components = jsonurl.split("?");
-  var urlalone = components[0];
-  var querystring = "";
-  if (components.length > 1) {
-    querystring = components[1];
-  }
-  var HTTPMethod = "GET";
-  if (jsonurl.length > 2048) {
-    HTTPMethod = "POST";
-  }
+  const json = reportTable.data("json");
+  const url = reportTable.data("url");
+  const HTTPMethod = "POST";
 
   $.ajax({
-    url: urlalone,
-    data: querystring,
+    url: url,
+    data: json,
     type: HTTPMethod,
     dataType: "json",
+    processData: false,
+    contentType: "application/json",
     success: function (data, textStatus, jqXHR) {
       var coldefs = reportTable.data("coldefs");
       if (coldefs == null) return;

--- a/src/main/org/epics/archiverappliance/retrieval/DataRetrievalServlet.java
+++ b/src/main/org/epics/archiverappliance/retrieval/DataRetrievalServlet.java
@@ -400,7 +400,7 @@ public class DataRetrievalServlet extends HttpServlet {
         String pvNameFromRequest = pvName;
 
         pvName = PVNames.stripPrefixFromName(pvName);
-        pvName = PVNames.normalizePVName(pvName);
+        pvName = PVNames.normalizeChannelName(pvName);
         configService.getRetrievalRuntimeState().updateRetrievalMetrics(pvName, Instant.now(), req.getRemoteAddr());
 
         PVTypeInfo typeInfo = PVNames.determineAppropriatePVTypeInfo(pvName, configService);
@@ -731,7 +731,7 @@ public class DataRetrievalServlet extends HttpServlet {
         // String arrays might be inefficient for retrieval. In any case, they are sorted, which is essential later on.
         List<String> pvNames = null;
         if (req.getMethod().equals("POST")) {
-            pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
+            pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req);
         } else {
             pvNames = Arrays.asList(req.getParameterValues("pv"));
         }

--- a/src/main/org/epics/archiverappliance/retrieval/GetDataAtTime.java
+++ b/src/main/org/epics/archiverappliance/retrieval/GetDataAtTime.java
@@ -22,9 +22,6 @@ import org.epics.archiverappliance.utils.ui.GetUrlContent;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONValue;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.time.Instant;
@@ -37,329 +34,377 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 public class GetDataAtTime {
-	private static final Logger logger = LogManager.getLogger(GetDataAtTime.class);
-	
-	static class Appliance2PVs {
-		ApplianceInfo applianceInfo;
-		LinkedList<String> pvsFromAppliance;
-		LinkedList<String> remainingPVs;
-		HashMap<String, HashMap<String, Object>> pvValues;	
-		Appliance2PVs(ApplianceInfo applianceInfo) {
-			this.applianceInfo = applianceInfo;
-			this.pvsFromAppliance = new LinkedList<String>();
-			this.remainingPVs = new LinkedList<String>();
-			this.pvValues = new HashMap<String, HashMap<String, Object>>();
-		}
-	}
-	
-	@SuppressWarnings("unchecked")
-	private static Appliance2PVs getPVSFromAppliance(Appliance2PVs gatherer, LinkedList<String> pvNames) {
-		try {
-			JSONArray resp = GetUrlContent.postStringListAndGetJSON(gatherer.applianceInfo.getMgmtURL() + "/archivedPVsForThisAppliance", "pv", pvNames);
-			logger.debug("Done calling remote appliance " + gatherer.applianceInfo.getIdentity() + " and got PV count " + resp.size());
-			gatherer.pvsFromAppliance = new LinkedList<String>(resp);
-			gatherer.remainingPVs = new LinkedList<String>(gatherer.pvsFromAppliance);
-		} catch (IOException ex) {
-			logger.error("Exception getting list of PVs from appliance", ex);
-		}
-		return gatherer;
-	}
+    private static final Logger logger = LogManager.getLogger(GetDataAtTime.class);
+
+    static class Appliance2PVs {
+        ApplianceInfo applianceInfo;
+        LinkedList<String> pvsFromAppliance;
+        LinkedList<String> remainingPVs;
+        HashMap<String, HashMap<String, Object>> pvValues;
+
+        Appliance2PVs(ApplianceInfo applianceInfo) {
+            this.applianceInfo = applianceInfo;
+            this.pvsFromAppliance = new LinkedList<String>();
+            this.remainingPVs = new LinkedList<String>();
+            this.pvValues = new HashMap<String, HashMap<String, Object>>();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Appliance2PVs getPVSFromAppliance(Appliance2PVs gatherer, LinkedList<String> pvNames) {
+        try {
+            JSONArray resp = GetUrlContent.postStringListAndGetJSON(
+                    gatherer.applianceInfo.getMgmtURL() + "/archivedPVsForThisAppliance", "pv", pvNames);
+            logger.debug("Done calling remote appliance " + gatherer.applianceInfo.getIdentity() + " and got PV count "
+                    + resp.size());
+            gatherer.pvsFromAppliance = new LinkedList<String>(resp);
+            gatherer.remainingPVs = new LinkedList<String>(gatherer.pvsFromAppliance);
+        } catch (IOException ex) {
+            logger.error("Exception getting list of PVs from appliance", ex);
+        }
+        return gatherer;
+    }
 
     private static Appliance2PVs getDataFromEngine(Appliance2PVs gatherer, Instant atTime) {
-		try {
-			if(gatherer.remainingPVs.size() <= 0) return gatherer;
-			HashMap<String, HashMap<String, Object>> resp = GetUrlContent.postStringListAndGetJSON(gatherer.applianceInfo.getEngineURL() + "/getDataAtTime?at="+TimeUtils.convertToISO8601String(atTime), "pv", gatherer.remainingPVs);
-			if(resp == null) return gatherer;
-			logger.debug("Done calling engine for appliance " + gatherer.applianceInfo.getIdentity() + " and got PV count " + ((resp != null) ? resp.size() : 0));
-			for(String pvName : resp.keySet()) {
-				if(!gatherer.pvValues.containsKey(pvName)) {
-					gatherer.pvValues.put(pvName, resp.get(pvName));
-					gatherer.remainingPVs.remove(pvName);
-				}
-			}
-		} catch (IOException ex) {
-			logger.error("Exception getting data from the engine", ex);
-		}
-		return gatherer;
-	}
+        try {
+            if (gatherer.remainingPVs.size() <= 0) return gatherer;
+            HashMap<String, HashMap<String, Object>> resp = GetUrlContent.postStringListAndGetJSON(
+                    gatherer.applianceInfo.getEngineURL() + "/getDataAtTime?at="
+                            + TimeUtils.convertToISO8601String(atTime),
+                    "pv",
+                    gatherer.remainingPVs);
+            if (resp == null) return gatherer;
+            logger.debug("Done calling engine for appliance " + gatherer.applianceInfo.getIdentity()
+                    + " and got PV count " + ((resp != null) ? resp.size() : 0));
+            for (String pvName : resp.keySet()) {
+                if (!gatherer.pvValues.containsKey(pvName)) {
+                    gatherer.pvValues.put(pvName, resp.get(pvName));
+                    gatherer.remainingPVs.remove(pvName);
+                }
+            }
+        } catch (IOException ex) {
+            logger.error("Exception getting data from the engine", ex);
+        }
+        return gatherer;
+    }
 
     private static Appliance2PVs getDataFromRetrieval(Appliance2PVs gatherer, Instant atTime) {
-		try {
-			if(gatherer.remainingPVs.size() <= 0) return gatherer;
-			HashMap<String, HashMap<String, Object>> resp = GetUrlContent.postStringListAndGetJSON(gatherer.applianceInfo.getRetrievalURL() + "/../data/getDataAtTimeForAppliance?at="+TimeUtils.convertToISO8601String(atTime), "pv", gatherer.remainingPVs);
-			if(resp == null) return gatherer;
-			logger.debug("Done calling retrieval for appliance " + gatherer.applianceInfo.getIdentity() + " and got PV count " + ((resp != null) ? resp.size() : 0));
-			for(String pvName : resp.keySet()) {
-				if(!gatherer.pvValues.containsKey(pvName)) {
-					gatherer.pvValues.put(pvName, resp.get(pvName));
-					gatherer.remainingPVs.remove(pvName);
-				}
-			}
-		} catch (IOException ex) {
-			logger.error("Exception getting data from the retrieval", ex);
-		}
-		return gatherer;
-	}
+        try {
+            if (gatherer.remainingPVs.size() <= 0) return gatherer;
+            HashMap<String, HashMap<String, Object>> resp = GetUrlContent.postStringListAndGetJSON(
+                    gatherer.applianceInfo.getRetrievalURL() + "/../data/getDataAtTimeForAppliance?at="
+                            + TimeUtils.convertToISO8601String(atTime),
+                    "pv",
+                    gatherer.remainingPVs);
+            if (resp == null) return gatherer;
+            logger.debug("Done calling retrieval for appliance " + gatherer.applianceInfo.getIdentity()
+                    + " and got PV count " + ((resp != null) ? resp.size() : 0));
+            for (String pvName : resp.keySet()) {
+                if (!gatherer.pvValues.containsKey(pvName)) {
+                    gatherer.pvValues.put(pvName, resp.get(pvName));
+                    gatherer.remainingPVs.remove(pvName);
+                }
+            }
+        } catch (IOException ex) {
+            logger.error("Exception getting data from the retrieval", ex);
+        }
+        return gatherer;
+    }
 
-    private static HashMap<String, HashMap<String, Object>> getDataFromRemoteArchApplicance(String applianceRetrievalURL, LinkedList<String> remainingPVs, Instant atTime) {
-		try {
-			if(remainingPVs.size() <= 0) { return null; } 
-			HashMap<String, HashMap<String, Object>> resp = GetUrlContent.postStringListAndGetJSON(applianceRetrievalURL + "?at="+TimeUtils.convertToISO8601String(atTime)+"&includeProxies=false", "pv", remainingPVs);
-			if(resp == null) return null;
-			logger.debug("Done calling remote appliance at " + applianceRetrievalURL + " and got PV count " +  + ((resp != null) ? resp.size() : 0));
-			return resp;
-		} catch (Throwable t) {
-			logger.error("Exception getting data from the remote appliance " + applianceRetrievalURL, t);
-		}
-		return null;
-	}
+    private static HashMap<String, HashMap<String, Object>> getDataFromRemoteArchApplicance(
+            String applianceRetrievalURL, LinkedList<String> remainingPVs, Instant atTime) {
+        try {
+            if (remainingPVs.size() <= 0) {
+                return null;
+            }
+            HashMap<String, HashMap<String, Object>> resp = GetUrlContent.postStringListAndGetJSON(
+                    applianceRetrievalURL + "?at=" + TimeUtils.convertToISO8601String(atTime) + "&includeProxies=false",
+                    "pv",
+                    remainingPVs);
+            if (resp == null) return null;
+            logger.debug("Done calling remote appliance at " + applianceRetrievalURL + " and got PV count "
+                    + +((resp != null) ? resp.size() : 0));
+            return resp;
+        } catch (Throwable t) {
+            logger.error("Exception getting data from the remote appliance " + applianceRetrievalURL, t);
+        }
+        return null;
+    }
 
-	
-	
-	private static <T> CompletableFuture<T>[] toArray(List<CompletableFuture<T>> list) {
-		@SuppressWarnings("unchecked")
-		CompletableFuture<T>[] futures = list.toArray(new CompletableFuture[0]);
-		return futures;
-	}
-	
+    private static <T> CompletableFuture<T>[] toArray(List<CompletableFuture<T>> list) {
+        @SuppressWarnings("unchecked")
+        CompletableFuture<T>[] futures = list.toArray(new CompletableFuture[0]);
+        return futures;
+    }
 
-	/**
-	 * The main getDataAtTime function. Pass in a list of PVs and a time. 
-	 * For now, we do not proxy external servers. 
-	 * @param req
-	 * @param resp
-	 * @param configService
-	 * @throws ServletException
-	 * @throws IOException
-	 * @throws InterruptedException
-	 * @throws ExecutionException
-	 */
-	public static void getDataAtTime(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws ServletException, IOException, InterruptedException, ExecutionException {
-		PoorMansProfiler pmansProfiler = new PoorMansProfiler();
+    /**
+     * The main getDataAtTime function. Pass in a list of PVs and a time.
+     * For now, we do not proxy external servers.
+     * @param req
+     * @param resp
+     * @param configService
+     * @throws ServletException
+     * @throws IOException
+     * @throws InterruptedException
+     * @throws ExecutionException
+     */
+    public static void getDataAtTime(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws ServletException, IOException, InterruptedException, ExecutionException {
+        PoorMansProfiler pmansProfiler = new PoorMansProfiler();
 
-		LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
-		String timeStr = req.getParameter("at");
-		if(timeStr == null) {
-			timeStr = TimeUtils.convertToISO8601String(TimeUtils.getCurrentEpochSeconds());
-		}
+        LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
+        String timeStr = req.getParameter("at");
+        if (timeStr == null) {
+            timeStr = TimeUtils.convertToISO8601String(TimeUtils.getCurrentEpochSeconds());
+        }
         Instant atTime = TimeUtils.convertFromISO8601String(timeStr);
-		
-		boolean fetchFromExternalAppliances = req.getParameter("includeProxies") != null && Boolean.parseBoolean(req.getParameter("includeProxies"));		
 
-		pmansProfiler.mark("After request params.");		
+        boolean fetchFromExternalAppliances =
+                req.getParameter("includeProxies") != null && Boolean.parseBoolean(req.getParameter("includeProxies"));
 
-		HashMap<String, Appliance2PVs> valuesGatherer = new HashMap<String, Appliance2PVs>();
-		List<CompletableFuture<Appliance2PVs>> pvBreakdownCalls = new LinkedList<CompletableFuture<Appliance2PVs>>();
-		for(ApplianceInfo applianceInfo : configService.getAppliancesInCluster()) {
-			Appliance2PVs gatherer = new Appliance2PVs(applianceInfo);
-			valuesGatherer.put(applianceInfo.getIdentity(), gatherer);
-			try {
-				pvBreakdownCalls.add(CompletableFuture.supplyAsync(() -> { return getPVSFromAppliance(gatherer, pvNames); } ));
-			} catch(Throwable t) {
-				logger.error("Exception adding completable future", t);
-			}
-		}
-		
-		CompletableFuture.allOf(toArray(pvBreakdownCalls)).join();
-		pmansProfiler.mark("After filtering calls.");
-				
-		List<CompletableFuture<Appliance2PVs>> engineCalls = new LinkedList<CompletableFuture<Appliance2PVs>>();
-		for(ApplianceInfo applianceInfo : configService.getAppliancesInCluster()) {
-			try {
-				engineCalls.add(CompletableFuture.supplyAsync(() -> { return getDataFromEngine(valuesGatherer.get(applianceInfo.getIdentity()), atTime); } ));
-			} catch(Throwable t) {
-				logger.error("Exception adding completable future", t);
-			}
-		}
-		CompletableFuture.allOf(toArray(engineCalls)).join();
-		pmansProfiler.mark("After engine calls.");
+        pmansProfiler.mark("After request params.");
 
-		
-		List<CompletableFuture<Appliance2PVs>> retrievalCalls = new LinkedList<CompletableFuture<Appliance2PVs>>();
-		for(ApplianceInfo applianceInfo : configService.getAppliancesInCluster()) {
-			try {
-				retrievalCalls.add(CompletableFuture.supplyAsync(() -> { return getDataFromRetrieval(valuesGatherer.get(applianceInfo.getIdentity()), atTime); } ));
-			} catch(Throwable t) {
-				logger.error("Exception adding completable future", t);
-			}
-		}
-		CompletableFuture.allOf(toArray(retrievalCalls)).join();
-		pmansProfiler.mark("After retrieval calls.");
-		
-		HashMap<String, HashMap<String, Object>> ret = new HashMap<String, HashMap<String, Object>>();
-		for(CompletableFuture<Appliance2PVs> retcl : retrievalCalls) {
-			Appliance2PVs a2pv = retcl.get();
-			ret.putAll(a2pv.pvValues);
-		}
-		
-		if(fetchFromExternalAppliances) { 
-			Map<String, String> externalServers = configService.getExternalArchiverDataServers();
-			if(externalServers != null) {
-				HashSet<String> pvsForExternalServers = new HashSet<String>(pvNames);
-				pvsForExternalServers.removeAll(ret.keySet());
-				if(pvsForExternalServers.size() > 0) {
-					List<CompletableFuture<HashMap<String, HashMap<String, Object>>>> proxyCalls = new LinkedList<CompletableFuture<HashMap<String, HashMap<String, Object>>>>();				
-					for(String serverUrl : externalServers.keySet()) { 
-						String index = externalServers.get(serverUrl);
-						if(index.equals("pbraw")) { 
-							logger.debug("Adding external EPICS Archiver Appliance " + serverUrl);
-							proxyCalls.add(CompletableFuture.supplyAsync(() -> { return getDataFromRemoteArchApplicance(serverUrl + "/data/getDataAtTime", new LinkedList<String>(pvsForExternalServers), atTime); } ));
-						}
-					}
-					CompletableFuture.allOf(toArray(proxyCalls)).join();				
-					pmansProfiler.mark("After calls to remote appliances.");
-					for(CompletableFuture<HashMap<String, HashMap<String, Object>>> proxyCall : proxyCalls) {
-						HashMap<String, HashMap<String, Object>> res = proxyCall.get();
-						if(res != null && res.size() > 0) {
-							for(String proxyPv : res.keySet()) { 
-								if(!ret.containsKey(proxyPv)) {
-									logger.debug("Adding data for PV from external server " + proxyPv);
-									ret.put(proxyPv, res.get(proxyPv));
-								}
-							}
-						}
-					}
-				} else {
-					logger.debug("Not calling external servers as there are no PV's left in the request.");
-				}
-			}
-		}
-		
-		try(PrintWriter out = resp.getWriter()) {
-			JSONValue.writeJSONString(ret, out);
-		} catch (Exception ex) {
-			logger.error("Exception getting data", ex);
-		}
-		
-		logger.info("Retrieval time for " + pvNames.size() + " PVs at " + timeStr + pmansProfiler.toString());
+        HashMap<String, Appliance2PVs> valuesGatherer = new HashMap<String, Appliance2PVs>();
+        List<CompletableFuture<Appliance2PVs>> pvBreakdownCalls = new LinkedList<CompletableFuture<Appliance2PVs>>();
+        for (ApplianceInfo applianceInfo : configService.getAppliancesInCluster()) {
+            Appliance2PVs gatherer = new Appliance2PVs(applianceInfo);
+            valuesGatherer.put(applianceInfo.getIdentity(), gatherer);
+            try {
+                pvBreakdownCalls.add(CompletableFuture.supplyAsync(() -> {
+                    return getPVSFromAppliance(gatherer, pvNames);
+                }));
+            } catch (Throwable t) {
+                logger.error("Exception adding completable future", t);
+            }
+        }
 
-	}
-	
-	static class PVWithData {
-		String pvName;
-		HashMap<String, Object> sample;
-		public PVWithData(String pvName, HashMap<String, Object> sample) {
-			this.pvName = pvName;
-			this.sample = sample;
-		}
-		
-	}
-	
-	
-	/**
-	 * Async method for getting data for a pv from its list of stores.
-	 * Walk thru the store till you find the closest sample before the requested time. 
-	 * @param pvName
-	 * @param atTime
-	 * @param configService
-	 * @return
-	 */
+        CompletableFuture.allOf(toArray(pvBreakdownCalls)).join();
+        pmansProfiler.mark("After filtering calls.");
+
+        List<CompletableFuture<Appliance2PVs>> engineCalls = new LinkedList<CompletableFuture<Appliance2PVs>>();
+        for (ApplianceInfo applianceInfo : configService.getAppliancesInCluster()) {
+            try {
+                engineCalls.add(CompletableFuture.supplyAsync(() -> {
+                    return getDataFromEngine(valuesGatherer.get(applianceInfo.getIdentity()), atTime);
+                }));
+            } catch (Throwable t) {
+                logger.error("Exception adding completable future", t);
+            }
+        }
+        CompletableFuture.allOf(toArray(engineCalls)).join();
+        pmansProfiler.mark("After engine calls.");
+
+        List<CompletableFuture<Appliance2PVs>> retrievalCalls = new LinkedList<CompletableFuture<Appliance2PVs>>();
+        for (ApplianceInfo applianceInfo : configService.getAppliancesInCluster()) {
+            try {
+                retrievalCalls.add(CompletableFuture.supplyAsync(() -> {
+                    return getDataFromRetrieval(valuesGatherer.get(applianceInfo.getIdentity()), atTime);
+                }));
+            } catch (Throwable t) {
+                logger.error("Exception adding completable future", t);
+            }
+        }
+        CompletableFuture.allOf(toArray(retrievalCalls)).join();
+        pmansProfiler.mark("After retrieval calls.");
+
+        HashMap<String, HashMap<String, Object>> ret = new HashMap<String, HashMap<String, Object>>();
+        for (CompletableFuture<Appliance2PVs> retcl : retrievalCalls) {
+            Appliance2PVs a2pv = retcl.get();
+            ret.putAll(a2pv.pvValues);
+        }
+
+        if (fetchFromExternalAppliances) {
+            Map<String, String> externalServers = configService.getExternalArchiverDataServers();
+            if (externalServers != null) {
+                HashSet<String> pvsForExternalServers = new HashSet<String>(pvNames);
+                pvsForExternalServers.removeAll(ret.keySet());
+                if (pvsForExternalServers.size() > 0) {
+                    List<CompletableFuture<HashMap<String, HashMap<String, Object>>>> proxyCalls =
+                            new LinkedList<CompletableFuture<HashMap<String, HashMap<String, Object>>>>();
+                    for (String serverUrl : externalServers.keySet()) {
+                        String index = externalServers.get(serverUrl);
+                        if (index.equals("pbraw")) {
+                            logger.debug("Adding external EPICS Archiver Appliance " + serverUrl);
+                            proxyCalls.add(CompletableFuture.supplyAsync(() -> {
+                                return getDataFromRemoteArchApplicance(
+                                        serverUrl + "/data/getDataAtTime",
+                                        new LinkedList<String>(pvsForExternalServers),
+                                        atTime);
+                            }));
+                        }
+                    }
+                    CompletableFuture.allOf(toArray(proxyCalls)).join();
+                    pmansProfiler.mark("After calls to remote appliances.");
+                    for (CompletableFuture<HashMap<String, HashMap<String, Object>>> proxyCall : proxyCalls) {
+                        HashMap<String, HashMap<String, Object>> res = proxyCall.get();
+                        if (res != null && res.size() > 0) {
+                            for (String proxyPv : res.keySet()) {
+                                if (!ret.containsKey(proxyPv)) {
+                                    logger.debug("Adding data for PV from external server " + proxyPv);
+                                    ret.put(proxyPv, res.get(proxyPv));
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    logger.debug("Not calling external servers as there are no PV's left in the request.");
+                }
+            }
+        }
+
+        try (PrintWriter out = resp.getWriter()) {
+            JSONValue.writeJSONString(ret, out);
+        } catch (Exception ex) {
+            logger.error("Exception getting data", ex);
+        }
+
+        logger.info("Retrieval time for " + pvNames.size() + " PVs at " + timeStr + pmansProfiler.toString());
+    }
+
+    static class PVWithData {
+        String pvName;
+        HashMap<String, Object> sample;
+
+        public PVWithData(String pvName, HashMap<String, Object> sample) {
+            this.pvName = pvName;
+            this.sample = sample;
+        }
+    }
+
+    /**
+     * Async method for getting data for a pv from its list of stores.
+     * Walk thru the store till you find the closest sample before the requested time.
+     * @param pvName
+     * @param atTime
+     * @param configService
+     * @return
+     */
     private static PVWithData getDataAtTimeForPVFromStores(String pvName, Instant atTime, ConfigService configService) {
-		String nameFromUser = pvName;
+        String nameFromUser = pvName;
         Instant startTime = atTime;
-		String fieldName = PVNames.getFieldName(pvName);
-		
-		PVTypeInfo typeInfo = PVNames.determineAppropriatePVTypeInfo(pvName, configService);
-		if(typeInfo == null) return null;
-		if(!typeInfo.getApplianceIdentity().equals(configService.getMyApplianceInfo().getIdentity())) return null;
+        String fieldName = PVNames.getFieldName(pvName);
 
-		pvName = typeInfo.getPvName();
-		PostProcessor postProcessor = new DefaultRawPostProcessor();
-		if(fieldName != null && Arrays.asList(typeInfo.getArchiveFields()).contains(fieldName)) {
-			startTime = TimeUtils.minusDays(atTime, 1); // We typically write out embedded fields once a day; so go back a day to catch any changes if present.
-			postProcessor = new ExtraFieldsPostProcessor(fieldName);
-		}
+        PVTypeInfo typeInfo = PVNames.determineAppropriatePVTypeInfo(pvName, configService);
+        if (typeInfo == null) return null;
+        if (!typeInfo.getApplianceIdentity()
+                .equals(configService.getMyApplianceInfo().getIdentity())) return null;
 
-		
-		
-		// There is a separate bulk call for the engine; so we can skip the engine. 
-		// Go thru the stores in order...
-		try {
-			DBRTimeEvent potentialEvent = null, dEv = null;
-			for(String store : typeInfo.getDataStores()) {
-				StoragePlugin storagePlugin = StoragePluginURLParser.parseStoragePlugin(store, configService);
-				try(BasicContext context = new BasicContext()) {
-					List<Callable<EventStream>> streams = storagePlugin.getDataForPV(context, pvName, startTime, atTime, postProcessor);
-					if(streams != null) {
-						for(Callable<EventStream> stcl : streams) {
-							try(EventStream stream = stcl.call()) {
-								for(Event e : stream) {
-									dEv = (DBRTimeEvent) e;
-                                    if (dEv.getEventTimeStamp().isBefore(atTime) || dEv.getEventTimeStamp().equals(atTime)) {
-										if(potentialEvent != null) {
+        pvName = typeInfo.getPvName();
+        PostProcessor postProcessor = new DefaultRawPostProcessor();
+        if (fieldName != null && Arrays.asList(typeInfo.getArchiveFields()).contains(fieldName)) {
+            startTime = TimeUtils.minusDays(
+                    atTime,
+                    1); // We typically write out embedded fields once a day; so go back a day to catch any changes if
+            // present.
+            postProcessor = new ExtraFieldsPostProcessor(fieldName);
+        }
+
+        // There is a separate bulk call for the engine; so we can skip the engine.
+        // Go thru the stores in order...
+        try {
+            DBRTimeEvent potentialEvent = null, dEv = null;
+            for (String store : typeInfo.getDataStores()) {
+                StoragePlugin storagePlugin = StoragePluginURLParser.parseStoragePlugin(store, configService);
+                try (BasicContext context = new BasicContext()) {
+                    List<Callable<EventStream>> streams =
+                            storagePlugin.getDataForPV(context, pvName, startTime, atTime, postProcessor);
+                    if (streams != null) {
+                        for (Callable<EventStream> stcl : streams) {
+                            try (EventStream stream = stcl.call()) {
+                                for (Event e : stream) {
+                                    dEv = (DBRTimeEvent) e;
+                                    if (dEv.getEventTimeStamp().isBefore(atTime)
+                                            || dEv.getEventTimeStamp().equals(atTime)) {
+                                        if (potentialEvent != null) {
                                             if (dEv.getEventTimeStamp().isAfter(potentialEvent.getEventTimeStamp())) {
-												potentialEvent = (DBRTimeEvent) dEv.makeClone();							
-											}
-										} else {
-											potentialEvent = dEv;
-										}
-									} else {
-										if(potentialEvent != null) {
-											HashMap<String, Object> evnt = new HashMap<String, Object>();
-											evnt.put("secs", potentialEvent.getEpochSeconds());
-                                            evnt.put("nanos", potentialEvent.getEventTimeStamp().getNano());
-											evnt.put("severity", potentialEvent.getSeverity());
-											evnt.put("status", potentialEvent.getStatus());
-											evnt.put("val", JSONValue.parse(potentialEvent.getSampleValue().toJSONString()));
-											return new PVWithData(nameFromUser, evnt);
-										}
-									}
-								}
-							}
-						}
-					} else {
-						logger.warn("No eventstream when looking for point data for PV " + pvName);
-					}
-				}
-			}
-			if(potentialEvent != null) {
-				HashMap<String, Object> evnt = new HashMap<String, Object>();
-				evnt.put("secs", potentialEvent.getEpochSeconds());
+                                                potentialEvent = (DBRTimeEvent) dEv.makeClone();
+                                            }
+                                        } else {
+                                            potentialEvent = dEv;
+                                        }
+                                    } else {
+                                        if (potentialEvent != null) {
+                                            HashMap<String, Object> evnt = new HashMap<String, Object>();
+                                            evnt.put("secs", potentialEvent.getEpochSeconds());
+                                            evnt.put(
+                                                    "nanos",
+                                                    potentialEvent
+                                                            .getEventTimeStamp()
+                                                            .getNano());
+                                            evnt.put("severity", potentialEvent.getSeverity());
+                                            evnt.put("status", potentialEvent.getStatus());
+                                            evnt.put(
+                                                    "val",
+                                                    JSONValue.parse(potentialEvent
+                                                            .getSampleValue()
+                                                            .toJSONString()));
+                                            return new PVWithData(nameFromUser, evnt);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        logger.warn("No eventstream when looking for point data for PV " + pvName);
+                    }
+                }
+            }
+            if (potentialEvent != null) {
+                HashMap<String, Object> evnt = new HashMap<String, Object>();
+                evnt.put("secs", potentialEvent.getEpochSeconds());
                 evnt.put("nanos", potentialEvent.getEventTimeStamp().getNano());
-				evnt.put("severity", potentialEvent.getSeverity());
-				evnt.put("status", potentialEvent.getStatus());
-				evnt.put("val", JSONValue.parse(potentialEvent.getSampleValue().toJSONString()));
-				return new PVWithData(nameFromUser, evnt);
-			}
-		} catch(Exception ex) {
-			logger.error("Getting data at time for PV " + pvName, ex);
-		}
-		
-		return null;
-	}
-	
-	/**
-	 * Get data at a specified time from the data stores for the specified set of PV's.
-	 * This only returns data for those PV's that are on this appliance.
-	 */
-	public static void getDataAtTimeForAppliance(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws ServletException, IOException, InterruptedException, ExecutionException {
-		LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
-		String timeStr = req.getParameter("at");
-		if(timeStr == null) {
-			timeStr = TimeUtils.convertToISO8601String(TimeUtils.getCurrentEpochSeconds());
-		}
-        Instant atTime = TimeUtils.convertFromISO8601String(timeStr);
-		
-		logger.debug("Getting data from instance for " + pvNames.size() + " PVs at " + TimeUtils.convertToHumanReadableString(atTime));
+                evnt.put("severity", potentialEvent.getSeverity());
+                evnt.put("status", potentialEvent.getStatus());
+                evnt.put("val", JSONValue.parse(potentialEvent.getSampleValue().toJSONString()));
+                return new PVWithData(nameFromUser, evnt);
+            }
+        } catch (Exception ex) {
+            logger.error("Getting data at time for PV " + pvName, ex);
+        }
 
-		List<CompletableFuture<PVWithData>> retrievalCalls = new LinkedList<CompletableFuture<PVWithData>>();
-		for(String pvName : pvNames) {
-			retrievalCalls.add(CompletableFuture.supplyAsync(() -> { return getDataAtTimeForPVFromStores(pvName, atTime, configService); }));
-		}
-		
-		CompletableFuture.allOf(toArray(retrievalCalls)).join();
-		HashMap<String, HashMap<String, Object>> ret = new HashMap<String, HashMap<String, Object>>();
-		for(CompletableFuture<PVWithData> res : retrievalCalls) {
-			PVWithData pd = res.get();
-			if(pd != null) {
-				ret.put(pd.pvName, pd.sample);
-			}
-		}
-		
-		try(PrintWriter out = resp.getWriter()) {
-				JSONValue.writeJSONString(ret, out);
-		}
-	}
+        return null;
+    }
+
+    /**
+     * Get data at a specified time from the data stores for the specified set of PV's.
+     * This only returns data for those PV's that are on this appliance.
+     */
+    public static void getDataAtTimeForAppliance(
+            HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws ServletException, IOException, InterruptedException, ExecutionException {
+        LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
+        String timeStr = req.getParameter("at");
+        if (timeStr == null) {
+            timeStr = TimeUtils.convertToISO8601String(TimeUtils.getCurrentEpochSeconds());
+        }
+        Instant atTime = TimeUtils.convertFromISO8601String(timeStr);
+
+        logger.debug("Getting data from instance for " + pvNames.size() + " PVs at "
+                + TimeUtils.convertToHumanReadableString(atTime));
+
+        List<CompletableFuture<PVWithData>> retrievalCalls = new LinkedList<CompletableFuture<PVWithData>>();
+        for (String pvName : pvNames) {
+            retrievalCalls.add(CompletableFuture.supplyAsync(() -> {
+                return getDataAtTimeForPVFromStores(pvName, atTime, configService);
+            }));
+        }
+
+        CompletableFuture.allOf(toArray(retrievalCalls)).join();
+        HashMap<String, HashMap<String, Object>> ret = new HashMap<String, HashMap<String, Object>>();
+        for (CompletableFuture<PVWithData> res : retrievalCalls) {
+            PVWithData pd = res.get();
+            if (pd != null) {
+                ret.put(pd.pvName, pd.sample);
+            }
+        }
+
+        try (PrintWriter out = resp.getWriter()) {
+            JSONValue.writeJSONString(ret, out);
+        }
+    }
 }

--- a/src/main/org/epics/archiverappliance/retrieval/GetDataAtTime.java
+++ b/src/main/org/epics/archiverappliance/retrieval/GetDataAtTime.java
@@ -157,7 +157,7 @@ public class GetDataAtTime {
             throws ServletException, IOException, InterruptedException, ExecutionException {
         PoorMansProfiler pmansProfiler = new PoorMansProfiler();
 
-        LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
+        LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req);
         String timeStr = req.getParameter("at");
         if (timeStr == null) {
             timeStr = TimeUtils.convertToISO8601String(TimeUtils.getCurrentEpochSeconds());
@@ -377,7 +377,7 @@ public class GetDataAtTime {
     public static void getDataAtTimeForAppliance(
             HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
             throws ServletException, IOException, InterruptedException, ExecutionException {
-        LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req, configService);
+        LinkedList<String> pvNames = PVsMatchingParameter.getPVNamesFromPostBody(req);
         String timeStr = req.getParameter("at");
         if (timeStr == null) {
             timeStr = TimeUtils.convertToISO8601String(TimeUtils.getCurrentEpochSeconds());

--- a/src/main/org/epics/archiverappliance/retrieval/RemotableEventStreamDesc.java
+++ b/src/main/org/epics/archiverappliance/retrieval/RemotableEventStreamDesc.java
@@ -61,7 +61,7 @@ public class RemotableEventStreamDesc extends EventStreamDesc {
     }
 
     public void mergeFrom(PVTypeInfo info, HashMap<String, String> engineMetadata) throws IOException {
-        if (!PVNames.stripFieldNameFromPVName(this.pvName).equals(PVNames.stripFieldNameFromPVName(info.getPvName())))
+        if (!PVNames.channelNamePVName(this.pvName).equals(PVNames.channelNamePVName(info.getPvName())))
             throw new IOException("Mismatch in pv info's. Src is for " + this.pvName + ". Info from config db is for "
                     + info.getPvName());
         this.elementCount = info.getElementCount();

--- a/src/main/org/epics/archiverappliance/retrieval/RemotableEventStreamDesc.java
+++ b/src/main/org/epics/archiverappliance/retrieval/RemotableEventStreamDesc.java
@@ -7,12 +7,9 @@
  *******************************************************************************/
 package org.epics.archiverappliance.retrieval;
 
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
-
+import edu.stanford.slac.archiverappliance.PB.EPICSEvent;
+import edu.stanford.slac.archiverappliance.PB.EPICSEvent.FieldValue;
+import edu.stanford.slac.archiverappliance.PB.EPICSEvent.PayloadInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.EventStreamDesc;
@@ -20,9 +17,10 @@ import org.epics.archiverappliance.config.ArchDBRTypes;
 import org.epics.archiverappliance.config.PVNames;
 import org.epics.archiverappliance.config.PVTypeInfo;
 
-import edu.stanford.slac.archiverappliance.PB.EPICSEvent;
-import edu.stanford.slac.archiverappliance.PB.EPICSEvent.FieldValue;
-import edu.stanford.slac.archiverappliance.PB.EPICSEvent.PayloadInfo;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
 
 /**
  * Information about the whole stream that is often used in generating headers etc...
@@ -30,112 +28,125 @@ import edu.stanford.slac.archiverappliance.PB.EPICSEvent.PayloadInfo;
  *
  */
 public class RemotableEventStreamDesc extends EventStreamDesc {
-	private static Logger logger = LogManager.getLogger(RemotableEventStreamDesc.class.getName());
-	private short year;
-	private int elementCount = 1;
-	private HashMap<String, String> headers = new HashMap<String, String>();
+    private static Logger logger = LogManager.getLogger(RemotableEventStreamDesc.class.getName());
+    private short year;
+    private int elementCount = 1;
+    private HashMap<String, String> headers = new HashMap<String, String>();
 
-	
-	public RemotableEventStreamDesc(ArchDBRTypes archDBRType, String pvName, short year) {
-		super(archDBRType, pvName);
-		this.archDBRType = archDBRType;
-		this.year = year;
-	}
-	
-	public RemotableEventStreamDesc(String pvName, PayloadInfo info) {
-		super(ArchDBRTypes.valueOf(info.getType()), pvName);
-		if(!pvName.equals(info.getPvname())) { 
-			logger.warn("Returning data from PV " + info.getPvname() + " as the data for PV " + pvName);
-		}
-		this.year = (short) info.getYear();
-		if(info.hasElementCount()) this.setElementCount(info.getElementCount());
-		if(info.getHeadersCount() > 0 ) { 
-			for(FieldValue f : info.getHeadersList()) { 
-				this.headers.put(f.getName(), f.getVal());
-			}
-		}
-	}
-	
-	public RemotableEventStreamDesc(RemotableEventStreamDesc other) { 
-		super(other);
-		this.year = other.year;
-		this.elementCount = other.elementCount;
-		this.headers = new HashMap<String, String>(other.headers);
-	}
-	
-	public void mergeFrom(PVTypeInfo info, HashMap<String, String> engineMetadata) throws IOException {
-		if(!PVNames.stripFieldNameFromPVName(this.pvName).equals(PVNames.stripFieldNameFromPVName(info.getPvName()))) throw new IOException("Mismatch in pv info's. Src is for " + this.pvName + ". Info from config db is for " + info.getPvName());
-		this.elementCount = info.getElementCount();
-		if(!this.headers.containsKey("EGU")) { 
-			this.headers.put("EGU", info.getUnits());
-		}
-		if(!this.headers.containsKey("PREC")) { 
-			this.headers.put("PREC", Integer.valueOf((int)info.getPrecision().intValue()).toString());
-		}
+    public RemotableEventStreamDesc(ArchDBRTypes archDBRType, String pvName, short year) {
+        super(archDBRType, pvName);
+        this.archDBRType = archDBRType;
+        this.year = year;
+    }
 
-		// There are cases when we use operators where the DBR type of the PVTypeInfo is not the same as the DBR type of the event stream
-		// So instead of throwing an exception; for now, I am just logging a warning.
-		// Will revisit if lets thru event streams of difference kinds.
-		// if(!this.archDBRType.equals(info.getDBRType())) throw new MismatchedDBRTypeException(info.getPvName(), info.getDBRType(), this.source, this.archDBRType);
-		
-		if(!this.archDBRType.equals(info.getDBRType()))  { 
-			logger.warn("For pv " + this.pvName + " dbr types do not match for stream " + this.source);
-		}
-		
-		if(engineMetadata != null) { 
-			this.headers.putAll(engineMetadata);
-		}
-	}
-	
-	
-	public void mergeInto(PayloadInfo.Builder builder) {
-		if(!this.headers.isEmpty()) { 
-			LinkedList<FieldValue> fieldValuesList = new LinkedList<FieldValue>();
-			for(String fieldName : this.headers.keySet()) {
-				String fieldValue = headers.get(fieldName);
-				if(fieldValue != null && !fieldValue.isEmpty()) { 
-					fieldValuesList.add(EPICSEvent.FieldValue.newBuilder().setName(fieldName).setVal(fieldValue).build());
-				}
-			}
-			builder.addAllHeaders(fieldValuesList);
-		}
-	}
+    public RemotableEventStreamDesc(String pvName, PayloadInfo info) {
+        super(ArchDBRTypes.valueOf(info.getType()), pvName);
+        if (!pvName.equals(info.getPvname())) {
+            logger.warn("Returning data from PV " + info.getPvname() + " as the data for PV " + pvName);
+        }
+        this.year = (short) info.getYear();
+        if (info.hasElementCount()) this.setElementCount(info.getElementCount());
+        if (info.getHeadersCount() > 0) {
+            for (FieldValue f : info.getHeadersList()) {
+                this.headers.put(f.getName(), f.getVal());
+            }
+        }
+    }
 
-	public ArchDBRTypes getArchDBRType() {
-		return archDBRType;
-	}
+    public RemotableEventStreamDesc(RemotableEventStreamDesc other) {
+        super(other);
+        this.year = other.year;
+        this.elementCount = other.elementCount;
+        this.headers = new HashMap<String, String>(other.headers);
+    }
 
-	public void setArchDBRType(ArchDBRTypes archDBRType) {
-		this.archDBRType = archDBRType;
-	}
-	public String getPvName() {
-		return pvName;
-	}
-	public void setPvName(String pvName) {
-		this.pvName = pvName;
-	}
-	public short getYear() {
-		return year;
-	}
-	public void setYear(short year) {
-		this.year = year;
-	}
-	public int getElementCount() {
-		return elementCount;
-	}
-	public void setElementCount(int elementCount) {
-		this.elementCount = elementCount;
-	}
+    public void mergeFrom(PVTypeInfo info, HashMap<String, String> engineMetadata) throws IOException {
+        if (!PVNames.stripFieldNameFromPVName(this.pvName).equals(PVNames.stripFieldNameFromPVName(info.getPvName())))
+            throw new IOException("Mismatch in pv info's. Src is for " + this.pvName + ". Info from config db is for "
+                    + info.getPvName());
+        this.elementCount = info.getElementCount();
+        if (!this.headers.containsKey("EGU")) {
+            this.headers.put("EGU", info.getUnits());
+        }
+        if (!this.headers.containsKey("PREC")) {
+            this.headers.put(
+                    "PREC",
+                    Integer.valueOf((int) info.getPrecision().intValue()).toString());
+        }
 
-	public HashMap<String, String> getHeaders() {
-		return headers;
-	}
-	
-	public void addHeaders(Map<String, String> vals) { 
-		this.headers.putAll(vals);
-	}
-	
-	public void addHeader(String name, String value) { 
-		this.headers.put(name, value);
-	}
+        // There are cases when we use operators where the DBR type of the PVTypeInfo is not the same as the DBR type of
+        // the event stream
+        // So instead of throwing an exception; for now, I am just logging a warning.
+        // Will revisit if lets thru event streams of difference kinds.
+        // if(!this.archDBRType.equals(info.getDBRType())) throw new MismatchedDBRTypeException(info.getPvName(),
+        // info.getDBRType(), this.source, this.archDBRType);
+
+        if (!this.archDBRType.equals(info.getDBRType())) {
+            logger.warn("For pv " + this.pvName + " dbr types do not match for stream " + this.source);
+        }
+
+        if (engineMetadata != null) {
+            this.headers.putAll(engineMetadata);
+        }
+    }
+
+    public void mergeInto(PayloadInfo.Builder builder) {
+        if (!this.headers.isEmpty()) {
+            LinkedList<FieldValue> fieldValuesList = new LinkedList<FieldValue>();
+            for (String fieldName : this.headers.keySet()) {
+                String fieldValue = headers.get(fieldName);
+                if (fieldValue != null && !fieldValue.isEmpty()) {
+                    fieldValuesList.add(EPICSEvent.FieldValue.newBuilder()
+                            .setName(fieldName)
+                            .setVal(fieldValue)
+                            .build());
+                }
+            }
+            builder.addAllHeaders(fieldValuesList);
+        }
+    }
+
+    public ArchDBRTypes getArchDBRType() {
+        return archDBRType;
+    }
+
+    public void setArchDBRType(ArchDBRTypes archDBRType) {
+        this.archDBRType = archDBRType;
+    }
+
+    public String getPvName() {
+        return pvName;
+    }
+
+    public void setPvName(String pvName) {
+        this.pvName = pvName;
+    }
+
+    public short getYear() {
+        return year;
+    }
+
+    public void setYear(short year) {
+        this.year = year;
+    }
+
+    public int getElementCount() {
+        return elementCount;
+    }
+
+    public void setElementCount(int elementCount) {
+        this.elementCount = elementCount;
+    }
+
+    public HashMap<String, String> getHeaders() {
+        return headers;
+    }
+
+    public void addHeaders(Map<String, String> vals) {
+        this.headers.putAll(vals);
+    }
+
+    public void addHeader(String name, String value) {
+        this.headers.put(name, value);
+    }
 }

--- a/src/main/org/epics/archiverappliance/retrieval/bpl/AreWeArchivingPV.java
+++ b/src/main/org/epics/archiverappliance/retrieval/bpl/AreWeArchivingPV.java
@@ -47,7 +47,7 @@ public class AreWeArchivingPV implements BPLAction {
 
         PVTypeInfo typeInfo = configService.getTypeInfoForPV(pvName);
         if (typeInfo == null) {
-            typeInfo = configService.getTypeInfoForPV(PVNames.stripFieldNameFromPVName(pvName));
+            typeInfo = configService.getTypeInfoForPV(PVNames.channelNamePVName(pvName));
             if (typeInfo == null) {
                 retVal.put("status", Boolean.FALSE.toString());
             } else {

--- a/src/main/org/epics/archiverappliance/retrieval/bpl/AreWeArchivingPV.java
+++ b/src/main/org/epics/archiverappliance/retrieval/bpl/AreWeArchivingPV.java
@@ -1,69 +1,67 @@
 package org.epics.archiverappliance.retrieval.bpl;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.HashMap;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.BPLAction;
 import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.config.PVNames;
 import org.epics.archiverappliance.config.PVTypeInfo;
-import org.epics.archiverappliance.retrieval.mimeresponses.MimeResponse;
 import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
 import org.json.simple.JSONValue;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * Send a true/false if we are archiving the given PV or not.
- * <ol> 
+ * <ol>
  * <li>pv - The name of the pv.</li>
  * </ol>
  * @author mshankar
  *
  */
 public class AreWeArchivingPV implements BPLAction {
-	private static Logger logger = LogManager.getLogger(AreWeArchivingPV.class.getName());
+    private static Logger logger = LogManager.getLogger(AreWeArchivingPV.class.getName());
 
-	@Override
-	public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException {
-		String pvName = req.getParameter("pv");
-		logger.debug("Checking to see if we are archiving PV " + pvName);
-		
-		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+    @Override
+    public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws IOException {
+        String pvName = req.getParameter("pv");
+        logger.debug("Checking to see if we are archiving PV " + pvName);
 
-		if(pvName == null || pvName.equals("")) {
-			resp.sendError(HttpServletResponse.SC_NOT_FOUND);
-			return;
-		}
+        resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
 
-		// String pvNameFromRequest = pvName;
-		String realName = configService.getRealNameForAlias(pvName);
-		if(realName != null) pvName = realName;
-		
-		HashMap<String, String> retVal = new HashMap<String, String>();
+        if (pvName == null || pvName.isEmpty()) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
 
-		PVTypeInfo typeInfo = configService.getTypeInfoForPV(pvName);
-		if(typeInfo == null) {
-			typeInfo = configService.getTypeInfoForPV(PVNames.stripFieldNameFromPVName(pvName));
-			if(typeInfo == null) {
-				retVal.put("status", Boolean.FALSE.toString());
-			} else { 
-				retVal.put("status", Boolean.TRUE.toString());
-			}
-		} else { 
-			retVal.put("status", Boolean.TRUE.toString());
-		}
-		
-		
-		try (PrintWriter out = resp.getWriter()) {
-			out.println(JSONValue.toJSONString(retVal));
-		} catch(Exception ex) {
-			logger.error("Exception checking if we are archiving pv " + pvName, ex);
-			resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-		}
-	}
+        // String pvNameFromRequest = pvName;
+        String realName = configService.getRealNameForAlias(pvName);
+        if (realName != null) pvName = realName;
+
+        HashMap<String, String> retVal = new HashMap<String, String>();
+
+        PVTypeInfo typeInfo = configService.getTypeInfoForPV(pvName);
+        if (typeInfo == null) {
+            typeInfo = configService.getTypeInfoForPV(PVNames.stripFieldNameFromPVName(pvName));
+            if (typeInfo == null) {
+                retVal.put("status", Boolean.FALSE.toString());
+            } else {
+                retVal.put("status", Boolean.TRUE.toString());
+            }
+        } else {
+            retVal.put("status", Boolean.TRUE.toString());
+        }
+
+        try (PrintWriter out = resp.getWriter()) {
+            out.println(JSONValue.toJSONString(retVal));
+        } catch (Exception ex) {
+            logger.error("Exception checking if we are archiving pv " + pvName, ex);
+            resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/src/test/org/epics/archiverappliance/config/PVNameRegexTest.java
+++ b/src/test/org/epics/archiverappliance/config/PVNameRegexTest.java
@@ -1,7 +1,13 @@
 package org.epics.archiverappliance.config;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Small unit test to make sure the regex that checks for valid pv names does something reasonable
@@ -10,70 +16,89 @@ import org.junit.jupiter.api.Test;
  */
 public class PVNameRegexTest {
 
-    @Test
-    public void test() {
-        Assertions.assertTrue(!PVNames.isValidPVName(null), "Checking for null pvName failed");
-        Assertions.assertTrue(!PVNames.isValidPVName(""), "Checking for empty pvName failed");
-        String pvName = "";
-        pvName = "archappl:arch:sine";
-        Assertions.assertTrue(PVNames.isValidPVName(pvName), "Valid pvName is deemed invalid " + pvName);
-        pvName = "archappl:arch:sine1";
-        Assertions.assertTrue(PVNames.isValidPVName(pvName), "Valid pvName is deemed invalid " + pvName);
-        pvName = "archappl:arch:sine1.HIHI";
-        Assertions.assertTrue(PVNames.isValidPVName(pvName), "Valid pvName is deemed invalid " + pvName);
-        pvName = "archappl:arch:sine100";
-        Assertions.assertTrue(PVNames.isValidPVName(pvName), "Valid pvName is deemed invalid " + pvName);
-        pvName = "archappl_arch_sine";
-        Assertions.assertTrue(PVNames.isValidPVName(pvName), "Valid pvName is deemed invalid " + pvName);
-        pvName = "archappl-arch-sine";
-        Assertions.assertTrue(PVNames.isValidPVName(pvName), "Valid pvName is deemed invalid " + pvName);
-        pvName = "archappl+arch+sine";
-        Assertions.assertTrue(PVNames.isValidPVName(pvName), "Valid pvName is deemed invalid " + pvName);
-        pvName = "archappl[arch]sine";
-        Assertions.assertTrue(PVNames.isValidPVName(pvName), "Valid pvName is deemed invalid " + pvName);
-        pvName = "archappl<arch>sine";
-        Assertions.assertTrue(PVNames.isValidPVName(pvName), "Valid pvName is deemed invalid " + pvName);
-        pvName = "archappl:arch;sine";
-        Assertions.assertTrue(PVNames.isValidPVName(pvName), "Valid pvName is deemed invalid " + pvName);
-        pvName = "archappl:ar/h:sine";
-        Assertions.assertTrue(PVNames.isValidPVName(pvName), "Valid pvName is deemed invalid " + pvName);
-        // Add for FRIB
-        pvName = "P#6:000357";
-        Assertions.assertTrue(PVNames.isValidPVName(pvName), "Valid pvName is deemed invalid " + pvName);
-        // Add for BNL
-        pvName = "LN-AM{RadMon:1}Lvl:Raw-I";
-        Assertions.assertTrue(PVNames.isValidPVName(pvName), "Valid pvName is deemed invalid " + pvName);
+    private static final List<String> validPVNames = List.of(
+            "archappl:arch:sine",
+            "archappl:arch:sine1",
+            "archappl:arch:sine1",
+            "archappl:arch:sine100",
+            "archappl_arch_sine",
+            "archappl-arch-sine",
+            "archappl+arch+sine",
+            "archappl[arch]sine",
+            "archappl<arch>sine",
+            "archappl:arch;sine",
+            "archappl:ar/h:sine",
+            "P#6:000357",
+            "LN-AM{RadMon:1}Lvl:Raw-I");
 
-        // Let's test some invalid ones
-        pvName = "\"archappl:arch:sine";
-        Assertions.assertTrue(!PVNames.isValidPVName(pvName), "Invalid pvName is deemed valid " + pvName);
-        pvName = "archappl:arch:sine\"";
-        Assertions.assertTrue(!PVNames.isValidPVName(pvName), "Invalid pvName is deemed valid " + pvName);
-        pvName = "archappl:ar'h:sine";
-        Assertions.assertTrue(!PVNames.isValidPVName(pvName), "Invalid pvName is deemed valid " + pvName);
-        pvName = "archappl:ar!h:sine";
-        Assertions.assertTrue(!PVNames.isValidPVName(pvName), "Invalid pvName is deemed valid " + pvName);
-        pvName = "archappl:ar$h:sine";
-        Assertions.assertTrue(!PVNames.isValidPVName(pvName), "Invalid pvName is deemed valid " + pvName);
-        pvName = "archappl:ar%h:sine";
-        Assertions.assertTrue(!PVNames.isValidPVName(pvName), "Invalid pvName is deemed valid " + pvName);
-        pvName = "archappl:ar*h:sine";
-        Assertions.assertTrue(!PVNames.isValidPVName(pvName), "Invalid pvName is deemed valid " + pvName);
-        pvName = "archappl:ar\\h:sine";
-        Assertions.assertTrue(!PVNames.isValidPVName(pvName), "Invalid pvName is deemed valid " + pvName);
-        pvName = "archappl:ar|h:sine";
-        Assertions.assertTrue(!PVNames.isValidPVName(pvName), "Invalid pvName is deemed valid " + pvName);
-        pvName = "archappl:ar'h:sine";
-        Assertions.assertTrue(!PVNames.isValidPVName(pvName), "Invalid pvName is deemed valid " + pvName);
-        pvName = "archappl:ar?h:sine";
-        Assertions.assertTrue(!PVNames.isValidPVName(pvName), "Invalid pvName is deemed valid " + pvName);
-        pvName = "archappl:ar&h:sine";
-        Assertions.assertTrue(!PVNames.isValidPVName(pvName), "Invalid pvName is deemed valid " + pvName);
-        pvName = "archappl:ar@ch:sine";
-        Assertions.assertTrue(!PVNames.isValidPVName(pvName), "Invalid pvName is deemed valid " + pvName);
-        pvName = "archappl:(arch):sine";
-        Assertions.assertTrue(!PVNames.isValidPVName(pvName), "Invalid pvName is deemed valid " + pvName);
-        pvName = "archappl:arch:sine=1.0";
-        Assertions.assertTrue(!PVNames.isValidPVName(pvName), "Invalid pvName is deemed valid " + pvName);
+    private static final String valFieldName = ".VAL";
+    private static final List<String> validFieldNames = List.of(".HIHI", ".LO", "");
+    private static final List<String> validFieldModifiers = List.of(
+            ".{'dbnd':{'abs':1}}",
+            ".{flv('H-GX')}",
+            ".{'dbnd':{'abs':1.5}}",
+            ".{\"dbnd\":{'a':'b',\"s\",'b'}}",
+            ".{'dbnd':{'hi':1.5},'a':{'b':'c'}}",
+            ".[3:5]",
+            "");
+
+    private static Stream<Arguments> provideValidChannelNames() {
+        return validPVNames.stream()
+                .flatMap(pvName -> validFieldNames.stream().map(fieldName -> pvName + fieldName))
+                .flatMap(pvAndFieldName -> validFieldModifiers.stream()
+                        .map(fieldModifier -> Arguments.of(pvAndFieldName + fieldModifier)));
+    }
+    /**
+     * Tests list of pv names valid for the archiver. Larger than the list documented in <a href="https://docs.epics-controls.org/en/latest/appdevguide/databaseDefinition.html#definitions-8">App dev Guide</a>
+     * due to some labs using other characters. {@link PVNames#isValidChannelName}.
+     */
+    @ParameterizedTest
+    @MethodSource("provideValidChannelNames")
+    public void testValidChannelNames(String pvName) {
+        Assertions.assertTrue(PVNames.isValidChannelName(pvName), "Valid pvName is deemed invalid " + pvName);
+        Assertions.assertEquals(pvName, PVNames.normalizeChannelName(pvName));
+    }
+
+    private static Stream<Arguments> providePVNames() {
+        return validPVNames.stream().flatMap(pvName -> validFieldModifiers.stream()
+                .map(fieldModifier -> Arguments.of(pvName, fieldModifier)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("providePVNames")
+    public void testNormalizePVName(String pvName, String fieldModifier) {
+        String channelName = pvName + valFieldName + fieldModifier;
+        Assertions.assertEquals(pvName + fieldModifier, PVNames.normalizeChannelName(channelName));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "\"archappl:arch:sine",
+                "archappl:arch:sine\"",
+                "archappl:ar!h:sine",
+                "archappl:ar$h:sine",
+                "archappl:ar%h:sine",
+                "archappl:ar*h:sine",
+                "archappl:ar\\h:sine",
+                "archappl:ar|h:sine",
+                "archappl:ar?h:sine",
+                "archappl:ar&h:sine",
+                "archappl:ar@ch:sine",
+                "archappl:(arch):sine",
+                "archappl:arch:sine=1.0",
+                "archappl:sine.HI'",
+                "archappl:sine.HI.BOO",
+                "archappl:sine.HI.",
+                "archappl:sine.",
+                "archappl:sine.{",
+                "archappl:sine.}",
+                "archappl:sine.5",
+                ""
+            })
+    public void testInvalidPVNames(String pvName) {
+        Assertions.assertFalse(PVNames.isValidChannelName(pvName), "Invalid pvName is deemed valid " + pvName);
+
+        Assertions.assertFalse(PVNames.isValidChannelName(null), "null is deemed invalid");
     }
 }

--- a/src/test/org/epics/archiverappliance/engine/test/ArchiveFieldsTest.java
+++ b/src/test/org/epics/archiverappliance/engine/test/ArchiveFieldsTest.java
@@ -26,182 +26,232 @@ import org.junit.jupiter.api.Test;
 
 /**
  * test for meta data archiving
- * 
+ *
  * @author Luofeng Li
- * 
+ *
  */
 @Tag("localEpics")
-public class ArchiveFieldsTest  {
-	private static final Logger logger = LogManager.getLogger(ArchiveFieldsTest.class.getName());
-	private SIOCSetup ioc = null;
-	private ConfigServiceForTests testConfigService;
+public class ArchiveFieldsTest {
+    private static final Logger logger = LogManager.getLogger(ArchiveFieldsTest.class.getName());
+    private SIOCSetup ioc = null;
+    private ConfigServiceForTests testConfigService;
     private final String pvPrefix = ArchiveFieldsTest.class.getSimpleName();
 
-	@BeforeEach
-	public void setUp() throws Exception {
-		ioc = new SIOCSetup(pvPrefix);
-		ioc.startSIOCWithDefaultDB();
+    @BeforeEach
+    public void setUp() throws Exception {
+        ioc = new SIOCSetup(pvPrefix);
+        ioc.startSIOCWithDefaultDB();
         testConfigService = new ConfigServiceForTests(-1);
         Thread.sleep(3000);
-	}
+    }
 
-	@AfterEach
-	public void tearDown() throws Exception {
+    @AfterEach
+    public void tearDown() throws Exception {
 
-		testConfigService.shutdownNow();
-		ioc.stopSIOC();
+        testConfigService.shutdownNow();
+        ioc.stopSIOC();
+    }
 
-	}
+    /**
+     * test one pv with meta field. We must make sure the meta fields should be
+     * archived too
+     */
+    @Test
+    public void oneChannelWithMetaField() {
 
+        try {
+            String pvName = pvPrefix + "test_NOADEL";
+            MemBufWriter myWriter = new MemBufWriter(pvName, ArchDBRTypes.DBR_SCALAR_DOUBLE);
+            PVTypeInfo typeInfo = new PVTypeInfo(pvName, ArchDBRTypes.DBR_SCALAR_DOUBLE, true, 1);
+            typeInfo.addArchiveField("HIHI");
+            typeInfo.addArchiveField("LOLO");
+            testConfigService.updateTypeInfoForPV(pvName, typeInfo);
+            testConfigService.registerPVToAppliance(pvName, testConfigService.getMyApplianceInfo());
 
-	/**
-	 * test one pv with meta field. We must make sure the meta fields should be
-	 * archived too
-	 */
-	@Test
-	public void oneChannelWithMetaField() {
+            ArchiveEngine.archivePV(
+                    pvName,
+                    1,
+                    SamplingMethod.MONITOR,
+                    myWriter,
+                    testConfigService,
+                    ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                    null,
+                    typeInfo.getArchiveFields(),
+                    false,
+                    false);
+            Thread.sleep(15 * 1000);
+            testConfigService.getEngineContext().getChannelList().get(pvName).startUpMetaChannels();
+            Thread.sleep(15 * 1000);
+            Assertions.assertFalse(
+                    testConfigService
+                            .getEngineContext()
+                            .getChannelList()
+                            .get(pvName)
+                            .metaChannelsNeedStartingUp(),
+                    "Not emough delay - metafields still need starting up");
+            logger.info("Changing fields");
+            SIOCSetup.caput(pvName + ".HIHI", 80);
+            SIOCSetup.caput(pvName + ".LOLO", 5);
+            Thread.sleep(1000);
+            SIOCSetup.caput(pvName + ".HIHI", 85);
+            SIOCSetup.caput(pvName + ".LOLO", 6);
+            logger.info("Done changing fields");
+            Thread.sleep(30000);
 
-		try {
-			String pvName = pvPrefix + "test_NOADEL";
-			MemBufWriter myWriter = new MemBufWriter(pvName, ArchDBRTypes.DBR_SCALAR_DOUBLE);
-			PVTypeInfo typeInfo = new PVTypeInfo(pvName, ArchDBRTypes.DBR_SCALAR_DOUBLE, true, 1);
-			typeInfo.addArchiveField("HIHI");
-			typeInfo.addArchiveField("LOLO");
-			testConfigService.updateTypeInfoForPV(pvName, typeInfo);
-			testConfigService.registerPVToAppliance(pvName, testConfigService.getMyApplianceInfo());
+            int hihiNum = 0;
+            int loloNUm = 0;
+            int totalEvents = 0;
+            for (Event e : myWriter.getCollectedSamples()) {
+                DBRTimeEvent tempDBRTimeEvent = (DBRTimeEvent) e;
+                String hihiVluue = tempDBRTimeEvent.getFieldValue("HIHI");
+                if (hihiVluue != null) {
+                    hihiNum++;
+                }
 
-			ArchiveEngine.archivePV(pvName, 1, SamplingMethod.MONITOR, myWriter, testConfigService, ArchDBRTypes.DBR_SCALAR_DOUBLE, null, typeInfo.getArchiveFields(), false, false);
-			Thread.sleep(15*1000);
-			testConfigService.getEngineContext().getChannelList().get(pvName).startUpMetaChannels();
-			Thread.sleep(15 * 1000);
-			Assertions.assertFalse(testConfigService.getEngineContext().getChannelList().get(pvName).metaChannelsNeedStartingUp(), "Not emough delay - metafields still need starting up");
-			logger.info("Changing fields");
-			SIOCSetup.caput(pvName + ".HIHI", 80);
-			SIOCSetup.caput(pvName + ".LOLO", 5);
-			Thread.sleep(1000);
-			SIOCSetup.caput(pvName + ".HIHI", 85);
-			SIOCSetup.caput(pvName + ".LOLO", 6);
-			logger.info("Done changing fields");
-			Thread.sleep(30000);
+                String loloVluue = tempDBRTimeEvent.getFieldValue("LOLO");
+                if (loloVluue != null) {
+                    loloNUm++;
+                }
+                totalEvents++;
+            }
+            Assertions.assertTrue(totalEvents >= 2, "We should have some events in the current samples " + totalEvents);
+            Assertions.assertTrue(
+                    hihiNum >= 2,
+                    "the number of value for test_0.HIHI num is " + hihiNum + " and <3 and" + "it should be >=3");
+            Assertions.assertTrue(
+                    loloNUm >= 2,
+                    "the number of value for test_0.LOLO num is " + loloNUm + " and <3 and" + "it should be >=3");
+            Thread.sleep(3000);
 
-			int hihiNum = 0;
-			int loloNUm = 0;
-			int totalEvents = 0;
-			for (Event e : myWriter.getCollectedSamples()) {
-				DBRTimeEvent tempDBRTimeEvent = (DBRTimeEvent) e;
-				String hihiVluue = tempDBRTimeEvent.getFieldValue("HIHI");
-				if (hihiVluue != null) {
-					hihiNum++;
-				}
+        } catch (Exception e) {
+            //
+            Assertions.fail(e.getMessage());
+            logger.error("Exception", e);
+        }
+    }
 
-				String loloVluue = tempDBRTimeEvent.getFieldValue("LOLO");
-				if (loloVluue != null) {
-					loloNUm++;
-				}
-				totalEvents++;
-			}
-			Assertions.assertTrue(totalEvents >= 2, "We should have some events in the current samples " + totalEvents);
-			Assertions.assertTrue(hihiNum >= 2, "the number of value for test_0.HIHI num is " + hihiNum
-					+ " and <3 and" + "it should be >=3");
-			Assertions.assertTrue(loloNUm >= 2, "the number of value for test_0.LOLO num is " + loloNUm
-					+ " and <3 and" + "it should be >=3");
-			Thread.sleep(3000);
+    /**
+     * test one pv with meta field.this pv and the meta fields are controlled by
+     * another pv to start or stop archiving. We must make sure when the pv is
+     * stopped or started archiving ,all the meta field should be stopped or
+     * stated at the same time
+     */
+    @Test
+    public void oneChannelWithMetaFieldWithControlPv() {
 
-		} catch (Exception e) {
-			//
-			Assertions.fail(e.getMessage());
-			logger.error("Exception", e);
-		}
-	}
+        try {
+            String pvName = pvPrefix + "test_1";
 
-	/**
-	 * test one pv with meta field.this pv and the meta fields are controlled by
-	 * another pv to start or stop archiving. We must make sure when the pv is
-	 * stopped or started archiving ,all the meta field should be stopped or
-	 * stated at the same time
-	 */
-	@Test
-	public void oneChannelWithMetaFieldWithControlPv() {
+            MemBufWriter myWriter = new MemBufWriter(pvName, ArchDBRTypes.DBR_SCALAR_DOUBLE);
 
-		try {
-			String pvName = pvPrefix + "test_1";
+            String controlPVName = pvPrefix + "test:enable0";
+            SIOCSetup.caput(controlPVName, 1);
+            Thread.sleep(3000);
+            String[] metaFields = {"HIHI", "LOLO"};
+            PVTypeInfo typeInfo = new PVTypeInfo(pvName, ArchDBRTypes.DBR_SCALAR_DOUBLE, true, 1);
+            typeInfo.setSamplingMethod(SamplingMethod.SCAN);
+            typeInfo.setSamplingPeriod(20);
+            typeInfo.setDataStores(new String[] {"blackhole://localhost"});
+            typeInfo.setArchiveFields(metaFields);
+            typeInfo.setControllingPV(controlPVName);
+            testConfigService.updateTypeInfoForPV(pvName, typeInfo);
+            ArchiveEngine.archivePV(
+                    pvName,
+                    1,
+                    SamplingMethod.SCAN,
+                    myWriter,
+                    testConfigService,
+                    ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                    null,
+                    controlPVName,
+                    metaFields,
+                    null,
+                    false,
+                    false);
+            Thread.sleep(10 * 1000);
+            testConfigService.getEngineContext().getChannelList().get(pvName).startUpMetaChannels();
+            Thread.sleep(10 * 1000);
+            Assertions.assertFalse(
+                    testConfigService
+                            .getEngineContext()
+                            .getChannelList()
+                            .get(pvName)
+                            .metaChannelsNeedStartingUp(),
+                    "Not emough delay - metafields still need starting up");
+            ArchiveChannel archiveChannel =
+                    testConfigService.getEngineContext().getChannelList().get(pvName);
 
-			MemBufWriter myWriter = new MemBufWriter(pvName, ArchDBRTypes.DBR_SCALAR_DOUBLE);
-
-			String controlPVName = pvPrefix + "test:enable0";
-			SIOCSetup.caput(controlPVName, 1);
-			Thread.sleep(3000);
-			String[] metaFields = { "HIHI", "LOLO" };
-			PVTypeInfo typeInfo = new PVTypeInfo(pvName,ArchDBRTypes.DBR_SCALAR_DOUBLE, true, 1);
-			typeInfo.setSamplingMethod(SamplingMethod.SCAN);
-			typeInfo.setSamplingPeriod(20);
-			typeInfo.setDataStores(new String[] {"blackhole://localhost"});
-			typeInfo.setArchiveFields(metaFields);
-			typeInfo.setControllingPV(controlPVName);
-			testConfigService.updateTypeInfoForPV(pvName, typeInfo);
-			ArchiveEngine.archivePV(pvName, 1, SamplingMethod.SCAN, myWriter,
-					testConfigService, ArchDBRTypes.DBR_SCALAR_DOUBLE, null,
-					controlPVName, metaFields, null, false, false);
-			Thread.sleep(10 * 1000);
-			testConfigService.getEngineContext().getChannelList().get(pvName).startUpMetaChannels();
-			Thread.sleep(10 * 1000);
-			Assertions.assertFalse(testConfigService.getEngineContext().getChannelList().get(pvName).metaChannelsNeedStartingUp(), "Not emough delay - metafields still need starting up");
-			ArchiveChannel archiveChannel = testConfigService
-					.getEngineContext().getChannelList().get(pvName);
-
-			boolean samplesExist = !myWriter.getCollectedSamples().isEmpty();
-			boolean result = archiveChannel.isConnected()
-					&& samplesExist;
+            boolean samplesExist = !myWriter.getCollectedSamples().isEmpty();
+            boolean result = archiveChannel.isConnected() && samplesExist;
             Assertions.assertTrue(result, pvName + "is not started successfully and it shoule be started successfully");
 
-			for (String metaFieldTemp : metaFields) {
-				String pvNameTemp = pvName + "." + metaFieldTemp;
-				Assertions.assertTrue(archiveChannel.isMetaPVConnected(metaFieldTemp), "the channel for " + pvNameTemp + " should be created and connected but it is not");
+            for (String metaFieldTemp : metaFields) {
+                String pvNameTemp = pvName + "." + metaFieldTemp;
+                Assertions.assertTrue(
+                        archiveChannel.isMetaPVConnected(metaFieldTemp),
+                        "the channel for " + pvNameTemp + " should be created and connected but it is not");
+            }
+            Thread.sleep(10 * 1000);
+            SIOCSetup.caput(controlPVName, 0);
+            testConfigService.getEngineContext().getWriteThead().flushBuffer();
+            Thread.sleep(10 * 1000);
+            archiveChannel =
+                    testConfigService.getEngineContext().getChannelList().get(pvName);
+            Assertions.assertTrue(
+                    archiveChannel == null || !archiveChannel.isConnected(),
+                    pvName + "is not stopped successfully and it should be stopped successfully");
+            Assertions.assertTrue(
+                    archiveChannel == null
+                            || archiveChannel
+                                    .getSampleBuffer()
+                                    .getCurrentSamples()
+                                    .isEmpty(),
+                    pvName + "should not have any data");
 
-			}
-			Thread.sleep(10 * 1000);
-			SIOCSetup.caput(controlPVName, 0);
-			testConfigService.getEngineContext().getWriteThead().flushBuffer();
-			Thread.sleep(10 * 1000);
-			archiveChannel = testConfigService.getEngineContext().getChannelList().get(pvName);
-			Assertions.assertTrue(archiveChannel == null || !archiveChannel.isConnected(), pvName + "is not stopped successfully and it should be stopped successfully");
-			Assertions.assertTrue(archiveChannel == null || archiveChannel.getSampleBuffer().getCurrentSamples().isEmpty(), pvName + "should not have any data");
+            if (archiveChannel != null) {
+                for (String metaFieldTemp : metaFields) {
+                    String pvNameTemp = pvName + "." + metaFieldTemp;
+                    Assertions.assertFalse(
+                            archiveChannel.isMetaPVConnected(metaFieldTemp),
+                            "the channel for " + pvNameTemp + " should be not connected but it is ");
+                }
+            }
 
-			if(archiveChannel != null) { 
-				for (String metaFieldTemp : metaFields) {
-					String pvNameTemp = pvName + "." + metaFieldTemp;
-					Assertions.assertFalse(archiveChannel.isMetaPVConnected(metaFieldTemp), "the channel for " + pvNameTemp
-							+ " should be not connected but it is ");
-				}
-			}
+            Thread.sleep(10 * 1000);
+            SIOCSetup.caput(controlPVName, 1);
+            Thread.sleep(10 * 1000);
+            archiveChannel =
+                    testConfigService.getEngineContext().getChannelList().get(pvName);
+            Assertions.assertNotNull(
+                    archiveChannel,
+                    "After resuming the control channel, the archive channel for pv " + pvName + " is still null");
+            boolean result3 = archiveChannel.isConnected();
+            Assertions.assertTrue(
+                    result3, pvName + "is not started successfully and it should be started successfully");
 
-			Thread.sleep(10 * 1000);
-			SIOCSetup.caput(controlPVName, 1);
-			Thread.sleep(10 * 1000);
-			archiveChannel = testConfigService.getEngineContext().getChannelList().get(pvName);
-			Assertions.assertNotNull(archiveChannel, "After resuming the control channel, the archive channel for pv " + pvName + " is still null");
-			boolean result3 = archiveChannel.isConnected();
-			Assertions.assertTrue(result3, pvName
-					+ "is not started successfully and it should be started successfully");
-			
-			Thread.sleep(15*1000);
-			testConfigService.getEngineContext().getChannelList().get(pvName).startUpMetaChannels();
-			Thread.sleep(15 * 1000);
-			Assertions.assertFalse(testConfigService.getEngineContext().getChannelList().get(pvName).metaChannelsNeedStartingUp(), "Not emough delay - metafields still need starting up");
+            Thread.sleep(15 * 1000);
+            testConfigService.getEngineContext().getChannelList().get(pvName).startUpMetaChannels();
+            Thread.sleep(15 * 1000);
+            Assertions.assertFalse(
+                    testConfigService
+                            .getEngineContext()
+                            .getChannelList()
+                            .get(pvName)
+                            .metaChannelsNeedStartingUp(),
+                    "Not emough delay - metafields still need starting up");
 
-			// check meta field is not connected
-			for (String metaFieldTemp : metaFields) {
-				String pvNameTemp = pvName + "." + metaFieldTemp;
-				Assertions.assertTrue(archiveChannel.isMetaPVConnected(metaFieldTemp), "the channel for " + pvNameTemp
-						+ " should be reconnected but it is  not");
+            // check meta field is not connected
+            for (String metaFieldTemp : metaFields) {
+                String pvNameTemp = pvName + "." + metaFieldTemp;
+                Assertions.assertTrue(
+                        archiveChannel.isMetaPVConnected(metaFieldTemp),
+                        "the channel for " + pvNameTemp + " should be reconnected but it is  not");
+            }
 
-			}
-
-		} catch (Exception e) {
-			//
-			Assertions.fail(e.getMessage());
-			logger.error("Exception", e);
-		}
-	}
-
+        } catch (Exception e) {
+            //
+            Assertions.fail(e.getMessage());
+            logger.error("Exception", e);
+        }
+    }
 }

--- a/src/test/org/epics/archiverappliance/mgmt/DbdArchiveTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/DbdArchiveTest.java
@@ -1,0 +1,98 @@
+package org.epics.archiverappliance.mgmt;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.epics.archiverappliance.Event;
+import org.epics.archiverappliance.EventStream;
+import org.epics.archiverappliance.SIOCSetup;
+import org.epics.archiverappliance.TomcatSetup;
+import org.epics.archiverappliance.config.ConfigServiceForTests;
+import org.epics.archiverappliance.retrieval.client.RawDataRetrievalAsEventStream;
+import org.epics.archiverappliance.utils.ui.GetUrlContent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+
+import static org.epics.archiverappliance.engine.V4.PVAccessUtil.waitForStatusChange;
+
+@Tag("integration")
+public class DbdArchiveTest {
+    private static final Logger logger = LogManager.getLogger(DbdArchiveTest.class.getName());
+    private static final TomcatSetup tomcatSetup = new TomcatSetup();
+    private SIOCSetup ioc = null;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        ioc = new SIOCSetup();
+        ioc.startSIOCWithDefaultDB();
+
+        tomcatSetup.setUpWebApps(DbdArchiveTest.class.getSimpleName());
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+
+        tomcatSetup.tearDown();
+        ioc.stopSIOC();
+    }
+
+    /**
+     * test one pv with meta field. We must make sure the meta fields should be
+     * archived too
+     */
+    @Test
+    public void testArchiveFilterPV() {
+
+        try {
+            String pvName = "ArchUnitTest:manual";
+            String filter = ".{'dbnd':{'abs':0.1}}";
+            String fullPVName = pvName + filter;
+
+            String pvURLName = URLEncoder.encode(fullPVName, StandardCharsets.UTF_8);
+
+            Instant firstInstant = Instant.now();
+
+            SIOCSetup.caput(pvName, 0);
+            // Archive PV
+            String mgmtUrl = "http://localhost:17665/mgmt/bpl/";
+            String archivePVURL = mgmtUrl + "archivePV?pv=";
+
+            GetUrlContent.getURLContentAsJSONArray(archivePVURL + pvURLName);
+            waitForStatusChange(fullPVName, "Being archived", 60, mgmtUrl, 10);
+
+            SIOCSetup.caput(pvName, 0);
+            SIOCSetup.caput(pvName, 0.1);
+            SIOCSetup.caput(pvName, 0.15);
+            SIOCSetup.caput(pvName, 1.0);
+            SIOCSetup.caput(pvName, 1.05);
+            SIOCSetup.caput(pvName, 1.06);
+
+            Instant end = Instant.now();
+            RawDataRetrievalAsEventStream rawDataRetrieval = new RawDataRetrievalAsEventStream(
+                    "http://localhost:" + ConfigServiceForTests.RETRIEVAL_TEST_PORT + "/retrieval/data/getData.raw");
+            EventStream stream = rawDataRetrieval.getDataForPVS(
+                    new String[] {pvURLName},
+                    firstInstant,
+                    end,
+                    desc -> logger.info("Getting data for PV " + desc.getPvName()));
+
+            int totalEvents = 0;
+            for (Event e : stream) {
+                logger.info("event " + e.getSampleValue().toString());
+                totalEvents++;
+            }
+            Assertions.assertEquals(3, totalEvents, "We should have some events in the current samples " + totalEvents);
+
+        } catch (Exception e) {
+            //
+            Assertions.fail(e.getMessage());
+            logger.error("Exception", e);
+        }
+    }
+}


### PR DESCRIPTION
### Allow usage of field Modifiers.

Essentially allows the archiving of pvs, or channels with path "pvName.fieldName.fieldModifier". Field Modifiers are documented at https://epics.anl.gov/base/R7-0/8-docs/filters.html . 

Examples of Field Modifiers are Channel Filters, such as 

PVNAME.{'dbnd':{'rel':0.1}}

Which filters all changes that have a change < 0.1 from being sent along the connection.

Fixes #192 

### Implementation notes: 

Have to update 3 main places.

PVNames.java now splits up a channel name into a pvName, Field and FieldModifier. Then uses these to check a channelName is valid, or if it is a field channel.

PVsMatchingParameter is refactored to simplify and becomes the main place to handle multiple pvs as input to a BPLAction. In addition a new api accepting a list of pvs of the form [{"pv": "pvName"}, {"pv": "pvName2"}], this is to allow fieldModifiers with "," character. Which would have failed using the www-form-encoded input api.

mgmt.js and reportable.js are then updated to use the new json api, to support channel names with field modifiers.

### Note
Note the filters support many different special characters. So filenames may be strange.