### PR TITLE
#259 Remove the call to getPausedPVsInThisAppliance() when computing …

### DIFF
--- a/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
+++ b/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
@@ -935,6 +935,7 @@ public class DefaultConfigService implements ConfigService {
 
                 if (typeInfo.isPaused()) {
                     logger.debug(() -> "Skipping archiving paused PV " + pvName + " on startup");
+                    this.engineContext.incrementPausedPVCount();
                     continue;
                 }
 

--- a/src/main/org/epics/archiverappliance/engine/ArchiveEngine.java
+++ b/src/main/org/epics/archiverappliance/engine/ArchiveEngine.java
@@ -322,6 +322,8 @@ public class ArchiveEngine {
 		if (channel != null) {
 			channel.shutdownMetaChannels();
 			channel.stop();
+			channel.setPaused(true);
+			engineContext.incrementPausedPVCount();
 			destoryPv(pvName, configservice);
 		}
 	}
@@ -344,12 +346,14 @@ public class ArchiveEngine {
 		if (channel != null) {
 			channel.stop();
 			channel.start();
+			channel.setPaused(false);
 		} else {
 			// We have not created the channel on startup.
 			// We should start it up
 			logger.debug("We had not created the channel on startup. Creating it " + pvName);
 			startChannelsForPV(pvName, configservice);
 		}
+		engineContext.decrementPausedPVCount();
 	}
 
 

--- a/src/main/org/epics/archiverappliance/engine/epics/EngineMetrics.java
+++ b/src/main/org/epics/archiverappliance/engine/epics/EngineMetrics.java
@@ -161,15 +161,13 @@ public class EngineMetrics implements Details {
         int disconnectedChannels = 0;
         int totalChannels = 0;
 
-        Set<String> pausedPVs = configService.getPausedPVsInThisAppliance();
-
         for (Entry<String, ArchiveChannel> tempEntry :
                 engineContext.getChannelList().entrySet()) {
             ArchiveChannel channel = tempEntry.getValue();
             String pvName = channel.getName();
             try {
-                if (pausedPVs.contains(pvName)) {
-                    // Skipping paused PV.
+                if (channel.isPaused()) {
+                    logger.debug("Skipping paused PV {}", pvName);
                     continue;
                 }
 
@@ -196,7 +194,7 @@ public class EngineMetrics implements Details {
         engineMetrics.setPvCount(totalChannels);
         engineMetrics.setConnectedPVCount(connectedChannels);
         engineMetrics.setDisconnectedPVCount(disconnectedChannels);
-        engineMetrics.setPausedPVCount(pausedPVs.size());
+        engineMetrics.setPausedPVCount(engineContext.getPausedPVCount());
         int totalchannelCount = engineContext.getChannelList().size();
         for (ArchiveChannel archiveChannel : engineContext.getChannelList().values()) {
             totalchannelCount += archiveChannel.getMetaChannelCount();

--- a/src/main/org/epics/archiverappliance/engine/model/ArchiveChannel.java
+++ b/src/main/org/epics/archiverappliance/engine/model/ArchiveChannel.java
@@ -152,6 +152,14 @@ public abstract class ArchiveChannel {
      * Is this channel currently enabled?
      */
     private boolean enabled = true;
+
+    /**
+     * Is this channel currently paused? The source of truth for this is the PVTypeInfo in the database. 
+     * But we cache this value here as a performance optimization for CapacityPlanning/EngineMetrics.
+     * By default, this is false because in DefaultConfigService.archivePVSonStartup, we skip starting PV's that are paused. 
+     */
+    private boolean paused = false;
+
     /** Buffer of received samples, periodically written */
     private SampleBuffer buffer;
     /**
@@ -827,5 +835,13 @@ public abstract class ArchiveChannel {
         if (this.pv != null) {
             this.pv.aboutToWriteBuffer(lastSample);
         }
+    }
+
+    public void setPaused(boolean pausedVal) {
+        this.paused = pausedVal;
+    }
+
+    public boolean isPaused() { 
+        return this.paused;
     }
 }

--- a/src/main/org/epics/archiverappliance/engine/pv/EngineContext.java
+++ b/src/main/org/epics/archiverappliance/engine/pv/EngineContext.java
@@ -115,6 +115,11 @@ public class EngineContext {
 	private ScheduledFuture<?> disconnectFuture = null;
 	
 	private double sampleBufferCapacityAdjustment = 1.0;
+
+	/**
+	 * An optimization for EngineMetrics. Note; this value may not be all that accurate but should be reasonably accurate.
+	 */
+	private int pausedPVCount = 0;
 	
 
 	/***
@@ -851,5 +856,17 @@ public class EngineContext {
 		obj.put("source", "engine");
 		ret.add(obj);
 		return ret;
+	}
+
+	public void incrementPausedPVCount() { 
+		this.pausedPVCount++;
+	}
+
+	public void decrementPausedPVCount() { 
+		this.pausedPVCount--;
+	}
+
+	public int getPausedPVCount() { 
+		return this.pausedPVCount;
 	}
 }


### PR DESCRIPTION
…EngineMetrics.

This involves caching the paused state in the channel and the count in EngineContext.