### PR TITLE
Confirm log4j2.xml loads in Tomcat 9.0.89

### DIFF
--- a/src/main/org/epics/archiverappliance/config/ArchServletContextListener.java
+++ b/src/main/org/epics/archiverappliance/config/ArchServletContextListener.java
@@ -27,6 +27,8 @@ public class ArchServletContextListener implements ServletContextListener {
 	private static final Logger configlogger = LogManager.getLogger("config." + ArchServletContextListener.class);
 	@Override
 	public void contextInitialized(ServletContextEvent sce) {
+		// This should hopefully trigger the log4j2 initialization
+		configlogger.info("Initializing the ArchServletContextListener");
 		try {
 			String configServiceImplClassName = System.getProperty(ConfigService.ARCHAPPL_CONFIGSERVICE_IMPL);
 			if(configServiceImplClassName == null) {

--- a/src/main/org/epics/archiverappliance/engine/WEB-INF/web.xml
+++ b/src/main/org/epics/archiverappliance/engine/WEB-INF/web.xml
@@ -1,4 +1,9 @@
-<web-app>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                      http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+  version="4.0"
+  metadata-complete="true">
     <servlet>
         <servlet-name>EngineBPLServlet</servlet-name>
         <servlet-class>org.epics.archiverappliance.engine.BPLServlet</servlet-class>

--- a/src/main/org/epics/archiverappliance/etl/WEB-INF/web.xml
+++ b/src/main/org/epics/archiverappliance/etl/WEB-INF/web.xml
@@ -1,4 +1,9 @@
-<web-app>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                      http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+  version="4.0"
+  metadata-complete="true">
    <servlet>
         <servlet-name>StaticContent</servlet-name>
         <servlet-class>org.epics.archiverappliance.common.StaticContentServlet</servlet-class>

--- a/src/main/org/epics/archiverappliance/mgmt/WEB-INF/web.xml
+++ b/src/main/org/epics/archiverappliance/mgmt/WEB-INF/web.xml
@@ -1,4 +1,9 @@
-<web-app>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                      http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+  version="4.0"
+  metadata-complete="true">
    <filter>
        <filter-name>MgmtUIFilter</filter-name>
        <filter-class>org.epics.archiverappliance.mgmt.MgmtUIFilter</filter-class>

--- a/src/main/org/epics/archiverappliance/retrieval/WEB-INF/web.xml
+++ b/src/main/org/epics/archiverappliance/retrieval/WEB-INF/web.xml
@@ -1,4 +1,9 @@
-<web-app>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                      http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+  version="4.0"
+  metadata-complete="true">
    <filter>
        <filter-name>CorsFilter</filter-name>
        <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>

--- a/src/resources/test/log4j2.xml
+++ b/src/resources/test/log4j2.xml
@@ -1,13 +1,28 @@
-<Configuration>
-    <Appenders>
-        <Console name="STDOUT" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d %-5p [%t] %C{2} (%F:%L) - %m%n"/>
-        </Console>
-    </Appenders>
-    <Loggers>
-        <Logger name="org.apache.log4j.xml" level="info"/>
-        <Root level="info">
-            <AppenderRef ref="STDOUT"/>
-        </Root>
-    </Loggers>
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="ERROR">
+ <Appenders>
+  <RollingFile name="RollingFile" fileName="arch.log" filePattern="arch-%d{yyyy-MM-dd}-%i.log">
+   <PatternLayout>
+    <pattern>[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n</pattern>
+   </PatternLayout>
+   <Policies>
+    <TimeBasedTriggeringPolicy/>
+    <SizeBasedTriggeringPolicy size="25 MB"/>
+   </Policies>
+   <DefaultRolloverStrategy max="10"/>
+  </RollingFile>
+  <Console name="STDOUT" target="SYSTEM_OUT">
+   <PatternLayout>
+    <pattern>[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n</pattern>
+   </PatternLayout>
+  </Console>
+ </Appenders>
+
+ <Loggers>
+  <Logger name="config" level="debug"/>
+  <Root level="debug">
+   <AppenderRef ref="RollingFile" level="info"/>
+   <AppenderRef ref="STDOUT" level="info"/>
+  </Root>
+ </Loggers>
 </Configuration>


### PR DESCRIPTION
I think  we need to specify the webapp version for Servlet API. 

I also changed the log4j2.xml for tests to something with a rolling file appender. We may want to consider changing the file logging to debug later.