### PR TITLE
Fix a couple of log statements that are filling up the production logs

### DIFF
--- a/src/main/org/epics/archiverappliance/engine/pv/EPICS_V3_PV.java
+++ b/src/main/org/epics/archiverappliance/engine/pv/EPICS_V3_PV.java
@@ -708,7 +708,7 @@ public class EPICS_V3_PV implements PV, ControllingPV, ConnectionListener, Monit
                 } else {
                     assert (con != null);
                     if (generatedDBRType != archDBRType) {
-                        logger.warn("The type of PV " + this.name + " has changed from " + archDBRType + " to "
+                        logger.debug("The type of PV " + this.name + " has changed from " + archDBRType + " to "
                                 + generatedDBRType);
                         fireDroppedSampleTypeChange(generatedDBRType);
                         return;

--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/PostProcessors.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/PostProcessors.java
@@ -98,11 +98,11 @@ public class PostProcessors {
 						}
 						return implementationInstance;
 					}
+					logger.error("Did not find post processor for " + postProcessorUserArg);
 				}
 			} catch(Exception ex) {
 				logger.error("Exception initializing processor", ex);
 			}
-			logger.error("Did not find post processor for " + postProcessorUserArg);
 		}
 		return null;
 	}


### PR DESCRIPTION
The log statement in PostProcessors is incorrectly placed.
The log statement in EPICS_V3_PV is not necessarily needed as a warning as we maintain a count of samples lost to type changes.