### PR TITLE
Clean up stray tomcats during testing using a testing specific tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -436,7 +436,8 @@ tasks.register("shutdownAllTomcats", Exec) {
 	description "task to shut down all tomcats after running integration tests," +
 			" if they didn't shut down correctly."
 	ignoreExitValue true
-	commandLine "pkill", "-9", "-f", "tomcat"
+    commandLine "echo", "This is where we kill any lingering tomcats using a special tag"
+    commandLine "pkill", "-9", "-f", "Deaatag=eaatesttm"
 }
 
 tasks.register("integrationTestSetup", Copy) {

--- a/src/test/org/epics/archiverappliance/TomcatSetup.java
+++ b/src/test/org/epics/archiverappliance/TomcatSetup.java
@@ -231,6 +231,7 @@ public class TomcatSetup {
 		File workFolder = new File("build/tomcats/tomcat_" + testName + File.separator + applianceName);
 		assert (workFolder.exists());
 		environment.put("CATALINA_BASE", workFolder.getAbsolutePath());
+        environment.put("CATALINA_OPTS", "-Deaatag=eaatesttm"); // The tag is for pkill during testing
 
 		environment.put("LOG4J_CONFIGURATION_FILE", (new File("src/resources/test/log4j2.xml")).getAbsolutePath());
 		environment.put(ConfigService.ARCHAPPL_CONFIGSERVICE_IMPL, ConfigServiceForTests.class.getName());


### PR DESCRIPTION
The current cleanup kills jenkins processes; so need to apply the pkill only to those tomcats started by the tests.