### PR TITLE
Add build_docs script for Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -273,7 +273,11 @@ tasks.register("sphinx", Exec) {
 	dependsOn "javadoc"
 	workingDir "docs"
 	it.outputs.dir("docs/docs/build")
-	commandLine "./build_docs.sh"
+	if (System.getProperty('os.name').toLowerCase().contains('windows')) {
+		commandLine 'cmd', '/c', 'build_docs.bat'
+	} else {
+		commandLine "./build_docs.sh"
+	}
 }
 
 /**

--- a/docs/build_docs.bat
+++ b/docs/build_docs.bat
@@ -1,0 +1,13 @@
+@echo off
+where sphinx-build >nul 2>nul
+IF NOT "%ERRORLEVEL%"=="0" (
+    echo "Instaling sphinx-build in a new virtual environment"
+    python -m venv .venv
+    .venv\Scripts\activate.bat
+    python -m pip install --upgrade --no-cache-dir pip setuptools
+    python -m pip install --upgrade --no-cache-dir sphinx readthedocs-sphinx-ext
+    python -m pip install --exists-action=w --no-cache-dir -r docs\requirements.txt
+) ELSE (
+    echo "Using sphinx-build from the environment"
+)
+sphinx-build docs\source docs\build


### PR DESCRIPTION
Currently, it seems that Windows building cannot execute successfully since build_docs.sh for Linux is used to build the documentation. Probably a Windows equivalent script can be added to support Windows building.