### PR TITLE
Use the cached version of capacity planning data in the appliance metrics details page

### DIFF
--- a/src/main/org/epics/archiverappliance/mgmt/archivepv/CapacityPlanningData.java
+++ b/src/main/org/epics/archiverappliance/mgmt/archivepv/CapacityPlanningData.java
@@ -133,6 +133,11 @@ public class CapacityPlanningData {
 		cachedCPStaticData = newStaticData;
 		return cachedCPStaticData;
 	}
+
+
+	public static CPStaticData getCachedMetricsForAppliances(ConfigService configService) throws IOException {
+		return cachedCPStaticData;
+	}
 	
 	public static class CPStaticData {
 		public ConcurrentHashMap<ApplianceInfo, CapacityPlanningData> cpApplianceMetrics;


### PR DESCRIPTION
While this primarily addresses #269, this is also probably more desirable in that we want to see what's being used for capacity planning as opposed to computing it from scratch.