### PR TITLE
Fixes a bug in SummaryStatsPostProcessor

### DIFF
--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/SummaryStatsPostProcessor.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/SummaryStatsPostProcessor.java
@@ -12,7 +12,6 @@ import org.epics.archiverappliance.data.DBRTimeEvent;
 import org.epics.archiverappliance.engine.membuf.ArrayListEventStream;
 import org.epics.archiverappliance.retrieval.RemotableEventStreamDesc;
 
-import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.HashMap;
@@ -20,6 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Callable;
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * Abstract class for various operators that operate on a SummaryStatistics
@@ -27,285 +27,330 @@ import java.util.concurrent.Callable;
  * @author mshankar
  *
  */
-public abstract class SummaryStatsPostProcessor implements PostProcessor, PostProcessorWithConsolidatedEventStream, FillNoFillSupport {
-	@Override
-	public abstract String getIdentity();
-	public abstract SummaryStatsCollector getCollector();
-	
-	/**
-	 * @return true if this post processor is providing an array (list) of data, or false if a single value is provided 
-	 */
-	public boolean isProvidingVectorData() {
-	    return false;
-	}
-	
-	/**
-	 * @return the number of elements per sample that this post processor provides
-	 */
-	public int getElementCount() {
-	    return 1;
-	}
+public abstract class SummaryStatsPostProcessor
+        implements PostProcessor, PostProcessorWithConsolidatedEventStream, FillNoFillSupport {
+    @Override
+    public abstract String getIdentity();
 
+    public abstract SummaryStatsCollector getCollector();
 
-	private Instant start;
-	private Instant end;
+    /**
+     * @return true if this post processor is providing an array (list) of data, or false if a single value is provided
+     */
+    public boolean isProvidingVectorData() {
+        return false;
+    }
 
-	private static Logger logger = LogManager.getLogger(SummaryStatsPostProcessor.class.getName());
-	int intervalSecs = PostProcessors.DEFAULT_SUMMARIZING_INTERVAL;
+    /**
+     * @return the number of elements per sample that this post processor provides
+     */
+    public int getElementCount() {
+        return 1;
+    }
+
+    private Instant start;
+    private Instant end;
+
+    private static Logger logger = LogManager.getLogger(SummaryStatsPostProcessor.class.getName());
+    int intervalSecs = PostProcessors.DEFAULT_SUMMARIZING_INTERVAL;
     private Instant previousEventTimestamp = Instant.ofEpochMilli(1);
-	
-	static class SummaryValue { 
-		/**
-		 * The summary value
-		 */
-		double value;
-		/**
-		 * Maximize severity
-		 */
-		int severity;
-		/**
-		 * Do we have any connection changed events
-		 */
-		boolean connectionChanged;
-		
-		HashMap<String, String> additionalCols = null;
-		
+
+    static class SummaryValue {
+        /**
+         * The summary value
+         */
+        double value;
+        /**
+         * Maximize severity
+         */
+        int severity;
+        /**
+         * Do we have any connection changed events
+         */
+        boolean connectionChanged;
+
+        HashMap<String, String> additionalCols = null;
+
         /**
          * Summary values
          */
         List<Double> values;
 
-		public SummaryValue(double value, int severity, boolean connectionChanged) {
-			this.value = value;
-			this.severity = severity;
-			this.connectionChanged = connectionChanged;
-		}
+        public SummaryValue(double value, int severity, boolean connectionChanged) {
+            this.value = value;
+            this.severity = severity;
+            this.connectionChanged = connectionChanged;
+        }
 
-		public SummaryValue(List<Double> values, int severity, boolean connectionChanged) {
-		    this.values = values;
-		    this.value = Double.NaN;
-		    this.severity = severity;
-		    this.connectionChanged = connectionChanged;
-		}		
-		
-		public void addAdditionalColumn(HashMap<String, String> additionalColumns) {
-			for(String name : additionalColumns.keySet()) { 
-				String value = additionalColumns.get(name);
-				if(this.additionalCols == null) { 
-					this.additionalCols = new HashMap<String, String>();
-				}
-				this.additionalCols.put(name,  value);
-			}
-		}
-	}
+        public SummaryValue(List<Double> values, int severity, boolean connectionChanged) {
+            this.values = values;
+            this.value = Double.NaN;
+            this.severity = severity;
+            this.connectionChanged = connectionChanged;
+        }
 
-	protected LinkedHashMap<Long, SummaryValue> consolidatedData = new LinkedHashMap<Long, SummaryValue>();
-	long firstBin = 0;
-	long lastBin = Long.MAX_VALUE;
-	long currentBin = -1;
-	int currentMaxSeverity = 0;
-	boolean currentConnectionChangedEvents = false;
-	SummaryStatsCollector currentBinCollector = null;
-	RemotableEventStreamDesc srcDesc = null;
-	private boolean inheritValuesFromPreviousBins = true;
-	Event lastSampleBeforeStart = null;
-	boolean lastSampleBeforeStartAdded = false;
-	
-	@Override
-	public void initialize(String userarg, String pvName) throws IOException {
-		if(userarg != null && userarg.contains("_")) {
-			String[] userparams = userarg.split("_");
-			String intervalStr = userparams[1];
-			intervalSecs = Integer.parseInt(intervalStr);
-			logger.debug("Using use supplied interval of " + intervalSecs);
-		} else {
-			logger.debug("Using the default interval of  " + intervalSecs + " as the user has not specified the interval argument.");
-		}
-	}
-	
-	
+        public void addAdditionalColumn(HashMap<String, String> additionalColumns) {
+            for (String name : additionalColumns.keySet()) {
+                String value = additionalColumns.get(name);
+                if (this.additionalCols == null) {
+                    this.additionalCols = new HashMap<String, String>();
+                }
+                this.additionalCols.put(name, value);
+            }
+        }
+    }
 
-	@Override
-    public long estimateMemoryConsumption(String pvName, PVTypeInfo typeInfo, Instant start, Instant end, HttpServletRequest req) {
-		this.start = start;
-		this.end = end;
-		firstBin = TimeUtils.convertToEpochSeconds(start)/intervalSecs;
-		lastBin = TimeUtils.convertToEpochSeconds(end)/intervalSecs;
-		logger.debug("Expecting " + lastBin + " - " + firstBin + " values " + (lastBin+2 - firstBin)); // Add 2 for the first and last bins..
-		float storageRate = typeInfo.getComputedStorageRate();
-		long numSeconds = TimeUtils.convertToEpochSeconds(end) - TimeUtils.convertToEpochSeconds(start);
-		// Add a fudge factor of 2 for java 
-		long estimatedMemoryConsumption = (long) (storageRate*numSeconds*2/intervalSecs);
-		return estimatedMemoryConsumption;
-	}
+    protected LinkedHashMap<Long, SummaryValue> consolidatedData = new LinkedHashMap<Long, SummaryValue>();
+    long firstBin = 0;
+    long lastBin = Long.MAX_VALUE;
+    long currentBin = -1;
+    int currentMaxSeverity = 0;
+    boolean currentConnectionChangedEvents = false;
+    SummaryStatsCollector currentBinCollector = null;
+    RemotableEventStreamDesc srcDesc = null;
+    private boolean inheritValuesFromPreviousBins = true;
+    Event lastSampleBeforeStart = null;
+    boolean lastSampleBeforeStartAdded = false;
 
-	@Override
-	public Callable<EventStream> wrap(final Callable<EventStream> callable) {
-	    final boolean vectorType = isProvidingVectorData();
-	    final int elementCount = getElementCount();
-		return new Callable<EventStream>() {
-			@Override
-			public EventStream call() throws Exception {
-				try(EventStream strm = callable.call()) {
-					// If we cache the mean/sigma etc, then we should add something to the desc telling us that this is cached data and then we can replace the stat value for that bin?
-					if(srcDesc == null) srcDesc = (RemotableEventStreamDesc) strm.getDescription();
-					boolean shouldAddLastSampleBeforeStart = true;
-					for(Event e : strm) {
-						try { 
-							DBRTimeEvent dbrTimeEvent = (DBRTimeEvent) e;
-							long epochSeconds = dbrTimeEvent.getEpochSeconds();
+    @Override
+    public void initialize(String userarg, String pvName) throws IOException {
+        if (userarg != null && userarg.contains("_")) {
+            String[] userparams = userarg.split("_");
+            String intervalStr = userparams[1];
+            intervalSecs = Integer.parseInt(intervalStr);
+            logger.debug("Using use supplied interval of " + intervalSecs);
+        } else {
+            logger.debug("Using the default interval of  " + intervalSecs
+                    + " as the user has not specified the interval argument.");
+        }
+    }
+
+    @Override
+    public long estimateMemoryConsumption(
+            String pvName, PVTypeInfo typeInfo, Instant start, Instant end, HttpServletRequest req) {
+        this.start = start;
+        this.end = end;
+        firstBin = TimeUtils.convertToEpochSeconds(start) / intervalSecs;
+        lastBin = TimeUtils.convertToEpochSeconds(end) / intervalSecs;
+        logger.debug("Expecting " + lastBin + " - " + firstBin + " values "
+                + (lastBin + 2 - firstBin)); // Add 2 for the first and last bins..
+        float storageRate = typeInfo.getComputedStorageRate();
+        long numSeconds = TimeUtils.convertToEpochSeconds(end) - TimeUtils.convertToEpochSeconds(start);
+        // Add a fudge factor of 2 for java
+        long estimatedMemoryConsumption = (long) (storageRate * numSeconds * 2 / intervalSecs);
+        return estimatedMemoryConsumption;
+    }
+
+    @Override
+    public Callable<EventStream> wrap(final Callable<EventStream> callable) {
+        final boolean vectorType = isProvidingVectorData();
+        final int elementCount = getElementCount();
+        return new Callable<EventStream>() {
+            @Override
+            public EventStream call() throws Exception {
+                try (EventStream strm = callable.call()) {
+                    // If we cache the mean/sigma etc, then we should add something to the desc telling us that this is
+                    // cached data and then we can replace the stat value for that bin?
+                    if (srcDesc == null) srcDesc = (RemotableEventStreamDesc) strm.getDescription();
+                    boolean shouldAddLastSampleBeforeStart = true;
+                    for (Event e : strm) {
+                        try {
+                            DBRTimeEvent dbrTimeEvent = (DBRTimeEvent) e;
+                            long epochSeconds = dbrTimeEvent.getEpochSeconds();
                             if (dbrTimeEvent.getEventTimeStamp().isAfter(previousEventTimestamp)) {
-								previousEventTimestamp = dbrTimeEvent.getEventTimeStamp();
-							} else {
-								// Note that this is expected. ETL is not transactional; so we can get the same event twice from different stores.
-								if(logger.isDebugEnabled()) { 
-									logger.debug("Skipping older event " + TimeUtils.convertToHumanReadableString(dbrTimeEvent.getEventTimeStamp()) + " previous " + TimeUtils.convertToHumanReadableString(previousEventTimestamp));
-								}
-								continue;
-							}
-							Instant eventInstant = dbrTimeEvent.getEventTimeStamp();
-							long binNumber = epochSeconds/intervalSecs;
-							if(eventInstant.isAfter(start) || eventInstant.equals(start)) {
-								if (eventInstant.equals(start)) {
-									shouldAddLastSampleBeforeStart = false;
-								}
-								if (eventInstant.isBefore(end) || eventInstant.equals(end)) {
-									if(binNumber != currentBin) {
-										if(currentBin != -1) {
-											SummaryValue summaryValue;
-											if (vectorType) {
-												summaryValue = new SummaryValue(((SummaryStatsVectorCollector)currentBinCollector).getVectorValues(), currentMaxSeverity, currentConnectionChangedEvents);
-											} else {
-												summaryValue = new SummaryValue(currentBinCollector.getStat(), currentMaxSeverity, currentConnectionChangedEvents);
-												if(currentBinCollector instanceof SummaryStatsCollectorAdditionalColumns) {
-													summaryValue.addAdditionalColumn(((SummaryStatsCollectorAdditionalColumns)currentBinCollector).getAdditionalStats());
-												}
-											}
-											consolidatedData.put(currentBin, summaryValue);
-										}
-										switchToNewBin(binNumber);
-									}
-									currentBinCollector.addEvent(e);
-									if(dbrTimeEvent.getSeverity() > currentMaxSeverity) {
-										currentMaxSeverity = dbrTimeEvent.getSeverity();
-									}
-									if(dbrTimeEvent.hasFieldValues() && dbrTimeEvent.getFields().containsKey("cnxregainedepsecs")) {
-										currentConnectionChangedEvents = true;
-									}
-								}
-							} else if (eventInstant.isBefore(start)) {
-								// Michael Davidsaver's special case; keep track of the last value before the start time and then add that in as a single sample.
-								if (lastSampleBeforeStart == null || e.getEventTimeStamp().isAfter(lastSampleBeforeStart.getEventTimeStamp())) {
-									lastSampleBeforeStart = e.makeClone();
-								}
-							}
-						} catch(PBParseException ex) { 
-							logger.error("Skipping possible corrupted event for pv " + strm.getDescription());
-						}
-					}
+                                previousEventTimestamp = dbrTimeEvent.getEventTimeStamp();
+                            } else {
+                                // Note that this is expected. ETL is not transactional; so we can get the same event
+                                // twice from different stores.
+                                if (logger.isDebugEnabled()) {
+                                    logger.debug("Skipping older event "
+                                            + TimeUtils.convertToHumanReadableString(dbrTimeEvent.getEventTimeStamp())
+                                            + " previous "
+                                            + TimeUtils.convertToHumanReadableString(previousEventTimestamp));
+                                }
+                                continue;
+                            }
+                            Instant eventInstant = dbrTimeEvent.getEventTimeStamp();
+                            long binNumber = epochSeconds / intervalSecs;
+                            if (eventInstant.isAfter(start) || eventInstant.equals(start)) {
+                                if (eventInstant.equals(start)) {
+                                    shouldAddLastSampleBeforeStart = false;
+                                }
+                                if (eventInstant.isBefore(end) || eventInstant.equals(end)) {
+                                    if (binNumber != currentBin) {
+                                        if (currentBin != -1) {
+                                            SummaryValue summaryValue;
+                                            if (vectorType) {
+                                                summaryValue = new SummaryValue(
+                                                        ((SummaryStatsVectorCollector) currentBinCollector)
+                                                                .getVectorValues(),
+                                                        currentMaxSeverity,
+                                                        currentConnectionChangedEvents);
+                                            } else {
+                                                summaryValue = new SummaryValue(
+                                                        currentBinCollector.getStat(),
+                                                        currentMaxSeverity,
+                                                        currentConnectionChangedEvents);
+                                                if (currentBinCollector
+                                                        instanceof SummaryStatsCollectorAdditionalColumns) {
+                                                    summaryValue.addAdditionalColumn(
+                                                            ((SummaryStatsCollectorAdditionalColumns)
+                                                                            currentBinCollector)
+                                                                    .getAdditionalStats());
+                                                }
+                                            }
+                                            consolidatedData.put(currentBin, summaryValue);
+                                        }
+                                        switchToNewBin(binNumber);
+                                    }
+                                    currentBinCollector.addEvent(e);
+                                    if (dbrTimeEvent.getSeverity() > currentMaxSeverity) {
+                                        currentMaxSeverity = dbrTimeEvent.getSeverity();
+                                    }
+                                    if (dbrTimeEvent.hasFieldValues()
+                                            && dbrTimeEvent.getFields().containsKey("cnxregainedepsecs")) {
+                                        currentConnectionChangedEvents = true;
+                                    }
+                                }
+                            } else if (eventInstant.isBefore(start)) {
+                                // Michael Davidsaver's special case; keep track of the last value before the start time
+                                // and then add that in as a single sample.
+                                if (lastSampleBeforeStart == null
+                                        || e.getEventTimeStamp().isAfter(lastSampleBeforeStart.getEventTimeStamp())) {
+                                    lastSampleBeforeStart = e.makeClone();
+                                }
+                            }
+                        } catch (PBParseException ex) {
+                            logger.error("Skipping possible corrupted event for pv " + strm.getDescription());
+                        }
+                    }
 
-					// We only add bins for the specified time frame.
-					// The ArchiveViewer depends on the number of values being the same and because of different rates for PVs, the bin number for the starting bin could be different...
-					// We could add a firstbin-1 and put all values before the starting timestamp in that bin but that would give incorrect summaries.
-					if(lastSampleBeforeStart != null && shouldAddLastSampleBeforeStart) {
-						switchToNewBin(firstBin-1);
-						currentBinCollector.addEvent(lastSampleBeforeStart);
-						lastSampleBeforeStartAdded = true;
-					}
+                    // We only add bins for the specified time frame.
+                    // The ArchiveViewer depends on the number of values being the same and because of different rates
+                    // for PVs, the bin number for the starting bin could be different...
+                    // We could add a firstbin-1 and put all values before the starting timestamp in that bin but that
+                    // would give incorrect summaries.
+                    if (lastSampleBeforeStart != null && shouldAddLastSampleBeforeStart) {
+                        switchToNewBin(firstBin - 1);
+                        currentBinCollector.addEvent(lastSampleBeforeStart);
+                        lastSampleBeforeStartAdded = true;
+                    }
 
-					return new SummaryStatsCollectorEventStream(firstBin, lastBin, intervalSecs, srcDesc, consolidatedData, inheritValuesFromPreviousBins, zeroOutEmptyBins(), vectorType, elementCount);
-				}
-			}
-		};
-	}
+                    return new SummaryStatsCollectorEventStream(
+                            firstBin,
+                            lastBin,
+                            intervalSecs,
+                            srcDesc,
+                            consolidatedData,
+                            inheritValuesFromPreviousBins,
+                            zeroOutEmptyBins(),
+                            vectorType,
+                            elementCount);
+                }
+            }
+        };
+    }
 
-	private void switchToNewBin(long binNumber) {
-		currentBin = binNumber;
-		currentMaxSeverity = 0;
-		currentConnectionChangedEvents = false;
-		currentBinCollector = getCollector();
-		currentBinCollector.setBinParams(intervalSecs, currentBin);
-	}
+    private void switchToNewBin(long binNumber) {
+        currentBin = binNumber;
+        currentMaxSeverity = 0;
+        currentConnectionChangedEvents = false;
+        currentBinCollector = getCollector();
+        currentBinCollector.setBinParams(intervalSecs, currentBin);
+    }
 
-	@Override
-	public String getExtension() {
-		String identity = this.getIdentity();
-		if(intervalSecs == PostProcessors.DEFAULT_SUMMARIZING_INTERVAL) {
-			return identity;
-		} else {
-			return identity + "_" + Integer.toString(intervalSecs);
-		}
-	}
-	
-	
-	@Override
-	public EventStream getConsolidatedEventStream() {
-		if(!lastSampleBeforeStartAdded && lastSampleBeforeStart != null) { 
-			switchToNewBin(firstBin-1);
-			logger.debug("Adding lastSampleBeforeStart to bin " + TimeUtils.convertToHumanReadableString(lastSampleBeforeStart.getEpochSeconds()));
-			currentBinCollector.addEvent(lastSampleBeforeStart);
-			lastSampleBeforeStartAdded = true; 
-		}
-		if(currentBin != -1) {
-		    SummaryValue summaryValue;
-		    if (isProvidingVectorData()) {
-		        summaryValue = new SummaryValue(((SummaryStatsVectorCollector)currentBinCollector).getVectorValues(), currentMaxSeverity, currentConnectionChangedEvents);
-		    } else {
-    			summaryValue = new SummaryValue(currentBinCollector.getStat(), currentMaxSeverity, currentConnectionChangedEvents);
-    			if(currentBinCollector instanceof SummaryStatsCollectorAdditionalColumns) { 
-    				summaryValue.addAdditionalColumn(((SummaryStatsCollectorAdditionalColumns)currentBinCollector).getAdditionalStats());
-    			}
-		    }
-    		consolidatedData.put(currentBin, summaryValue);
-			currentBinCollector = null;
-		}
-		if(consolidatedData.isEmpty()) { 
-			return new ArrayListEventStream(0, srcDesc);			
-		} else { 
-			return new SummaryStatsCollectorEventStream(this.firstBin == 0 ? 0 : this.firstBin-1, this.lastBin, this.intervalSecs, srcDesc, consolidatedData, inheritValuesFromPreviousBins, zeroOutEmptyBins(), isProvidingVectorData(), getElementCount());
-		}
+    @Override
+    public String getExtension() {
+        String identity = this.getIdentity();
+        if (intervalSecs == PostProcessors.DEFAULT_SUMMARIZING_INTERVAL) {
+            return identity;
+        } else {
+            return identity + "_" + Integer.toString(intervalSecs);
+        }
+    }
 
-	}
-	/* (non-Javadoc)
-	 * @see org.epics.archiverappliance.retrieval.postprocessors.PostProcessorWithConsolidatedEventStream#getStartBinEpochSeconds()
-	 */
-	@Override
-	public long getStartBinEpochSeconds() {
-		return this.firstBin*this.intervalSecs;
-	}
-	/* (non-Javadoc)
-	 * @see org.epics.archiverappliance.retrieval.postprocessors.PostProcessorWithConsolidatedEventStream#getEndBinEpochSeconds()
-	 */
-	@Override
-	public long getEndBinEpochSeconds() {
-		return this.lastBin*this.intervalSecs;
-	}
-	/* (non-Javadoc)
-	 * @see org.epics.archiverappliance.retrieval.postprocessors.PostProcessorWithConsolidatedEventStream#getBinTimestamps()
-	 */
-	@Override
-	public LinkedList<TimeSpan> getBinTimestamps() {
-		return getBinTimestamps(this.firstBin, this.lastBin, this.intervalSecs);
-	}
-	
-	public static LinkedList<TimeSpan> 	getBinTimestamps(long firstBin, long lastBin, int intervalSecs) { 
-		LinkedList<TimeSpan> ret = new LinkedList<TimeSpan>();
-		long previousBinEpochSeconds = firstBin*intervalSecs;
-		for(long currentBin = firstBin+1; currentBin <= lastBin; currentBin++) { 
-			long currentBinEpochSeconds = currentBin*intervalSecs;
-			ret.add(new TimeSpan(previousBinEpochSeconds, currentBinEpochSeconds));
-			previousBinEpochSeconds = currentBinEpochSeconds;
-		}
-		return ret;
-	}
+    @Override
+    public EventStream getConsolidatedEventStream() {
+        if (!lastSampleBeforeStartAdded && lastSampleBeforeStart != null) {
+            switchToNewBin(firstBin - 1);
+            logger.debug("Adding lastSampleBeforeStart to bin "
+                    + TimeUtils.convertToHumanReadableString(lastSampleBeforeStart.getEpochSeconds()));
+            currentBinCollector.addEvent(lastSampleBeforeStart);
+            lastSampleBeforeStartAdded = true;
+        }
+        if (currentBin != -1) {
+            SummaryValue summaryValue;
+            if (isProvidingVectorData()) {
+                summaryValue = new SummaryValue(
+                        ((SummaryStatsVectorCollector) currentBinCollector).getVectorValues(),
+                        currentMaxSeverity,
+                        currentConnectionChangedEvents);
+            } else {
+                summaryValue = new SummaryValue(
+                        currentBinCollector.getStat(), currentMaxSeverity, currentConnectionChangedEvents);
+                if (currentBinCollector instanceof SummaryStatsCollectorAdditionalColumns) {
+                    summaryValue.addAdditionalColumn(
+                            ((SummaryStatsCollectorAdditionalColumns) currentBinCollector).getAdditionalStats());
+                }
+            }
+            consolidatedData.put(currentBin, summaryValue);
+            currentBinCollector = null;
+        }
+        if (consolidatedData.isEmpty()) {
+            return new ArrayListEventStream(0, srcDesc);
+        } else {
+            return new SummaryStatsCollectorEventStream(
+                    this.firstBin == 0 ? 0 : this.firstBin - 1,
+                    this.lastBin,
+                    this.intervalSecs,
+                    srcDesc,
+                    consolidatedData,
+                    inheritValuesFromPreviousBins,
+                    zeroOutEmptyBins(),
+                    isProvidingVectorData(),
+                    getElementCount());
+        }
+    }
+    /* (non-Javadoc)
+     * @see org.epics.archiverappliance.retrieval.postprocessors.PostProcessorWithConsolidatedEventStream#getStartBinEpochSeconds()
+     */
+    @Override
+    public long getStartBinEpochSeconds() {
+        return this.firstBin * this.intervalSecs;
+    }
+    /* (non-Javadoc)
+     * @see org.epics.archiverappliance.retrieval.postprocessors.PostProcessorWithConsolidatedEventStream#getEndBinEpochSeconds()
+     */
+    @Override
+    public long getEndBinEpochSeconds() {
+        return this.lastBin * this.intervalSecs;
+    }
+    /* (non-Javadoc)
+     * @see org.epics.archiverappliance.retrieval.postprocessors.PostProcessorWithConsolidatedEventStream#getBinTimestamps()
+     */
+    @Override
+    public LinkedList<TimeSpan> getBinTimestamps() {
+        return getBinTimestamps(this.firstBin, this.lastBin, this.intervalSecs);
+    }
 
-	@Override
-	public void doNotInheritValuesFromPrevioisBins() {
-		this.inheritValuesFromPreviousBins = false;
-	}
-	
-	@Override
-	public boolean zeroOutEmptyBins() {
-		return false;
-	}
+    public static LinkedList<TimeSpan> getBinTimestamps(long firstBin, long lastBin, int intervalSecs) {
+        LinkedList<TimeSpan> ret = new LinkedList<TimeSpan>();
+        long previousBinEpochSeconds = firstBin * intervalSecs;
+        for (long currentBin = firstBin + 1; currentBin <= lastBin; currentBin++) {
+            long currentBinEpochSeconds = currentBin * intervalSecs;
+            ret.add(new TimeSpan(previousBinEpochSeconds, currentBinEpochSeconds));
+            previousBinEpochSeconds = currentBinEpochSeconds;
+        }
+        return ret;
+    }
+
+    @Override
+    public void doNotInheritValuesFromPrevioisBins() {
+        this.inheritValuesFromPreviousBins = false;
+    }
+
+    @Override
+    public boolean zeroOutEmptyBins() {
+        return false;
+    }
 }

--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/SummaryStatsPostProcessor.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/SummaryStatsPostProcessor.java
@@ -48,8 +48,8 @@ public abstract class SummaryStatsPostProcessor
         return 1;
     }
 
-    private Instant start;
-    private Instant end;
+    private Instant start = Instant.MIN;
+    private Instant end = Instant.MAX;
 
     private static Logger logger = LogManager.getLogger(SummaryStatsPostProcessor.class.getName());
     int intervalSecs = PostProcessors.DEFAULT_SUMMARIZING_INTERVAL;

--- a/src/test/org/epics/archiverappliance/etl/DataReductionPostProcessorsTest.java
+++ b/src/test/org/epics/archiverappliance/etl/DataReductionPostProcessorsTest.java
@@ -40,8 +40,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -166,11 +164,14 @@ public class DataReductionPostProcessorsTest {
         for (int day = 0; day < 40; day++) {
             // Generate data into the STS on a daily basis
             ArrayListEventStream genDataRaw = new ArrayListEventStream(
-                    PartitionGranularity.PARTITION_DAY.getApproxSecondsPerChunk(), new RemotableEventStreamDesc(ArchDBRTypes.DBR_SCALAR_DOUBLE, rawPVName, currentYear));
+                    PartitionGranularity.PARTITION_DAY.getApproxSecondsPerChunk(),
+                    new RemotableEventStreamDesc(ArchDBRTypes.DBR_SCALAR_DOUBLE, rawPVName, currentYear));
             ArrayListEventStream genDataReduced = new ArrayListEventStream(
-                    PartitionGranularity.PARTITION_DAY.getApproxSecondsPerChunk(), new RemotableEventStreamDesc(ArchDBRTypes.DBR_SCALAR_DOUBLE, reducedPVName, currentYear));
+                    PartitionGranularity.PARTITION_DAY.getApproxSecondsPerChunk(),
+                    new RemotableEventStreamDesc(ArchDBRTypes.DBR_SCALAR_DOUBLE, reducedPVName, currentYear));
             for (int second = 0; second < PartitionGranularity.PARTITION_DAY.getApproxSecondsPerChunk(); second++) {
-                YearSecondTimestamp ysts = new YearSecondTimestamp(currentYear, day * PartitionGranularity.PARTITION_DAY.getApproxSecondsPerChunk() + second, 0);
+                YearSecondTimestamp ysts = new YearSecondTimestamp(
+                        currentYear, day * PartitionGranularity.PARTITION_DAY.getApproxSecondsPerChunk() + second, 0);
                 Instant ts = TimeUtils.convertFromYearSecondTimestamp(ysts);
                 genDataRaw.add(
                         new POJOEvent(ArchDBRTypes.DBR_SCALAR_DOUBLE, ts, new ScalarValue<Double>(second * 1.0), 0, 0));
@@ -185,8 +186,8 @@ public class DataReductionPostProcessorsTest {
             logger.debug("For postprocessor " + reduceDataUsing + " done generating data into the STS for day " + day);
 
             // Run ETL at the end of the day
-            Instant timeETLruns = TimeUtils.convertFromYearSecondTimestamp(
-                    new YearSecondTimestamp(currentYear, day * PartitionGranularity.PARTITION_DAY.getApproxSecondsPerChunk() + 86399, 0));
+            Instant timeETLruns = TimeUtils.convertFromYearSecondTimestamp(new YearSecondTimestamp(
+                    currentYear, day * PartitionGranularity.PARTITION_DAY.getApproxSecondsPerChunk() + 86399, 0));
             ETLExecutor.runETLs(configService, timeETLruns);
             logger.debug("For postprocessor " + reduceDataUsing + " done performing ETL as though today is "
                     + TimeUtils.convertToHumanReadableString(timeETLruns));
@@ -241,16 +242,23 @@ public class DataReductionPostProcessorsTest {
                             logger.info("Reduced" + TimeUtils.convertToHumanReadableString(reducedTimestamps.pop()));
                     }
                 }
-	            Assertions.assertEquals(reducedCount, rawWithPPCount, "For postprocessor " + reduceDataUsing + " for day " + day + " we have " + rawWithPPCount
-			            + " rawWithPP events and " + reducedCount + " reduced events");
+                Assertions.assertEquals(
+                        reducedCount,
+                        rawWithPPCount,
+                        "For postprocessor " + reduceDataUsing + " for day " + day + " we have " + rawWithPPCount
+                                + " rawWithPP events and " + reducedCount + " reduced events");
             }
             if (day > 2) {
-                Assertions.assertTrue((rawWithPPCount != 0), "For postprocessor " + reduceDataUsing + " for day " + day
-                        + ", seems like no events were moved by ETL into LTS for " + rawPVName + " Count = "
-                        + rawWithPPCount);
-                Assertions.assertTrue((reducedCount != 0), "For postprocessor " + reduceDataUsing + " for day " + day
-                        + ", seems like no events were moved by ETL into LTS for " + reducedPVName + " Count = "
-                        + reducedCount);
+                Assertions.assertTrue(
+                        (rawWithPPCount != 0),
+                        "For postprocessor " + reduceDataUsing + " for day " + day
+                                + ", seems like no events were moved by ETL into LTS for " + rawPVName + " Count = "
+                                + rawWithPPCount);
+                Assertions.assertTrue(
+                        (reducedCount != 0),
+                        "For postprocessor " + reduceDataUsing + " for day " + day
+                                + ", seems like no events were moved by ETL into LTS for " + reducedPVName + " Count = "
+                                + reducedCount);
             }
         }
 


### PR DESCRIPTION
Bug is that in ETL process start and end are not set So need to specify when not set.

Also fixes DataReductionPostProcessorsTest to not need to be run in a single fork.