### PR TITLE
Issue #239 - Fixed params to StringUtils.containsAny

### DIFF
--- a/src/main/org/epics/archiverappliance/mgmt/bpl/PVsMatchingParameter.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/PVsMatchingParameter.java
@@ -144,7 +144,7 @@ public class PVsMatchingParameter {
             boolean includePVSThatDontExist,
             LinkedList<String> pvNames) {
         for (String pv : pvs) {
-            if (StringUtils.containsAny("*", "?")) {
+            if (StringUtils.containsAny(pv, "*?")) {
                 WildcardFileFilter matcher = new WildcardFileFilter(pv);
                 for (String pvName : configService.getAllPVs()) {
                     if (matcher.accept((new File(pvName)))) {


### PR DESCRIPTION
Search for test:*:sine now picks up test:arch:sine