### PR TITLE
Allows archapplsite, to be a full path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,10 +47,14 @@ def stageDir = layout.projectDirectory.file("build/stage")
 def srcDir = layout.projectDirectory.file("src/main")
 def libDir = layout.projectDirectory.file("lib")
 def apiDocsDir = layout.projectDirectory.file("docs/api")
-def archapplsite = System.getenv("ARCHAPPL_SITEID") ? System.getenv("ARCHAPPL_SITEID") : "tests"
+def archapplsite = System.getenv("ARCHAPPL_SITEID") ?: "tests"
+def defaultsitespecificpath = "src/sitespecific/${archapplsite}"
+// Allow the site to be outside of the repository
+def sitespecificpath = (new File("${defaultsitespecificpath}").exists()) ? defaultsitespecificpath : archapplsite
 
 ant.stage = stageDir
 ant.archapplsite = archapplsite
+ant.sitespecificpath = sitespecificpath
 ant.importBuild("build.xml")
 
 repositories {
@@ -252,7 +256,7 @@ tasks.withType(War).configureEach {
 			into "WEB-INF/classes"
 		}
 	}
-	from("src/sitespecific/${archapplsite}/classpathfiles") {
+	from("${sitespecificpath}/classpathfiles") {
 		into "WEB-INF/classes"
 	}
 	rootSpec.exclude("**/tomcat-servlet-api*.jar")

--- a/build.xml
+++ b/build.xml
@@ -12,14 +12,14 @@
 
 	<property environment="env"/>
 
-	<available file="src/sitespecific/${archapplsite}/build.xml" property="site_has_site_specific_build_xml">
+	<available file="${sitespecificpath}/build.xml" property="site_has_site_specific_build_xml">
 	</available>
 
-	<echo>Building the archiver appliance for the site ${archapplsite}</echo>
+	<echo>Building the archiver appliance for the site ${archapplsite} with path ${sitespecificpath}</echo>
 
 	<target name="sitespecificbuild" if="site_has_site_specific_build_xml" depends="stage">
 		<echo message="Calling site specific build for site ${archapplsite}"></echo>
-		<ant dir="src/sitespecific/${archapplsite}" inheritall="true"></ant>
+		<ant dir="${sitespecificpath}" inheritall="true"></ant>
 	</target>
 
 </project>


### PR DESCRIPTION
Allows the sitespecific build folder to not be in
src/sitespecific.
Useful if building a the archiver and maintaining the sitespecific code outside of the repo. Then this allows not having to copy the site specific code inside of the archiver repository.