### PR TITLE
#230 - Get uptime from a new BPL call for just the mgmt metrics.

### DIFF
--- a/src/main/org/epics/archiverappliance/mgmt/BPLServlet.java
+++ b/src/main/org/epics/archiverappliance/mgmt/BPLServlet.java
@@ -78,6 +78,7 @@ import org.epics.archiverappliance.mgmt.bpl.reports.InstanceReport;
 import org.epics.archiverappliance.mgmt.bpl.reports.InstanceReportDetails;
 import org.epics.archiverappliance.mgmt.bpl.reports.LostConnectionsReport;
 import org.epics.archiverappliance.mgmt.bpl.reports.MetaGetsAction;
+import org.epics.archiverappliance.mgmt.bpl.reports.MgmtMetrics;
 import org.epics.archiverappliance.mgmt.bpl.reports.NeverConnectedPVsAction;
 import org.epics.archiverappliance.mgmt.bpl.reports.NeverConnectedPVsForThisAppliance;
 import org.epics.archiverappliance.mgmt.bpl.reports.PVDetails;
@@ -186,6 +187,7 @@ public class BPLServlet extends HttpServlet {
         addAction("/getInstanceMetricsForAppliance", InstanceReportDetails.class);
         addAction("/getApplianceMetrics", ApplianceMetrics.class);
         addAction("/getApplianceMetricsForAppliance", ApplianceMetricsDetails.class);
+        addAction("/getMgmtMetricsForAppliance", MgmtMetrics.class);
         addAction("/getExternalArchiverServers", ChannelArchiverListView.class);
         addAction("/addExternalArchiverServer", AddExternalArchiverServer.class);
         addAction("/addExternalArchiverServerArchives", AddExternalArchiverServerArchives.class);

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/reports/MgmtMetrics.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/reports/MgmtMetrics.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2011 The Board of Trustees of the Leland Stanford Junior University
+ * as Operator of the SLAC National Accelerator Laboratory.
+ * Copyright (c) 2011 Brookhaven National Laboratory.
+ * EPICS archiver appliance is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ *******************************************************************************/
+package org.epics.archiverappliance.mgmt.bpl.reports;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.lang.management.ManagementFactory;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.epics.archiverappliance.common.BPLAction;
+import org.epics.archiverappliance.config.ConfigService;
+import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
+import org.json.simple.JSONValue;
+
+/**
+ * Get the metrics for this management instance. Typically called from other reports
+ * @author mshankar
+ *
+ */
+public class MgmtMetrics implements BPLAction {
+    private static final Logger logger = LogManager.getLogger(MgmtMetrics.class);
+
+    @Override
+    public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
+            throws IOException {
+        logger.info("Generating mgmt metrics report");
+        resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+        try (PrintWriter out = resp.getWriter()) {
+            Map<String, String> result = new HashMap<String, String>();
+            long vmStartTime = ManagementFactory.getRuntimeMXBean().getStartTime();
+            Duration vmInterval = Duration.between(
+                    Instant.ofEpochMilli(vmStartTime), Instant.ofEpochMilli(System.currentTimeMillis()));            
+            result.put("uptime", vmInterval.toString());
+
+            out.println(JSONValue.toJSONString(result));
+        }
+    }
+}


### PR DESCRIPTION
Yes; I know; another BPL call. But all of this instance/appliance metrics is too confusing for me right now. Will clean it up later. But for now, we need one call from the mgmt just for its metrics and this is it.