### PR TITLE
#260 Option for not looking up the lastKnownTimestamp on appliance startup.

### DIFF
--- a/docs/docs/source/user/userguide.md
+++ b/docs/docs/source/user/userguide.md
@@ -362,12 +362,15 @@ are
      PAST_CUTOFF_TIMESTAMP. PAST_CUTOFF_TIMESTAMP defaults to
      `1991-01-01T00:00:00.000Z`
   2. If the record processing timestamp from the IOC is after
-     (Appliance Current Time + FUTURE_CUTOFF_SECONDS) in the future.
-     FUTURE_CUTOFF_SECONDS defaults to 30\*60.
+     (Appliance Current Time + SERVER_IOC_DRIFT_SECONDS) in the future.
+     SERVER_IOC_DRIFT_SECONDS defaults to 30\*60.
   3. If the record processing timestamp from the IOC is before the
      timestamp of the previous sample.
   4. If the record processing timestamp from the IOC is identical to
      the timestamp of the previous sample.
+  5. If the record processing timestamp from the IOC of samples
+     from the second sample onwards are before the 
+     (Appliance Current Time - SERVER_IOC_DRIFT_SECONDS) in the past.
 - **PVs by dropped events from buffer overflows** - The
   EPICS archiver appliance discards events when the sampling buffers
   (as estimated from the sampling period) become full. These reports

--- a/src/main/org/epics/archiverappliance/engine/model/ArchiveChannel.java
+++ b/src/main/org/epics/archiverappliance/engine/model/ArchiveChannel.java
@@ -64,7 +64,7 @@ public abstract class ArchiveChannel {
     private static final ThrottledLogger trouble_sample_log = new ThrottledLogger(LogLevel.info, 60);
 
     private static final Instant PAST_CUTOFF_TIMESTAMP = TimeUtils.convertFromISO8601String("1991-01-01T00:00:00.000Z");
-    private static final int SERVER_IOC_DRIFT_SECONDS = 30 * 60;
+    private final int SERVER_IOC_DRIFT_SECONDS;
     /**
      * Initialize the metafields for this channel. In addition to the metafields specified  here, we also generate PV's
      * for the runtime fields.
@@ -200,6 +200,7 @@ public abstract class ArchiveChannel {
             final boolean usePVAccess)
             throws Exception {
         this.name = name;
+        this.SERVER_IOC_DRIFT_SECONDS = Integer.parseInt(configservice.getInstallationProperties().getProperty("org.epics.archiverappliance.engine.epics.server_ioc_drift_seconds", "1800"));
         this.controlPVname = controlPVname;
         this.writer = writer;
         this.enablement = enablement;

--- a/src/sitespecific/slacdev/classpathfiles/archappl.properties
+++ b/src/sitespecific/slacdev/classpathfiles/archappl.properties
@@ -52,6 +52,11 @@ org.epics.archiverappliance.engine.epics.JCAConfigGen.dispatcher=org.epics.archi
 # Routing all PVs thru fewer contexts seems to result in larger reconnect times.   
 org.epics.archiverappliance.engine.epics.commandThreadCount=10
 
+# Maximum amount of clock drift ( in seconds ) between appliance and IOC.
+# Samples more than this many seconds in the future are discarded for data quality reasons.
+# Samples from the second sample onwards (after a PV connect) more than this seconds in the past are discarded for data quality reasons.
+# org.epics.archiverappliance.engine.epics.server_ioc_drift_seconds=1800
+
 # The SCAN sampling method establishes camonitors and skips samples that are less than the sampling method.
 # However, the IOC itself could have some jitter and this will cause the SCAN'ed PV to miss samples that arrive a few milliseconds early.
 # Use this to control how much jitter you want to accommodate.

--- a/src/sitespecific/slacdev/classpathfiles/archappl.properties
+++ b/src/sitespecific/slacdev/classpathfiles/archappl.properties
@@ -84,6 +84,19 @@ org.epics.archiverappliance.config.RuntimeKeys=DESC
 # If you want to turn off this functionality, simply set this value to 0 
 org.epics.archiverappliance.engine.util.EngineContext.disconnectCheckTimeoutInMinutes = 0
 
+# Configure how fast the engine starts up PVs
+# To prevent broadcast storms, we pause for pausePerGroup seconds for every pausePerGroup PVs
+# org.epics.archiverappliance.engine.archivePVSonStartup.pausePerGroupPVCount = 2000
+# org.epics.archiverappliance.engine.archivePVSonStartup.pausePerGroupPauseTimeInSeconds = 2
+
+# This is a more complex one. 
+# Ideally, we'll look in the datastores for the last known sample and use that as a boundary condition for future samples.
+# But this can be expensive in systems with large numbers of PV's and can delay startup of PV's significantly.
+# In these case, we sacrifice the samples of PV's with ancient timestamps and only record samples from "now on".
+# But this may be a more suitable tradeoff for such installations.
+# If you set this to false, the boundary condition is the server's current timestamp when the PV is being started.
+org.epics.archiverappliance.engine.archivePVSonStartup.determineLastKnownEventFromStores = false
+
 # One can define a set of named flags (booleans) that can be used to control various processes in the system
 # For example, you can control the ETL process in a PlainPBStoragePlugin using a named flag to accomplish a gated ETL.
 # Named flags are not persistent; each time the server starts up, all the named flags are set to false

--- a/src/sitespecific/tests/classpathfiles/archappl.properties
+++ b/src/sitespecific/tests/classpathfiles/archappl.properties
@@ -84,6 +84,20 @@ org.epics.archiverappliance.config.RuntimeKeys=DESC
 # If you want to turn off this functionality, simply set this value to 0 
 org.epics.archiverappliance.engine.util.EngineContext.disconnectCheckTimeoutInMinutes = 0
 
+
+# Configure how fast the engine starts up PVs
+# To prevent broadcast storms, we pause for pausePerGroup seconds for every pausePerGroup PVs
+# org.epics.archiverappliance.engine.archivePVSonStartup.pausePerGroupPVCount = 2000
+# org.epics.archiverappliance.engine.archivePVSonStartup.pausePerGroupPauseTimeInSeconds = 2
+
+# This is a more complex one. 
+# Ideally, we'll look in the datastores for the last known sample and use that as a boundary condition for future samples.
+# But this can be expensive in systems with large numbers of PV's and can delay startup of PV's significantly.
+# In these case, we sacrifice the samples of PV's with ancient timestamps and only record samples from "now on".
+# But this may be a more suitable tradeoff for such installations.
+# If you set this to false, the boundary condition is the server's current timestamp when the PV is being started.
+# org.epics.archiverappliance.engine.archivePVSonStartup.determineLastKnownEventFromStores = true
+
 # One can define a set of named flags (booleans) that can be used to control various processes in the system
 # For example, you can control the ETL process in a PlainPBStoragePlugin using a named flag to accomplish a gated ETL.
 # Named flags are not persistent; each time the server starts up, all the named flags are set to false
@@ -131,3 +145,4 @@ org.epics.archiverappliance.engine.util.EngineContext.disconnectCheckTimeoutInMi
 # This may be faster in some situations.
 # However, this may not work in cases where the appliancs are accessed behind a load balancer.
 org.epics.archiverappliance.retrieval.DataRetrievalServlet.proxyRetrievalRequest=false
+

--- a/src/sitespecific/tests/classpathfiles/archappl.properties
+++ b/src/sitespecific/tests/classpathfiles/archappl.properties
@@ -52,6 +52,11 @@ org.epics.archiverappliance.engine.epics.JCAConfigGen.dispatcher=org.epics.archi
 # Routing all PVs thru fewer contexts seems to result in larger reconnect times.   
 org.epics.archiverappliance.engine.epics.commandThreadCount=10
 
+# Maximum amount of clock drift ( in seconds ) between appliance and IOC.
+# Samples more than this many seconds in the future are discarded for data quality reasons.
+# Samples from the second sample onwards (after a PV connect) more than this seconds in the past are discarded for data quality reasons.
+# org.epics.archiverappliance.engine.epics.server_ioc_drift_seconds=1800
+
 # The SCAN sampling method establishes camonitors and skips samples that are less than the sampling method.
 # However, the IOC itself could have some jitter and this will cause the SCAN'ed PV to miss samples that arrive a few milliseconds early.
 # Use this to control how much jitter you want to accommodate.


### PR DESCRIPTION
I think the option to not lookup the lastKnownTimestamp and making the pausePerGroupPVCount and pausePerGroupPauseTimeInSeconds archappl properties are straightforward. 

The changes in ArchiveChannel for dropping the second sample onwards in case the timestamps are more than clock_drift_seconds in the past is something that needs thought. If we don't lookup the lastKnownTimestamp, then IOC's with bad clocks can cause issues and we need to have a mechanism to catch these easily. To distinguish between a PV that changed in the past but has a good clock from an IOC that has a clock stuck in the past
- We allow the first sample after a PV connects without any checks
- We enforce a timestamp check from the second sample onwards to make sure it's not too far in the past.

I tested this using libfaketime on my dev box and it all seemed to work well. I'll do some testing on a prod-instance next Wed to see if this helps with improving the PV connect times.