### PR TITLE
Return metafields as part of the GetDataAtTime retrieval call #134

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ stage/
 .DS_Store
 *.swp
 /mts
+*.log
 
 .gradle
 **/build/

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ dependencies {
 	implementation("org.apache.commons:commons-math3:3.6.1")
 	implementation("commons-validator:commons-validator:1.7")
 	implementation("com.google.guava:guava:31.1-jre")
-	implementation("com.hazelcast:hazelcast-all:3.10.1")
+	implementation("com.hazelcast:hazelcast:5.4.0")
 	implementation("org.apache.httpcomponents:httpclient:4.5.14")
 	implementation("org.apache.httpcomponents:httpcore:4.4.16")
 	implementation("jdbm:jdbm:2.4") //clojar dependancy

--- a/src/main/edu/stanford/slac/archiverappliance/PB/utils/ReverseLineByteStream.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/utils/ReverseLineByteStream.java
@@ -7,8 +7,6 @@
  *******************************************************************************/
 package edu.stanford.slac.archiverappliance.PB.utils;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.ByteArray;
 import org.epics.archiverappliance.utils.nio.ArchPaths;
 
@@ -26,8 +24,7 @@ import java.nio.file.StandardOpenOption;
  *
  */
 public class ReverseLineByteStream implements Closeable {
-	private static final Logger logger = LogManager.getLogger(ReverseLineByteStream.class.getName());
-	public static int MAX_LINE_SIZE = 16 * 1024;
+	public static final int MAX_LINE_SIZE = 16 * 1024;
 	private SeekableByteChannel byteChannel = null;
 	private Path path = null;
 	private long stopAtPosition = 0L;

--- a/src/main/edu/stanford/slac/archiverappliance/PB/utils/ReverseLineByteStream.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/utils/ReverseLineByteStream.java
@@ -220,14 +220,14 @@ public class ReverseLineByteStream implements Closeable {
 	/**
 	 * Should only be used from the unit tests
 	 */
-	public boolean testFillBuffer() throws IOException {
+	boolean testFillBuffer() throws IOException {
 		return this.fillBuffer();
 	}	
 
 	/**
 	 * Should only be used from the unit tests
 	 */
-	public boolean testFillLineBuffer() throws IOException {
+	boolean testFillLineBuffer() throws IOException {
 		return this.fillLineBuffer();
 	}
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PB/utils/ReverseLineByteStream.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/utils/ReverseLineByteStream.java
@@ -1,0 +1,236 @@
+/*******************************************************************************
+ * Copyright (c) 2011 The Board of Trustees of the Leland Stanford Junior University
+ * as Operator of the SLAC National Accelerator Laboratory.
+ * Copyright (c) 2011 Brookhaven National Laboratory.
+ * EPICS archiver appliance is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ *******************************************************************************/
+package edu.stanford.slac.archiverappliance.PB.utils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.epics.archiverappliance.ByteArray;
+import org.epics.archiverappliance.utils.nio.ArchPaths;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * A modification of LineByteStream optimized for reading a PB chunk backwards in time
+ * Based off of dpetruha's answer here - https://stackoverflow.com/questions/8664705/how-to-read-file-from-end-to-start-in-reverse-order-in-java
+ * @author mshankar
+ *
+ */
+public class ReverseLineByteStream implements Closeable {
+	private static final Logger logger = LogManager.getLogger(ReverseLineByteStream.class.getName());
+	public static int MAX_LINE_SIZE = 16 * 1024;
+	private SeekableByteChannel byteChannel = null;
+	private Path path = null;
+	private long stopAtPosition = 0L;
+
+	/* This channel has been read until this position */
+	private long chReadUntil;
+
+	private byte[] buffer;
+	private int currentBufferPos;
+	
+	private byte[] currentLine;
+	private int currentLineWritePos = 0;
+	private int currentLineReadPos = 0;
+	private boolean lineBuffered = false;
+
+	// Used for testing
+	private long totalBytesRead = 0L;
+		
+	public ReverseLineByteStream(Path path) throws IOException {
+		this.path = path;
+		this.byteChannel = ArchPaths.newByteChannel(path, StandardOpenOption.READ);	
+		buffer = new byte[MAX_LINE_SIZE];
+		currentLine = new byte[MAX_LINE_SIZE];
+		currentLine[0] = LineEscaper.NEWLINE_CHAR;
+		chReadUntil = this.byteChannel.size();
+
+		fillBuffer();
+		fillLineBuffer();	
+	}
+
+	public ReverseLineByteStream(Path path, long startPosition, long endPosition) throws IOException {
+		this(path);
+		if(endPosition > 0 && endPosition < path.toFile().length()) {
+			this.seekToBeforePreviousLine(endPosition);
+		}
+		this.stopAtPosition = startPosition;
+	}
+
+	public void seekToBeforePreviousLine(long posn) throws IOException {
+		this.byteChannel.position(posn);
+		chReadUntil = this.byteChannel.position();
+		fillBuffer();
+		fillLineBuffer();	
+		// Read a line and ignore it...
+		ByteArray bar = new ByteArray(ReverseLineByteStream.MAX_LINE_SIZE);
+		this.readLine(bar);
+	}
+
+	public boolean readLine(ByteArray bar) throws IOException {
+		bar.reset();
+		if (chReadUntil <= stopAtPosition && currentBufferPos < 0 && currentLineReadPos < 0) {
+			return false;
+		}
+
+		if(chReadUntil + currentBufferPos < stopAtPosition) {
+			// logger.info("Reached the stopAtPosition {}", stopAtPosition);
+			return false;
+		}
+
+		if (!lineBuffered) {
+			fillLineBuffer();
+		}
+
+		if (lineBuffered) {
+			if (currentLineReadPos <= 0) {
+				// logger.info("Nothing read; escape hatch");
+				lineBuffered = false;
+				return false;
+			}
+
+			// logger.info("Picked up a line {}", currentLineReadPos);
+
+			bar.reset();
+			while(currentLineReadPos >= 0) {
+				bar.data[bar.len++] = currentLine[currentLineReadPos--];	
+				// logger.info("Char at {} is {}", currentLineReadPos+1, Character.toString(bar.data[bar.len-1]));
+			}
+			lineBuffered = false;
+			return true;
+		}
+		return false;
+	}
+
+	private boolean fillBuffer() throws IOException {
+		if (chReadUntil <= stopAtPosition) {
+			return false;
+		}
+		ByteBuffer bbuf = ByteBuffer.wrap(buffer);
+		bbuf.clear();
+
+		if (chReadUntil < buffer.length) {
+			// logger.debug("Reached Start of file Channel Read Until {} Total bytes read {}", chReadUntil, totalBytesRead);
+			this.byteChannel.position(0);
+			bbuf.limit((int)chReadUntil);
+			int bytesRead = this.byteChannel.read(bbuf);
+			assert(bytesRead == chReadUntil);
+			bbuf.flip();
+			currentBufferPos = bytesRead - 1;
+			totalBytesRead += bytesRead;
+			chReadUntil = chReadUntil - bytesRead;
+			// logger.debug("Reached Start BytesRead {} Channel Read Until {} Total bytes read {}", bytesRead, chReadUntil, totalBytesRead);
+		} else {
+			long currentFilePos = chReadUntil - buffer.length;
+			this.byteChannel.position(currentFilePos);
+			int bytesRead = this.byteChannel.read(bbuf);
+			assert(bytesRead == buffer.length);
+			bbuf.flip();
+			currentBufferPos = bytesRead - 1;
+			totalBytesRead += bytesRead;
+			chReadUntil = chReadUntil - bytesRead;
+			// logger.debug("BytesRead {} Channel Read Until {} Total bytes read {}", bytesRead, chReadUntil, totalBytesRead);
+		}
+		return true;
+	}
+
+	private boolean fillLineBuffer() throws IOException {
+		currentLineWritePos = 0;
+
+		while (true) {
+
+			// we've read all the buffer - need to fill it again
+			if (currentBufferPos < 0) {
+				// logger.debug("Empty buffer; filling it again");
+				fillBuffer();
+
+				if (currentBufferPos < 0) {
+					// logger.debug("Nothing buffered as we have reached the beginning of the file");
+					currentLineReadPos = currentLineWritePos - 1;
+					lineBuffered = true;
+					return false;
+				}
+			}
+
+			byte b = buffer[currentBufferPos--];
+
+			// newline is found - line fully buffered
+			if (b == LineEscaper.NEWLINE_CHAR) {
+				if((currentLineWritePos - 1) <= 0) {
+					currentLineWritePos = 0;
+					// logger.info("Encountered a new line and a blank line Currentbufferpos {} chReadUntil {} linelength {}", currentBufferPos, chReadUntil, currentLineWritePos);
+					continue;
+				}
+				// logger.info("Encountered a new line Currentbufferpos {} chReadUntil {} linelength {}", currentBufferPos, chReadUntil, currentLineWritePos);
+				currentLineReadPos = currentLineWritePos - 1;
+				lineBuffered = true;
+				return lineBuffered;
+			} else {
+				if (currentLineWritePos == MAX_LINE_SIZE) {
+					throw new IOException("file has a line exceeding " + MAX_LINE_SIZE
+							+ " bytes");
+				}
+
+				// write the current line bytes in reverse order - reading from
+				// the end will produce the correct line
+				currentLine[currentLineWritePos++] = b;
+				// logger.info("Writing char at {} is {}", currentLineWritePos-1, Character.toString(b));
+			}
+		}
+	}
+
+	public void safeClose() {
+		try {
+			this.close();
+		} catch(Throwable t) {
+			// Safe close...
+		}
+	}
+	
+	public String getAbsolutePath() {
+		return this.path.toAbsolutePath().toString();
+	}
+
+	@Override
+	public void close() throws IOException {
+		if(this.byteChannel != null) this.byteChannel.close();
+		this.byteChannel = null;
+		chReadUntil = 0;
+		buffer = null;
+		currentBufferPos = 0;
+		currentLine = null;
+		currentLineWritePos = 0;
+		currentLineReadPos = 0;
+		lineBuffered = false;
+	}
+
+	/**
+	 * Mainly used in the unit tests
+	 */
+	public long getTotalBytesRead() {
+		return totalBytesRead;
+	}
+
+	/**
+	 * Should only be used from the unit tests
+	 */
+	public boolean testFillBuffer() throws IOException {
+		return this.fillBuffer();
+	}	
+
+	/**
+	 * Should only be used from the unit tests
+	 */
+	public boolean testFillLineBuffer() throws IOException {
+		return this.fillLineBuffer();
+	}
+}

--- a/src/main/edu/stanford/slac/archiverappliance/PlainPB/FileStreamCreator.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PlainPB/FileStreamCreator.java
@@ -8,6 +8,7 @@
 package edu.stanford.slac.archiverappliance.PlainPB;
 
 import org.epics.archiverappliance.EventStream;
+import org.epics.archiverappliance.common.BiDirectionalIterable;
 import org.epics.archiverappliance.config.ArchDBRTypes;
 import org.epics.archiverappliance.etl.ETLStreamCreator;
 
@@ -59,6 +60,18 @@ public class FileStreamCreator implements ETLStreamCreator {
 
         return new FileBackedPBEventStream(pvName, path, dbrType);
     }
+
+
+    public static EventStream getStreamForIteration(
+            String pvName,
+            Path path,
+            Instant startAtTime,
+            ArchDBRTypes archDBRTypes,
+            BiDirectionalIterable.IterationDirection direction) throws IOException {
+
+        return new FileBackedPBEventStream(pvName, path, archDBRTypes, startAtTime, direction);
+    }
+
 
     @Override
     public EventStream getStream() throws IOException {

--- a/src/main/edu/stanford/slac/archiverappliance/PlainPB/PBEventStreamPositionBasedReverseIterator.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PlainPB/PBEventStreamPositionBasedReverseIterator.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2011 The Board of Trustees of the Leland Stanford Junior University
+ * as Operator of the SLAC National Accelerator Laboratory.
+ * Copyright (c) 2011 Brookhaven National Laboratory.
+ * EPICS archiver appliance is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ *******************************************************************************/
+package edu.stanford.slac.archiverappliance.PlainPB;
+
+
+import edu.stanford.slac.archiverappliance.PB.data.DBR2PBTypeMapping;
+import edu.stanford.slac.archiverappliance.PB.utils.LineByteStream;
+import edu.stanford.slac.archiverappliance.PB.utils.ReverseLineByteStream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.epics.archiverappliance.ByteArray;
+import org.epics.archiverappliance.Event;
+import org.epics.archiverappliance.config.ArchDBRTypes;
+import org.epics.archiverappliance.data.DBRTimeEvent;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.nio.file.Path;
+
+/**
+ * An iterator for a FileBackedPBEventStream that can go backwards in time
+ * @author mshankar
+ *
+ */
+public class PBEventStreamPositionBasedReverseIterator implements FileBackedPBEventStreamIterator {
+	private static final Logger logger = LogManager.getLogger(PBEventStreamPositionBasedReverseIterator.class.getName());
+	private short year = 0;
+	private ReverseLineByteStream lbs = null;
+	private final ByteArray nextLine = new ByteArray(LineByteStream.MAX_LINE_SIZE);
+
+	// Whether the line already in nextLine has been used by the iterator
+	private boolean lineUsed = false;
+	private final Constructor<? extends DBRTimeEvent> unmarshallingConstructor;
+
+	public PBEventStreamPositionBasedReverseIterator(Path path, long startFilePos, long endFilePos, short year, ArchDBRTypes type) throws IOException {
+		DBR2PBTypeMapping mapping = DBR2PBTypeMapping.getPBClassFor(type);
+		unmarshallingConstructor = mapping.getUnmarshallingFromByteArrayConstructor();
+		assert(endFilePos >= startFilePos);
+		this.year = year;
+		lbs = new ReverseLineByteStream(path, startFilePos, endFilePos);
+	}
+
+	@Override
+	public boolean hasNext() {
+		try {
+			if (nextLine.isEmpty() || lineUsed) {
+				readNextLine();
+				lineUsed = false;
+			}
+			if(!nextLine.isEmpty()) return true;
+		} catch(Exception ex) {
+			logger.error("Exception creating event object", ex);
+		}
+		return false;
+	}
+
+	private void readNextLine() throws IOException {
+		lbs.readLine(nextLine);
+	}
+
+
+	@Override
+	public Event next() {
+		try {
+			if (nextLine.isEmpty() || lineUsed) {
+				readNextLine();
+			}
+			Event e = unmarshallingConstructor.newInstance(year, nextLine);
+			lineUsed = true;
+			return e;
+		} catch (Exception ex) {
+			logger.error("Exception creating event object", ex);
+			return null;
+		}
+	}
+
+
+	@Override
+	public void remove() {
+		throw new UnsupportedOperationException();
+	}
+
+	public void close() {
+		lbs.safeClose();
+	}
+}

--- a/src/main/org/epics/archiverappliance/common/BiDirectionalIterable.java
+++ b/src/main/org/epics/archiverappliance/common/BiDirectionalIterable.java
@@ -1,0 +1,38 @@
+package org.epics.archiverappliance.common;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.Period;
+import java.util.function.Predicate;
+
+import org.epics.archiverappliance.Event;
+
+public interface BiDirectionalIterable {
+	public enum IterationDirection {
+		FORWARDS,
+		BACKWARDS
+	};
+
+	/**
+	 * Generic method to iterate over the data for specified PV.
+	 * We provide a time to start the iteration at ( inclusive ) and a direction and a Predicate.
+	 * The plugin then iterates ( forwards or backwards ) and calls the Predicate for each sample.
+	 * The iteration stops when the Predicate returns false or when we run out of samples.
+	 * Iteration also stops when we get an exception. 
+	 * So this mode of traversal is vulnerable to corruption in the data.
+	 * We may relax this constraint later by providing a optional bool to ignore exceptions.
+	 * @param context  &emsp;
+	 * @param pvName The PV name
+     * @param startAtTime Start the iteration at this time.
+     * If going forwards, this is the first sample on or before the specified time. 
+     * If going backwards, this is the first sample on or after the specified time.
+     * @param thePredicate - the Predicate to apply 
+     * @param direction - Forwards or backwards
+	 * @param searchPeriod - An estimate on the amount of time we want to iterate.
+	 * This is used to determine the appropriate chunks containing data at a very high level and thus to limit the search.
+	 * The predicate itself is the one that controls when the iteration terminates.
+	 * So, for example, you could specify a searchPeriod of 1 year but stop the iteration after 1 minute
+	 * @throws IOException  &emsp;
+	 */
+	public void iterate(BasicContext context, String pvName, Instant startAtTime, Predicate<Event> thePredicate, IterationDirection direction, Period searchPeriod) throws IOException;
+}

--- a/src/main/org/epics/archiverappliance/config/ConfigService.java
+++ b/src/main/org/epics/archiverappliance/config/ConfigService.java
@@ -29,6 +29,9 @@ import org.epics.archiverappliance.retrieval.RetrievalState;
 
 import com.google.common.eventbus.EventBus;
 
+import com.hazelcast.projection.Projection;
+
+
 /**
  * Interface for appliance configuration.
  * One gets to a config service implementation thru dependency injection of one kind or the other.
@@ -250,8 +253,15 @@ public interface ConfigService {
 	 * Much goodness is facilitated if the objects are returned in the same order (perhaps order of creation) all the time.
 	 * @return String All PVs being archiveed for this appliance
 	 */
-	public Iterable<String> getPVsForThisAppliance();
-	
+	public Set<String> getPVsForThisAppliance();
+
+	/**
+	 * Project the pvTypeInfo's for the given PV's using the given projection operator
+	 * This runs using Hz's query functions and can be run from any war file
+	 * For example, to quickly determine the appliances for a bunch of PV's, project the applianceIdentity and then do a stream groupby.
+	 * @return
+	 */
+	public <T> Collection<T> projectPVTypeInfos(Set<String> pvNames, Projection<Map.Entry<String, PVTypeInfo>, T> projection);
 	
 	/**
 	 * Is this PV archived on this appliance.

--- a/src/main/org/epics/archiverappliance/engine/bpl/GetDataAtTimeEngine.java
+++ b/src/main/org/epics/archiverappliance/engine/bpl/GetDataAtTimeEngine.java
@@ -47,8 +47,6 @@ public class GetDataAtTimeEngine implements BPLAction {
      * @param atTime
      * @param newEventToConsider
      * @param alreadyExistingEvent
-     * @param fieldIsEmbeddedInStream
-     * @param fieldName
      * @return
      */
     private static DBRTimeEvent evaluatePotentialEvent(

--- a/src/main/org/epics/archiverappliance/engine/bpl/GetDataAtTimeEngine.java
+++ b/src/main/org/epics/archiverappliance/engine/bpl/GetDataAtTimeEngine.java
@@ -20,6 +20,7 @@ import org.epics.archiverappliance.engine.membuf.ArrayListEventStream;
 import org.epics.archiverappliance.engine.model.ArchiveChannel;
 import org.epics.archiverappliance.engine.pv.EngineContext;
 import org.epics.archiverappliance.mgmt.bpl.PVsMatchingParameter;
+import org.epics.archiverappliance.utils.ui.MetaFields;
 import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
 import org.json.simple.JSONObject;
 
@@ -66,19 +67,6 @@ public class GetDataAtTimeEngine implements BPLAction {
         return alreadyExistingEvent;
     }
 
-    @SuppressWarnings("unchecked")
-    private static void addFieldValue(HashMap<String, Object> jsonval, String fieldName, String fieldValue) {
-        if(!jsonval.keySet().contains("meta")) {
-            HashMap<String, String> metaFields = new HashMap<String, String>();
-            jsonval.put("meta", metaFields);    
-        }
-        HashMap<String, String> meta = ((HashMap<String, String>)jsonval.get("meta"));
-        if(!meta.containsKey(fieldName)) {
-            meta.put(fieldName, fieldValue);
-        }
-    }
-
-
     @Override
     public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService)
             throws IOException {
@@ -124,9 +112,9 @@ public class GetDataAtTimeEngine implements BPLAction {
                     evnt.put("status", potentialEvent.getStatus());
                     HashMap<String, String> metafields = archiveChannel.getLatestMetadata();
                     if(metafields != null) {
-                        addFieldValue(evnt, "source", "engine");
+                        MetaFields.addMetaFieldValue(evnt, "source", "engine");
                         for(String key: metafields.keySet()) {
-                            addFieldValue(evnt, key, metafields.get(key));
+                            MetaFields.addMetaFieldValue(evnt, key, metafields.get(key));
                         }
                     }
 

--- a/src/main/org/epics/archiverappliance/retrieval/GetDataAtTime.java
+++ b/src/main/org/epics/archiverappliance/retrieval/GetDataAtTime.java
@@ -3,40 +3,49 @@ package org.epics.archiverappliance.retrieval;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.Event;
-import org.epics.archiverappliance.EventStream;
 import org.epics.archiverappliance.StoragePlugin;
 import org.epics.archiverappliance.common.BasicContext;
+import org.epics.archiverappliance.common.BiDirectionalIterable;
 import org.epics.archiverappliance.common.PoorMansProfiler;
 import org.epics.archiverappliance.common.TimeUtils;
+import org.epics.archiverappliance.common.BiDirectionalIterable.IterationDirection;
 import org.epics.archiverappliance.config.ApplianceInfo;
+import org.epics.archiverappliance.config.ArchDBRTypes;
 import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.config.PVNames;
 import org.epics.archiverappliance.config.PVTypeInfo;
 import org.epics.archiverappliance.config.StoragePluginURLParser;
 import org.epics.archiverappliance.data.DBRTimeEvent;
 import org.epics.archiverappliance.mgmt.bpl.PVsMatchingParameter;
-import org.epics.archiverappliance.retrieval.postprocessors.DefaultRawPostProcessor;
-import org.epics.archiverappliance.retrieval.postprocessors.ExtraFieldsPostProcessor;
-import org.epics.archiverappliance.retrieval.postprocessors.PostProcessor;
 import org.epics.archiverappliance.utils.ui.GetUrlContent;
-import org.json.simple.JSONArray;
 import org.json.simple.JSONValue;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Serializable;
 import java.time.Instant;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import com.hazelcast.projection.Projection;
 
 public class GetDataAtTime {
     private static final Logger logger = LogManager.getLogger(GetDataAtTime.class);
@@ -44,47 +53,30 @@ public class GetDataAtTime {
     static class Appliance2PVs {
         ApplianceInfo applianceInfo;
         LinkedList<String> pvsFromAppliance;
-        LinkedList<String> remainingPVs;
         HashMap<String, HashMap<String, Object>> pvValues;
 
         Appliance2PVs(ApplianceInfo applianceInfo) {
             this.applianceInfo = applianceInfo;
             this.pvsFromAppliance = new LinkedList<String>();
-            this.remainingPVs = new LinkedList<String>();
             this.pvValues = new HashMap<String, HashMap<String, Object>>();
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private static Appliance2PVs getPVSFromAppliance(Appliance2PVs gatherer, LinkedList<String> pvNames) {
-        try {
-            JSONArray resp = GetUrlContent.postStringListAndGetJSON(
-                    gatherer.applianceInfo.getMgmtURL() + "/archivedPVsForThisAppliance", "pv", pvNames);
-            logger.debug("Done calling remote appliance " + gatherer.applianceInfo.getIdentity() + " and got PV count "
-                    + resp.size());
-            gatherer.pvsFromAppliance = new LinkedList<String>(resp);
-            gatherer.remainingPVs = new LinkedList<String>(gatherer.pvsFromAppliance);
-        } catch (IOException ex) {
-            logger.error("Exception getting list of PVs from appliance", ex);
-        }
-        return gatherer;
-    }
-
     private static Appliance2PVs getDataFromEngine(Appliance2PVs gatherer, Instant atTime) {
         try {
-            if (gatherer.remainingPVs.size() <= 0) return gatherer;
             HashMap<String, HashMap<String, Object>> resp = GetUrlContent.postStringListAndGetJSON(
                     gatherer.applianceInfo.getEngineURL() + "/getDataAtTime?at="
                             + TimeUtils.convertToISO8601String(atTime),
                     "pv",
-                    gatherer.remainingPVs);
+                    gatherer.pvsFromAppliance);
             if (resp == null) return gatherer;
-            logger.debug("Done calling engine for appliance " + gatherer.applianceInfo.getIdentity()
-                    + " and got PV count " + ((resp != null) ? resp.size() : 0));
+            logger.debug("Done calling engine for appliance {} with PVs {} and got data for {} PVs ",
+                gatherer.applianceInfo.getIdentity(),
+                String.join(",", gatherer.pvsFromAppliance),
+                ((resp != null) ? String.join(",", resp.keySet()) : "no PVs"));
             for (String pvName : resp.keySet()) {
                 if (!gatherer.pvValues.containsKey(pvName)) {
                     gatherer.pvValues.put(pvName, resp.get(pvName));
-                    gatherer.remainingPVs.remove(pvName);
                 }
             }
         } catch (IOException ex) {
@@ -93,21 +85,24 @@ public class GetDataAtTime {
         return gatherer;
     }
 
-    private static Appliance2PVs getDataFromRetrieval(Appliance2PVs gatherer, Instant atTime) {
+    private static Appliance2PVs getDataFromRetrieval(Appliance2PVs gatherer, Instant atTime, Period searchPeriod) {
         try {
-            if (gatherer.remainingPVs.size() <= 0) return gatherer;
+            HashSet<String> remainingPVs = new HashSet<String>(gatherer.pvsFromAppliance);
+            // We only has for PVs that we do not already have the answer for.
+            remainingPVs.removeAll(gatherer.pvValues.keySet());
             HashMap<String, HashMap<String, Object>> resp = GetUrlContent.postStringListAndGetJSON(
                     gatherer.applianceInfo.getRetrievalURL() + "/../data/getDataAtTimeForAppliance?at="
-                            + TimeUtils.convertToISO8601String(atTime),
+                            + TimeUtils.convertToISO8601String(atTime)+"&searchPeriod="+searchPeriod.toString(),
                     "pv",
-                    gatherer.remainingPVs);
+                    remainingPVs);
             if (resp == null) return gatherer;
-            logger.debug("Done calling retrieval for appliance " + gatherer.applianceInfo.getIdentity()
-                    + " and got PV count " + ((resp != null) ? resp.size() : 0));
+            logger.debug("Done calling retrieval for appliance {} with PVs {} and got data for {}",
+                gatherer.applianceInfo.getIdentity(),
+                String.join(",", gatherer.pvsFromAppliance),
+                ((resp != null) ? String.join(",", resp.keySet()) : "no PVs"));
             for (String pvName : resp.keySet()) {
                 if (!gatherer.pvValues.containsKey(pvName)) {
                     gatherer.pvValues.put(pvName, resp.get(pvName));
-                    gatherer.remainingPVs.remove(pvName);
                 }
             }
         } catch (IOException ex) {
@@ -136,15 +131,39 @@ public class GetDataAtTime {
         return null;
     }
 
+    @SuppressWarnings("unchecked")
+    private static void addFieldValue(HashMap<String, Object> jsonval, String fieldName, String fieldValue) {
+        if(!jsonval.keySet().contains("meta")) {
+            HashMap<String, String> metaFields = new HashMap<String, String>();
+            jsonval.put("meta", metaFields);    
+        }
+        HashMap<String, String> meta = ((HashMap<String, String>)jsonval.get("meta"));
+        if(!meta.containsKey(fieldName)) {
+            meta.put(fieldName, fieldValue);
+        }
+    }
+
+
+
     private static <T> CompletableFuture<T>[] toArray(List<CompletableFuture<T>> list) {
         @SuppressWarnings("unchecked")
         CompletableFuture<T>[] futures = list.toArray(new CompletableFuture[0]);
         return futures;
     }
 
+    private static record PVNameMapping ( String nameFromRequest, String nameFromTypeInfo ) {};
+    private static record ProjRecord ( String pvName, String appliance, ArchDBRTypes DBRType, String[] archiveFields ) implements Serializable {};
+    private static class GDATProjection implements Projection<Map.Entry<String, PVTypeInfo>, ProjRecord> {
+        @Override
+        public ProjRecord transform(Map.Entry<String, PVTypeInfo> entry) {
+            String pvName = entry.getKey();
+            PVTypeInfo value = entry.getValue();
+            return new ProjRecord(pvName, value.getApplianceIdentity(), entry.getValue().getDBRType(), entry.getValue().getArchiveFields()) ;
+        }
+    }
+
     /**
      * The main getDataAtTime function. Pass in a list of PVs and a time.
-     * For now, we do not proxy external servers.
      * @param req
      * @param resp
      * @param configService
@@ -167,21 +186,58 @@ public class GetDataAtTime {
         boolean fetchFromExternalAppliances =
                 req.getParameter("includeProxies") != null && Boolean.parseBoolean(req.getParameter("includeProxies"));
 
+        String searchPeriodStr = req.getParameter("searchPeriod");
+        if(searchPeriodStr == null) {
+            searchPeriodStr = "P1D";
+        }
+        Period searchPeriod = Period.parse(searchPeriodStr);
+
         pmansProfiler.mark("After request params.");
+        
+        HashSet<String> paddedPVNames = new HashSet<String>();
+        LinkedList<PVNameMapping> nameMappings = new LinkedList<PVNameMapping>();
+        for(String pvName : pvNames) {
+            paddedPVNames.add(pvName);
+            nameMappings.add(new PVNameMapping(pvName, pvName));
+            // Patch pvNames to include PV's without any field names
+            String cname = PVNames.channelNamePVName(pvName);
+            if(!cname.equals(pvName)) {
+                paddedPVNames.add(cname);
+                nameMappings.add(new PVNameMapping(pvName, cname));
+            }
+            // Patch pvNames to add real names of any aliased PVs
+            String realName = configService.getRealNameForAlias(cname);
+            if(realName != null) {
+                paddedPVNames.add(realName);
+                nameMappings.add(new PVNameMapping(pvName, realName));
+            }
+        }
+        Map<String, List<PVNameMapping>> reverseMapping = nameMappings.stream().collect(Collectors.groupingBy(p -> p.nameFromTypeInfo()));
+        HashMap<String, String> pvName2TypeInfoName = new HashMap<String, String>();
 
         HashMap<String, Appliance2PVs> valuesGatherer = new HashMap<String, Appliance2PVs>();
-        List<CompletableFuture<Appliance2PVs>> pvBreakdownCalls = new LinkedList<CompletableFuture<Appliance2PVs>>();
+        Collection<ProjRecord> projRecords = configService.projectPVTypeInfos(new HashSet<String>(paddedPVNames), new GDATProjection());
+        Map<String, ProjRecord> pvName2proj = projRecords.stream().collect(Collectors.toMap(pr -> pr.pvName(), pr -> pr));
+
+        pmansProfiler.mark("After running projection");
+
+        Map<String, List<ProjRecord>> appliance2Records =  projRecords.stream().collect(Collectors.groupingBy(p -> p.appliance()));
         for (ApplianceInfo applianceInfo : configService.getAppliancesInCluster()) {
             Appliance2PVs gatherer = new Appliance2PVs(applianceInfo);
             valuesGatherer.put(applianceInfo.getIdentity(), gatherer);
-            try {
-                pvBreakdownCalls.add(CompletableFuture.supplyAsync(() -> {
-                    return getPVSFromAppliance(gatherer, pvNames);
-                }));
-            } catch (Throwable t) {
-                logger.error("Exception adding completable future", t);
+            List<ProjRecord> recsInAppliance = appliance2Records.getOrDefault(applianceInfo.getIdentity(), new LinkedList<ProjRecord>());
+            LinkedList<String> mappedPVsFromAppliance = new LinkedList<String>();
+            for(ProjRecord recInAppliance : recsInAppliance) {
+                List<PVNameMapping> mappedNms = reverseMapping.get(recInAppliance.pvName);
+                if(mappedNms != null && !mappedNms.isEmpty()) {
+                    mappedPVsFromAppliance.addAll(mappedNms.stream().map(pnm -> pnm.nameFromRequest).toList());
+                    mappedNms.forEach((pn -> pvName2TypeInfoName.put(pn.nameFromRequest, recInAppliance.pvName)));
+                }
             }
+            gatherer.pvsFromAppliance = mappedPVsFromAppliance;
         }
+
+        List<CompletableFuture<Appliance2PVs>> pvBreakdownCalls = new LinkedList<CompletableFuture<Appliance2PVs>>();
 
         CompletableFuture.allOf(toArray(pvBreakdownCalls)).join();
         pmansProfiler.mark("After filtering calls.");
@@ -203,7 +259,7 @@ public class GetDataAtTime {
         for (ApplianceInfo applianceInfo : configService.getAppliancesInCluster()) {
             try {
                 retrievalCalls.add(CompletableFuture.supplyAsync(() -> {
-                    return getDataFromRetrieval(valuesGatherer.get(applianceInfo.getIdentity()), atTime);
+                    return getDataFromRetrieval(valuesGatherer.get(applianceInfo.getIdentity()), atTime, searchPeriod);
                 }));
             } catch (Throwable t) {
                 logger.error("Exception adding completable future", t);
@@ -218,12 +274,21 @@ public class GetDataAtTime {
             ret.putAll(a2pv.pvValues);
         }
 
+        ret.forEach((pvName, jsonval) -> { 
+            String typeInfoName = pvName2TypeInfoName.get(pvName);
+            if(typeInfoName != null) {
+                ProjRecord projRec = pvName2proj.get(typeInfoName);
+                addFieldValue(jsonval, "DBRType", projRec.DBRType().toString());
+            }
+        });
+
         if (fetchFromExternalAppliances) {
             Map<String, String> externalServers = configService.getExternalArchiverDataServers();
             if (externalServers != null) {
-                HashSet<String> pvsForExternalServers = new HashSet<String>(pvNames);
-                pvsForExternalServers.removeAll(ret.keySet());
-                if (pvsForExternalServers.size() > 0) {
+                HashSet<String> remainingPVs = new HashSet<String>(pvNames);
+                // We only has for PVs that we do not already have the answer for.
+                remainingPVs.removeAll(ret.keySet());
+                if (remainingPVs.size() > 0) {
                     List<CompletableFuture<HashMap<String, HashMap<String, Object>>>> proxyCalls =
                             new LinkedList<CompletableFuture<HashMap<String, HashMap<String, Object>>>>();
                     for (String serverUrl : externalServers.keySet()) {
@@ -233,7 +298,7 @@ public class GetDataAtTime {
                             proxyCalls.add(CompletableFuture.supplyAsync(() -> {
                                 return getDataFromRemoteArchApplicance(
                                         serverUrl + "/data/getDataAtTime",
-                                        new LinkedList<String>(pvsForExternalServers),
+                                        new LinkedList<String>(remainingPVs),
                                         atTime);
                             }));
                         }
@@ -266,13 +331,69 @@ public class GetDataAtTime {
         logger.info("Retrieval time for " + pvNames.size() + " PVs at " + timeStr + pmansProfiler.toString());
     }
 
-    static class PVWithData {
+    private static class PVWithData {
         String pvName;
         HashMap<String, Object> sample;
 
         public PVWithData(String pvName, HashMap<String, Object> sample) {
             this.pvName = pvName;
             this.sample = sample;
+        }
+    }
+
+    private static class GetDataPredicate implements Predicate<Event> {
+        String pvName;
+        Instant atTime;
+        Instant stopAtTime;
+        HashMap<String, Object> evnt;
+        boolean pickedUpValue = false;
+        public GetDataPredicate(String pvName, Instant atTime) {
+            this.pvName = pvName;
+            this.atTime = atTime;
+            this.stopAtTime = atTime.minus(1, ChronoUnit.DAYS);
+            evnt = new HashMap<String, Object>();
+        }
+
+        public boolean test(Event event) {
+            DBRTimeEvent dbrEvent = (DBRTimeEvent) event;
+            // We are cruising backwards in time.
+            // At the first sample whose record processing timestamp is before or equal to the specified time, we pick up the value
+            // After that, we collect all the metadata 
+            // We stop after a days worth of iteration.
+            if(dbrEvent.getEventTimeStamp().isBefore(atTime) || dbrEvent.getEventTimeStamp().equals(atTime)) {
+                if(!pickedUpValue) {
+                    pickedUpValue = true;
+                    evnt.put("secs", dbrEvent.getEpochSeconds());
+                    this.stopAtTime = dbrEvent.getEventTimeStamp().minus(1, ChronoUnit.DAYS);
+                    evnt.put(
+                            "nanos",
+                            dbrEvent
+                                    .getEventTimeStamp()
+                                    .getNano());
+                    evnt.put("severity", dbrEvent.getSeverity());
+                    evnt.put("status", dbrEvent.getStatus());
+                    evnt.put(
+                            "val",
+                            JSONValue.parse(dbrEvent
+                                    .getSampleValue()
+                                    .toJSONString()));
+                }
+                if(pickedUpValue) {
+                    var evFields = dbrEvent.getFields();
+                    if(evFields != null && !evFields.isEmpty()) {
+                        for(String fieldName : evFields.keySet()) {
+                            addFieldValue(evnt, fieldName, evFields.get(fieldName));
+                        }
+                    }
+                }
+            }
+
+            if(dbrEvent.getEventTimeStamp().isBefore(this.stopAtTime)) {
+                logger.debug("Stopping iteration for {} at {}", this.pvName, TimeUtils.convertToHumanReadableString(dbrEvent.getEventTimeStamp()));
+                return false;
+            }
+
+            return true;
         }
     }
 
@@ -284,10 +405,8 @@ public class GetDataAtTime {
      * @param configService
      * @return
      */
-    private static PVWithData getDataAtTimeForPVFromStores(String pvName, Instant atTime, ConfigService configService) {
+    private static PVWithData getDataAtTimeForPVFromStores(String pvName, Instant atTime, Period searchPeriod, ConfigService configService) {
         String nameFromUser = pvName;
-        Instant startTime = atTime;
-        String fieldName = PVNames.getFieldName(pvName);
 
         PVTypeInfo typeInfo = PVNames.determineAppropriatePVTypeInfo(pvName, configService);
         if (typeInfo == null) return null;
@@ -295,73 +414,28 @@ public class GetDataAtTime {
                 .equals(configService.getMyApplianceInfo().getIdentity())) return null;
 
         pvName = typeInfo.getPvName();
-        PostProcessor postProcessor = new DefaultRawPostProcessor();
-        if (fieldName != null && Arrays.asList(typeInfo.getArchiveFields()).contains(fieldName)) {
-            startTime = TimeUtils.minusDays(
-                    atTime,
-                    1); // We typically write out embedded fields once a day; so go back a day to catch any changes if
-            // present.
-            postProcessor = new ExtraFieldsPostProcessor(fieldName);
-        }
 
         // There is a separate bulk call for the engine; so we can skip the engine.
-        // Go thru the stores in order...
+        // Go thru the stores in reverse order...
         try {
-            DBRTimeEvent potentialEvent = null, dEv = null;
-            for (String store : typeInfo.getDataStores()) {
+            // Very important we make a copy of the datastores here...
+            List<String> datastores = new ArrayList<String>(Arrays.asList(typeInfo.getDataStores()));
+            Collections.reverse(datastores);
+            for (String store : datastores) {
                 StoragePlugin storagePlugin = StoragePluginURLParser.parseStoragePlugin(store, configService);
                 try (BasicContext context = new BasicContext()) {
-                    List<Callable<EventStream>> streams =
-                            storagePlugin.getDataForPV(context, pvName, startTime, atTime, postProcessor);
-                    if (streams != null) {
-                        for (Callable<EventStream> stcl : streams) {
-                            try (EventStream stream = stcl.call()) {
-                                for (Event e : stream) {
-                                    dEv = (DBRTimeEvent) e;
-                                    if (dEv.getEventTimeStamp().isBefore(atTime)
-                                            || dEv.getEventTimeStamp().equals(atTime)) {
-                                        if (potentialEvent != null) {
-                                            if (dEv.getEventTimeStamp().isAfter(potentialEvent.getEventTimeStamp())) {
-                                                potentialEvent = (DBRTimeEvent) dEv.makeClone();
-                                            }
-                                        } else {
-                                            potentialEvent = dEv;
-                                        }
-                                    } else {
-                                        if (potentialEvent != null) {
-                                            HashMap<String, Object> evnt = new HashMap<String, Object>();
-                                            evnt.put("secs", potentialEvent.getEpochSeconds());
-                                            evnt.put(
-                                                    "nanos",
-                                                    potentialEvent
-                                                            .getEventTimeStamp()
-                                                            .getNano());
-                                            evnt.put("severity", potentialEvent.getSeverity());
-                                            evnt.put("status", potentialEvent.getStatus());
-                                            evnt.put(
-                                                    "val",
-                                                    JSONValue.parse(potentialEvent
-                                                            .getSampleValue()
-                                                            .toJSONString()));
-                                            return new PVWithData(nameFromUser, evnt);
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                    if(storagePlugin instanceof BiDirectionalIterable) {
+                        Instant startAtTime = atTime.plus(5, ChronoUnit.MINUTES);
+                        GetDataPredicate thePredicate = new GetDataPredicate(pvName, atTime);
+                        // The searchPeriod here is only to get enough chunks to facilitate the search. The iteration should stop at the specified time period.
+                        ((BiDirectionalIterable)storagePlugin).iterate(context, pvName, startAtTime, thePredicate, IterationDirection.BACKWARDS, searchPeriod.plusDays(31));
+                        if(thePredicate.pickedUpValue) {
+                            return new PVWithData(nameFromUser, thePredicate.evnt);
+                        }                        
                     } else {
-                        logger.warn("No eventstream when looking for point data for PV " + pvName);
+                        logger.info("Plugin {} does not implement the BiDirectionalIterable interface", storagePlugin.getName());
                     }
                 }
-            }
-            if (potentialEvent != null) {
-                HashMap<String, Object> evnt = new HashMap<String, Object>();
-                evnt.put("secs", potentialEvent.getEpochSeconds());
-                evnt.put("nanos", potentialEvent.getEventTimeStamp().getNano());
-                evnt.put("severity", potentialEvent.getSeverity());
-                evnt.put("status", potentialEvent.getStatus());
-                evnt.put("val", JSONValue.parse(potentialEvent.getSampleValue().toJSONString()));
-                return new PVWithData(nameFromUser, evnt);
             }
         } catch (Exception ex) {
             logger.error("Getting data at time for PV " + pvName, ex);
@@ -383,6 +457,12 @@ public class GetDataAtTime {
             timeStr = TimeUtils.convertToISO8601String(TimeUtils.getCurrentEpochSeconds());
         }
         Instant atTime = TimeUtils.convertFromISO8601String(timeStr);
+        String searchPeriodStr = req.getParameter("searchPeriod");
+        if(searchPeriodStr == null) {
+            searchPeriodStr = "P1D";
+        }
+        Period searchPeriod = Period.parse(searchPeriodStr);
+
 
         logger.debug("Getting data from instance for " + pvNames.size() + " PVs at "
                 + TimeUtils.convertToHumanReadableString(atTime));
@@ -390,7 +470,7 @@ public class GetDataAtTime {
         List<CompletableFuture<PVWithData>> retrievalCalls = new LinkedList<CompletableFuture<PVWithData>>();
         for (String pvName : pvNames) {
             retrievalCalls.add(CompletableFuture.supplyAsync(() -> {
-                return getDataAtTimeForPVFromStores(pvName, atTime, configService);
+                return getDataAtTimeForPVFromStores(pvName, atTime, searchPeriod, configService);
             }));
         }
 
@@ -406,5 +486,12 @@ public class GetDataAtTime {
         try (PrintWriter out = resp.getWriter()) {
             JSONValue.writeJSONString(ret, out);
         }
+    }
+
+    public static HashMap<String, HashMap<String, Object>> testGetDataAtTimeForPVFromStores(String pvName, Instant atTime, Period searchPeriod, ConfigService configService) {
+        HashMap<String, HashMap<String, Object>> ret = new HashMap<String, HashMap<String, Object>>();
+        PVWithData pd = getDataAtTimeForPVFromStores(pvName, atTime, searchPeriod, configService);
+        ret.put(pd.pvName, pd.sample);
+        return ret;
     }
 }

--- a/src/main/org/epics/archiverappliance/retrieval/GetDataAtTime.java
+++ b/src/main/org/epics/archiverappliance/retrieval/GetDataAtTime.java
@@ -18,6 +18,7 @@ import org.epics.archiverappliance.config.StoragePluginURLParser;
 import org.epics.archiverappliance.data.DBRTimeEvent;
 import org.epics.archiverappliance.mgmt.bpl.PVsMatchingParameter;
 import org.epics.archiverappliance.utils.ui.GetUrlContent;
+import org.epics.archiverappliance.utils.ui.MetaFields;
 import org.json.simple.JSONValue;
 
 import java.io.IOException;
@@ -130,20 +131,6 @@ public class GetDataAtTime {
         }
         return null;
     }
-
-    @SuppressWarnings("unchecked")
-    private static void addFieldValue(HashMap<String, Object> jsonval, String fieldName, String fieldValue) {
-        if(!jsonval.keySet().contains("meta")) {
-            HashMap<String, String> metaFields = new HashMap<String, String>();
-            jsonval.put("meta", metaFields);    
-        }
-        HashMap<String, String> meta = ((HashMap<String, String>)jsonval.get("meta"));
-        if(!meta.containsKey(fieldName)) {
-            meta.put(fieldName, fieldValue);
-        }
-    }
-
-
 
     private static <T> CompletableFuture<T>[] toArray(List<CompletableFuture<T>> list) {
         @SuppressWarnings("unchecked")
@@ -278,7 +265,7 @@ public class GetDataAtTime {
             String typeInfoName = pvName2TypeInfoName.get(pvName);
             if(typeInfoName != null) {
                 ProjRecord projRec = pvName2proj.get(typeInfoName);
-                addFieldValue(jsonval, "DBRType", projRec.DBRType().toString());
+                MetaFields.addMetaFieldValue(jsonval, "DBRType", projRec.DBRType().toString());
             }
         });
 
@@ -382,7 +369,7 @@ public class GetDataAtTime {
                     var evFields = dbrEvent.getFields();
                     if(evFields != null && !evFields.isEmpty()) {
                         for(String fieldName : evFields.keySet()) {
-                            addFieldValue(evnt, fieldName, evFields.get(fieldName));
+                            MetaFields.addMetaFieldValue(evnt, fieldName, evFields.get(fieldName));
                         }
                     }
                 }

--- a/src/main/org/epics/archiverappliance/utils/ui/GetUrlContent.java
+++ b/src/main/org/epics/archiverappliance/utils/ui/GetUrlContent.java
@@ -17,6 +17,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -340,7 +341,7 @@ public class GetUrlContent {
 	 * @return JSONArray  &emsp; 
 	 * @throws IOException  &emsp; 
 	 */
-	public static <T> T postStringListAndGetJSON(String url, String paramName, List<String> params) throws IOException {
+	public static <T> T postStringListAndGetJSON(String url, String paramName, Collection<String> params) throws IOException {
 		StringWriter buf = new StringWriter();
 		buf.append(paramName);
 		buf.append("=");

--- a/src/main/org/epics/archiverappliance/utils/ui/MetaFields.java
+++ b/src/main/org/epics/archiverappliance/utils/ui/MetaFields.java
@@ -1,0 +1,28 @@
+package org.epics.archiverappliance.utils.ui;
+
+import java.util.HashMap;
+
+/**
+ * Utility class for dealing with metafields as part of responses.
+ * @author mshankar
+ *
+ */
+public class MetaFields {
+
+    /*
+     * We typically return meta fields as a "meta" attribute in JSON objects.
+     * Use this utility method to add a meta field name/value pair into a JSON object
+     */
+    @SuppressWarnings("unchecked")
+    public static void addMetaFieldValue(HashMap<String, Object> jsonval, String fieldName, String fieldValue) {
+        if(!jsonval.keySet().contains("meta")) {
+            HashMap<String, String> metaFields = new HashMap<String, String>();
+            jsonval.put("meta", metaFields);    
+        }
+        HashMap<String, String> meta = ((HashMap<String, String>)jsonval.get("meta"));
+        if(!meta.containsKey(fieldName)) {
+            meta.put(fieldName, fieldValue);
+        }
+    }
+
+}

--- a/src/resources/test/log4j2.xml
+++ b/src/resources/test/log4j2.xml
@@ -20,8 +20,8 @@
 
  <Loggers>
   <Logger name="config" level="debug"/>
-  <Logger name="hz" level="warn"/>
-  <Root level="debug">
+  <Logger name="hz" level="$${env:HZ_LOG_LEVEL:-warn}"/>
+  <Root level="info">
    <AppenderRef ref="RollingFile" level="$${env:LOG_LEVEL:-info}"/>
    <AppenderRef ref="STDOUT" level="info"/>
   </Root>

--- a/src/test/edu/stanford/slac/archiverappliance/PB/utils/ReverseLineByteStreamTest.java
+++ b/src/test/edu/stanford/slac/archiverappliance/PB/utils/ReverseLineByteStreamTest.java
@@ -1,0 +1,199 @@
+package edu.stanford.slac.archiverappliance.PB.utils;
+
+import edu.stanford.slac.archiverappliance.PB.search.EvenNumberSampleFileGenerator;
+import org.epics.archiverappliance.ByteArray;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.epics.archiverappliance.config.ConfigServiceForTests;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.text.DecimalFormat;
+import java.util.Random;
+
+public class ReverseLineByteStreamTest {
+    private static Logger logger = LogManager.getLogger(ReverseLineByteStreamTest.class.getName());
+
+    /*
+     * Test that we are reading all the bytes in the file.
+     * The ReverseLineByteStream consists of multiple layers
+     * The bottom most reads the file into a buffer.
+     * This only tests that layer
+     */
+    @Test
+    public void testWeAreReadingAllBytes() throws Exception {
+        logger.info("testWeAreReadingAllBytes");
+        String fileName = ConfigServiceForTests.getDefaultPBTestFolder() + "/" + "ReverseLineByteStreamTest.txt";
+        for(int fileSize = 2*ReverseLineByteStream.MAX_LINE_SIZE; fileSize < 4*ReverseLineByteStream.MAX_LINE_SIZE; fileSize += 1) {
+            File f = new File(fileName);
+            if (f.exists()) {
+                f.delete();
+            }
+    
+            Random rand = new Random();
+            try(BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(f, false))) {
+                byte[] buffer = new byte[fileSize];
+                rand.nextBytes(buffer); // Don't really care what we put into the buffer
+                os.write(buffer);
+            }
+            
+            logger.debug("Testing with file length {} ", f.length());
+            try (ReverseLineByteStream lis = new ReverseLineByteStream(f.toPath())) {
+                boolean bRead = lis.testFillBuffer();
+                while(bRead) {
+                    bRead = lis.testFillBuffer();
+                }
+                Assertions.assertEquals(f.length(), lis.getTotalBytesRead(), "Mismatch in bytes read and file length");
+    
+                f.delete();
+            }
+            logger.debug("Done testing with file length {} ", f.length());
+        }
+    }
+
+    /*
+     * The ReverseLineByteStream consists of multiple layers
+     * The next layer up reads lines from the byte buffer into a line buffer.
+     * This only tests the line buffer layer
+     */
+    @Test
+    public void testWeAreReadingAllLines() throws Exception {
+        logger.info("testWeAreReadingAllLines");
+        String fileName = ConfigServiceForTests.getDefaultPBTestFolder() + "/" + "ReverseLineByteStreamTest.txt";
+        for(int numLines = 2; numLines < 100; numLines++) {
+            File f = new File(fileName);
+            if (f.exists()) {
+                f.delete();
+            }
+
+            int expectedLines = 10*1024 + numLines;
+
+            try(PrintStream fos = new PrintStream(new BufferedOutputStream(new FileOutputStream(f, false)))) {
+                for(int i = 0; i <= expectedLines; i++) {
+                    fos.print("We print the same line over and over again" + LineEscaper.NEWLINE_CHAR_STR);
+                }
+            }
+
+            logger.debug("Testing with numlines {} ", numLines);
+            try (ReverseLineByteStream lis = new ReverseLineByteStream(f.toPath())) {
+                int linesRead = 0;
+                boolean bRead = lis.testFillLineBuffer();
+                while(bRead) {
+                    linesRead++;
+                    bRead = lis.testFillLineBuffer();
+                }
+                Assertions.assertEquals(expectedLines, linesRead, "Mismatch in lines read");
+    
+                f.delete();
+            }
+            logger.debug("Done testing with numlines {} ", numLines);
+        }
+    }
+
+    /*
+     * The ReverseLineByteStream consists of multiple layers
+     * This tests the final layer; the one where we actually get the line
+     */
+    @Test
+    public void testTheActualLines() throws Exception {
+        logger.info("testTheActualLines");
+        String fileName = ConfigServiceForTests.getDefaultPBTestFolder() + "/" + "ReverseLineByteStreamTest.txt";
+        for(int numLines = 2; numLines < 100; numLines++) {
+            File f = new File(fileName);
+            if (f.exists()) {
+                f.delete();
+            }
+
+            int expectedLines = 10*1024 + numLines;
+            int maxInt = -1;
+
+            try(PrintStream fos = new PrintStream(new BufferedOutputStream(new FileOutputStream(f, false)))) {
+                for(int i = 0; i < expectedLines; i++) {
+                    fos.print("This is a line " + i + LineEscaper.NEWLINE_CHAR_STR);
+                    maxInt = i;
+                }
+            }
+            int expectedInt = maxInt;
+            logger.debug("Testing with numlines {} ", numLines);
+            try (ReverseLineByteStream lis = new ReverseLineByteStream(f.toPath())) {
+                int linesRead = 0;
+                ByteArray bar = new ByteArray(ReverseLineByteStream.MAX_LINE_SIZE);
+                boolean bRead = lis.readLine(bar);
+                String theline = new String(bar.toBytes());
+                while(bRead) {
+                    Assertions.assertEquals("This is a line " + expectedInt, theline, "Mismatch");
+                    linesRead++;
+                    expectedInt--;
+                    bRead = lis.readLine(bar);
+                    theline = new String(bar.toBytes());
+                }
+                Assertions.assertEquals("This is a line " + 0, theline, "Mismatch at line 0");
+                Assertions.assertEquals(expectedLines, linesRead, "Mismatch in lines read");
+    
+                f.delete();
+            }
+            logger.debug("Done testing with numlines {} ", numLines);
+        }
+    }
+
+    /*
+     * Test seek to position...
+     */
+    @Test
+    public void testSeekToPosition() throws Exception {
+        logger.debug("testSeekToPosition");
+        String fileName = ConfigServiceForTests.getDefaultPBTestFolder() + "/" + "ReverseLineByteStreamTest.txt";
+        File f = new File(fileName);
+        if (f.exists()) {
+            f.delete();
+        }
+
+        DecimalFormat fmt = new DecimalFormat( "0000" );
+        try(PrintStream fos = new PrintStream(new BufferedOutputStream(new FileOutputStream(f, false)));) {
+            for(int i = 0; i < 10000; i++) {
+                fos.print(fmt.format(i) + LineEscaper.NEWLINE_CHAR_STR);
+            }
+        }
+        // Each number is 4 chars and a new line = 5 chars
+        seekandCheck(f, 99, "0018"); // x63
+        seekandCheck(f, 100, "0018"); // x64
+        seekandCheck(f, 101, "0018"); // x65
+        seekandCheck(f, 102, "0019"); // x66
+        seekandCheck(f, 103, "0019"); // x67
+        seekandCheck(f, 104, "0019"); // x68
+        seekandCheck(f, 105, "0019"); // x69
+        seekandCheck(f, 106, "0019"); // x70
+        seekandCheck(f, 107, "0020"); // x71
+        seekandCheck(f, 108, "0020"); // x72
+
+        // The seekToBeforePreviousLine discards a line; so if we seek to the end of the file and read, we should skip one number
+        seekandCheck(f, f.length(), "9998");
+
+        // To read from the last line, use the plain constructor
+        ByteArray bar = new ByteArray(LineByteStream.MAX_LINE_SIZE);
+        try (ReverseLineByteStream lis = new ReverseLineByteStream(f.toPath())) {
+            lis.readLine(bar);
+            Assertions.assertEquals("9999", new String(bar.toBytes()), "Mismatch when reading from the end of the file");
+        }
+
+        f.delete();
+    }
+
+
+    private static void seekandCheck(File f, long position, String expectedNumberStr) throws IOException {
+        logger.info("Seeking to " + position + " and checking for " + expectedNumberStr);
+        ByteArray bar = new ByteArray(LineByteStream.MAX_LINE_SIZE);
+        try (ReverseLineByteStream lis = new ReverseLineByteStream(f.toPath())) {
+            lis.seekToBeforePreviousLine(position);
+            lis.readLine(bar);
+            Assertions.assertEquals(expectedNumberStr, new String(bar.toBytes()), "Mismatch at position " + position);
+        }
+    }
+}

--- a/src/test/edu/stanford/slac/archiverappliance/PB/utils/ReverseLineByteStreamTest.java
+++ b/src/test/edu/stanford/slac/archiverappliance/PB/utils/ReverseLineByteStreamTest.java
@@ -1,13 +1,11 @@
 package edu.stanford.slac.archiverappliance.PB.utils;
 
-import edu.stanford.slac.archiverappliance.PB.search.EvenNumberSampleFileGenerator;
 import org.epics.archiverappliance.ByteArray;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedOutputStream;

--- a/src/test/edu/stanford/slac/archiverappliance/PB/utils/ReverseLineByteStreamTest.java
+++ b/src/test/edu/stanford/slac/archiverappliance/PB/utils/ReverseLineByteStreamTest.java
@@ -89,7 +89,8 @@ public class ReverseLineByteStreamTest {
                     linesRead++;
                     bRead = lis.testFillLineBuffer();
                 }
-                Assertions.assertEquals(expectedLines, linesRead, "Mismatch in lines read");
+                // The -1 is because the ReverseLineByteStream constructors do a fillLineBuffer
+                Assertions.assertEquals(expectedLines-1, linesRead, "Mismatch in lines read");
     
                 f.delete();
             }
@@ -132,7 +133,9 @@ public class ReverseLineByteStreamTest {
                     linesRead++;
                     expectedInt--;
                     bRead = lis.readLine(bar);
-                    theline = new String(bar.toBytes());
+                    if(bRead) {
+                        theline = new String(bar.toBytes());
+                    }
                 }
                 Assertions.assertEquals("This is a line " + 0, theline, "Mismatch at line 0");
                 Assertions.assertEquals(expectedLines, linesRead, "Mismatch in lines read");

--- a/src/test/org/epics/archiverappliance/retrieval/saverestore/GetDataAtTimeForPVFromStoresTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/saverestore/GetDataAtTimeForPVFromStoresTest.java
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ * Copyright (c) 2011 The Board of Trustees of the Leland Stanford Junior University
+ * as Operator of the SLAC National Accelerator Laboratory.
+ * Copyright (c) 2011 Brookhaven National Laboratory.
+ * EPICS archiver appliance is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ *******************************************************************************/
+
+package org.epics.archiverappliance.retrieval.saverestore;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.epics.archiverappliance.common.BasicContext;
+import org.epics.archiverappliance.common.POJOEvent;
+import org.epics.archiverappliance.common.TimeUtils;
+import org.epics.archiverappliance.config.ArchDBRTypes;
+import org.epics.archiverappliance.config.ConfigServiceForTests;
+import org.epics.archiverappliance.config.PVTypeInfo;
+import org.epics.archiverappliance.config.StoragePluginURLParser;
+import org.epics.archiverappliance.config.exception.AlreadyRegisteredException;
+import org.epics.archiverappliance.config.exception.ConfigException;
+import org.epics.archiverappliance.data.DBRTimeEvent;
+import org.epics.archiverappliance.data.ScalarValue;
+import org.epics.archiverappliance.engine.membuf.ArrayListEventStream;
+import org.epics.archiverappliance.retrieval.GetDataAtTime;
+import org.epics.archiverappliance.retrieval.RemotableEventStreamDesc;
+import org.json.simple.JSONValue;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import edu.stanford.slac.archiverappliance.PlainPB.PlainPBStoragePlugin;
+
+
+/**
+ * Test GetDataAtTime's internal method getDataAtTimeForPVFromStores
+ * We want to make sure we pick up both the .VAL's and the .FIELDS's in various siutuations.
+ * Generate a PB file with a days worth of 1Hz PV data ending at the current time.
+ * Approx 12 hrs before the current time, add in all the fields as if it were the daily refresh of the metafields.
+ * At 3, 6, 9 hrs before the current time, update some field as if someone did a caput
+ * If we ask for getDataAtTimeForPVFromStores at various points in time, we should get various results.
+ * @author mshankar
+ *
+ */
+public class GetDataAtTimeForPVFromStoresTest {
+    private static final Logger logger = LogManager.getLogger(GetDataAtTimeForPVFromStoresTest.class.getName());
+    private static String pvName = "GetDataAtTimeForPVFromStoresTest";
+    private static ArchDBRTypes dbrType = ArchDBRTypes.DBR_SCALAR_DOUBLE;
+    private static ConfigServiceForTests configService;
+    private static short currentYear = TimeUtils.getCurrentYear();
+    private static Instant now = TimeUtils.now();
+    private static Instant yesterday = now.minus(86400, ChronoUnit.SECONDS);
+    private static Instant ago_3hrs = now.minus(60*60*3, ChronoUnit.SECONDS);
+    private static Instant ago_6hrs = now.minus(60*60*6, ChronoUnit.SECONDS);
+    private static Instant ago_9hrs = now.minus(60*60*9, ChronoUnit.SECONDS);
+    private static Instant ago_12hrs = now.minus(60*60*12, ChronoUnit.SECONDS);
+
+    static File testFolder = new File(ConfigServiceForTests.getDefaultPBTestFolder()
+            + File.separator
+            + GetDataAtTimeForPVFromStoresTest.class.getSimpleName());
+    static String storagePBPluginString = "pb://localhost?name=" + GetDataAtTimeForPVFromStoresTest.class.getSimpleName()
+            + "&rootFolder=" + testFolder.getAbsolutePath() + "&partitionGranularity=PARTITION_YEAR";
+
+    static {
+        try {
+            configService = new ConfigServiceForTests(-1);
+        } catch (ConfigException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    private static PlainPBStoragePlugin getStoragePlugin() throws IOException {
+        return (PlainPBStoragePlugin) StoragePluginURLParser.parseStoragePlugin(
+                storagePBPluginString,
+                configService);
+    }
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        deleteData();
+        createTestData();
+    }
+
+    @AfterAll
+    public static void tearDown() throws IOException {
+        deleteData();
+    }
+
+    private static void deleteData() throws IOException {
+        FileUtils.deleteDirectory(new File(getStoragePlugin().getRootFolder()));
+    }
+
+    private static void createTestData() throws IOException {
+        PlainPBStoragePlugin storagePlugin = getStoragePlugin();
+
+        try (BasicContext context = new BasicContext()) {
+            ArrayListEventStream events = new ArrayListEventStream(currentYear, 
+                new RemotableEventStreamDesc(ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                    pvName,
+                    currentYear));
+            Instant dataTs = yesterday;
+            while(dataTs.isBefore(now)) {
+                DBRTimeEvent ev = (DBRTimeEvent) new POJOEvent(dbrType, dataTs, new ScalarValue<Long>(dataTs.getEpochSecond()), 0, 0).makeClone();
+                if(dataTs.equals(ago_12hrs)) {
+                    logger.info("Daily refresh of meta at -12hrs");
+                    ev.addFieldValue("HIHI", "HIHI_@_12");
+                    ev.addFieldValue("LOLO", "LOLO_@_12");
+                    ev.addFieldValue("HIGH", "HIGH_@_12");
+                    ev.addFieldValue("LOW", "LOW_@_12");
+                }
+                if(dataTs.equals(ago_9hrs)) {
+                    logger.info("caput of HIHI at -9hrs");
+                    ev.addFieldValue("HIHI", "HIHI_@_9");
+                }
+                if(dataTs.equals(ago_6hrs)) {
+                    logger.info("caput of HIHI and LOLO at -6hrs");
+                    ev.addFieldValue("HIHI", "HIHI_@_6");
+                    ev.addFieldValue("LOLO", "LOLO_@_6");
+                }
+                if(dataTs.equals(ago_3hrs)) {
+                    logger.info("caput of HIHI at -3hrs");
+                    ev.addFieldValue("HIHI", "HIHI_@_3");
+                }
+                events.add(ev);
+                dataTs = dataTs.plus(1, ChronoUnit.SECONDS);
+            }
+            storagePlugin.appendData(context, pvName, events);
+        }
+
+        try {
+            PVTypeInfo typeInfo = new PVTypeInfo(pvName, ArchDBRTypes.DBR_SCALAR_DOUBLE, true, 1);
+            String[] dataStores = new String[] {storagePBPluginString};
+            typeInfo.setDataStores(dataStores);
+            typeInfo.setApplianceIdentity(configService.getMyApplianceInfo().getIdentity());
+            configService.updateTypeInfoForPV(pvName, typeInfo);
+            configService.registerPVToAppliance(pvName, configService.getMyApplianceInfo());    
+        } catch(AlreadyRegisteredException ex) {
+            throw new IOException(ex);
+        }
+    }
+    
+    @Test
+    public void testGetData() throws Exception {
+        testGetDataAsOf(now, 
+            Map.of(
+            "HIHI", "HIHI_@_3",
+            "LOLO", "LOLO_@_6",
+            "HIGH", "HIGH_@_12",
+            "LOW", "LOW_@_12"
+            )
+        );
+        testGetDataAsOf(now.minus(4, ChronoUnit.HOURS), 
+            Map.of(
+            "HIHI", "HIHI_@_6",
+            "LOLO", "LOLO_@_6",
+            "HIGH", "HIGH_@_12",
+            "LOW", "LOW_@_12"
+            )
+        );
+        testGetDataAsOf(now.minus(7, ChronoUnit.HOURS), 
+            Map.of(
+            "HIHI", "HIHI_@_9",
+            "LOLO", "LOLO_@_12",
+            "HIGH", "HIGH_@_12",
+            "LOW", "LOW_@_12"
+            )
+        );
+        testGetDataAsOf(now.minus(10, ChronoUnit.HOURS), 
+            Map.of(
+            "HIHI", "HIHI_@_12",
+            "LOLO", "LOLO_@_12",
+            "HIGH", "HIGH_@_12",
+            "LOW", "LOW_@_12"
+            )
+        );
+        testGetDataAsOf(now.minus(16, ChronoUnit.HOURS), null);
+    }
+
+    public void testGetDataAsOf(Instant when, Map<String, String> expectedFieldVals) throws Exception {
+        Period searchPeriod = Period.parse("P1D");
+        try (BasicContext context = new BasicContext()) {
+            HashMap<String, HashMap<String, Object>> pvDatas = GetDataAtTime.testGetDataAtTimeForPVFromStores(pvName, when, searchPeriod, configService);
+            HashMap<String, Object> pvData = pvDatas.get(pvName);
+            Assertions.assertNotNull(
+                pvData,
+                "Getting at time " + when + " returns null?"
+                );
+            logger.info(JSONValue.toJSONString(pvDatas));
+            Assertions.assertTrue(
+                Math.abs(((long)pvData.get("secs")) - when.getEpochSecond()) < 2,
+                "Expected " + when.getEpochSecond() + " got " + pvData.get("secs")
+            );
+            @SuppressWarnings("unchecked")
+            HashMap<String, String> metas = (HashMap<String, String>) pvData.get("meta");
+            if(expectedFieldVals == null) {
+                Assertions.assertNull(metas);
+            } else {
+                for(String key : expectedFieldVals.keySet()) {
+                    Assertions.assertNotNull(metas.get(key)); 
+                    Assertions.assertEquals(metas.get(key), expectedFieldVals.get(key));
+                }
+                for(String key : metas.keySet()){
+                    // Make sure every key in metas is expected.
+                    Assertions.assertTrue(expectedFieldVals.containsKey(key), "Unexpected key " + key);
+                }    
+            }
+        }
+    }
+}

--- a/src/test/org/epics/archiverappliance/retrieval/saverestore/GetDataAtTimeForPVFromStoresTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/saverestore/GetDataAtTimeForPVFromStoresTest.java
@@ -15,6 +15,7 @@ import java.time.Period;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
@@ -37,7 +38,9 @@ import org.json.simple.JSONValue;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import edu.stanford.slac.archiverappliance.PlainPB.PlainPBStoragePlugin;
 
@@ -147,42 +150,52 @@ public class GetDataAtTimeForPVFromStoresTest {
             throw new IOException(ex);
         }
     }
+
+    public static Stream<Arguments> provideTimesAndFields() {
+        return Stream.of(
+            Arguments.of(now,
+                Map.of(
+                    "HIHI", "HIHI_@_3",
+                    "LOLO", "LOLO_@_6",
+                    "HIGH", "HIGH_@_12",
+                    "LOW", "LOW_@_12"
+                    )
+                ),
+                Arguments.of(now.minus(4, ChronoUnit.HOURS),
+                Map.of(
+                    "HIHI", "HIHI_@_6",
+                    "LOLO", "LOLO_@_6",
+                    "HIGH", "HIGH_@_12",
+                    "LOW", "LOW_@_12"
+                    )
+                ),
+                Arguments.of(now.minus(7, ChronoUnit.HOURS),
+                Map.of(
+                    "HIHI", "HIHI_@_9",
+                    "LOLO", "LOLO_@_12",
+                    "HIGH", "HIGH_@_12",
+                    "LOW", "LOW_@_12"
+                    )
+                ),
+                Arguments.of(now.minus(10, ChronoUnit.HOURS), 
+                Map.of(
+                    "HIHI", "HIHI_@_12",
+                    "LOLO", "LOLO_@_12",
+                    "HIGH", "HIGH_@_12",
+                    "LOW", "LOW_@_12"
+                    )
+                ),
+                Arguments.of(now.minus(16, ChronoUnit.HOURS),
+                null
+                )
+        );
+    }
+
     
-    @Test
-    public void testGetData() throws Exception {
-        testGetDataAsOf(now, 
-            Map.of(
-            "HIHI", "HIHI_@_3",
-            "LOLO", "LOLO_@_6",
-            "HIGH", "HIGH_@_12",
-            "LOW", "LOW_@_12"
-            )
-        );
-        testGetDataAsOf(now.minus(4, ChronoUnit.HOURS), 
-            Map.of(
-            "HIHI", "HIHI_@_6",
-            "LOLO", "LOLO_@_6",
-            "HIGH", "HIGH_@_12",
-            "LOW", "LOW_@_12"
-            )
-        );
-        testGetDataAsOf(now.minus(7, ChronoUnit.HOURS), 
-            Map.of(
-            "HIHI", "HIHI_@_9",
-            "LOLO", "LOLO_@_12",
-            "HIGH", "HIGH_@_12",
-            "LOW", "LOW_@_12"
-            )
-        );
-        testGetDataAsOf(now.minus(10, ChronoUnit.HOURS), 
-            Map.of(
-            "HIHI", "HIHI_@_12",
-            "LOLO", "LOLO_@_12",
-            "HIGH", "HIGH_@_12",
-            "LOW", "LOW_@_12"
-            )
-        );
-        testGetDataAsOf(now.minus(16, ChronoUnit.HOURS), null);
+    @ParameterizedTest
+    @MethodSource("provideTimesAndFields")
+    public void testGetData(Instant when, Map<String, String> expectedFieldVals) throws Exception {
+        testGetDataAsOf(when, expectedFieldVals);
     }
 
     public void testGetDataAsOf(Instant when, Map<String, String> expectedFieldVals) throws Exception {


### PR DESCRIPTION
Changed GetDataAtTime significantly
Add a new bidirectional interface
Eliminated the mgmt call as part of GetDataAtTime in favor of a Hz query Hence, upgrade hz as part of this commit
Will consider switching to this for other calls as well. We should be able to support a higher concurrent users for the GetDataAtTime call simply by using a higher Hz query thread count