### PR TITLE
Typoe in default value Should be 2 seconds instead of 2000

### DIFF
--- a/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
+++ b/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
@@ -923,7 +923,7 @@ public class DefaultConfigService implements ConfigService {
         // To prevent broadcast storms, we pause for pausePerGroup seconds for every pausePerGroup PVs
         int currentPVCount = 0;
         int pausePerGroupPVCount = Integer.parseInt(this.getInstallationProperties().getProperty("org.epics.archiverappliance.engine.archivePVSonStartup.pausePerGroupPVCount", "2000"));
-        int pausePerGroupPauseTimeInSeconds = Integer.parseInt(this.getInstallationProperties().getProperty("org.epics.archiverappliance.engine.archivePVSonStartup.pausePerGroupPauseTimeInSeconds", "2000"));
+        int pausePerGroupPauseTimeInSeconds = Integer.parseInt(this.getInstallationProperties().getProperty("org.epics.archiverappliance.engine.archivePVSonStartup.pausePerGroupPauseTimeInSeconds", "2"));
         boolean determineLastKnownEventFromStores = Boolean.parseBoolean(this.getInstallationProperties().getProperty("org.epics.archiverappliance.engine.archivePVSonStartup.determineLastKnownEventFromStores", "true"));
 
         for (String pvName : this.getPVsForThisAppliance()) {


### PR DESCRIPTION
Apologies. Without this, the default settings will take days to connect to a few thousand PV.s