### PR TITLE
Static resources cannot be loaded from zip for Windows

### DIFF
--- a/src/main/org/epics/archiverappliance/common/StaticContentServlet.java
+++ b/src/main/org/epics/archiverappliance/common/StaticContentServlet.java
@@ -422,7 +422,7 @@ public class StaticContentServlet extends HttpServlet {
 						ZipEntry zentry = zis.getNextEntry();
 						while(zentry != null) { 
 							// logger.debug("Zip entry '" + zentry.getName() + "'");
-							if(zentry.getName().equals(potentialPathWithinZip)) {
+							if((File.separator.equals("/") && zentry.getName().equals(potentialPathWithinZip)) || (File.separator.equals("\\") && zentry.getName().equals(potentialPathWithinZip.replace("\\", "/")))) {
 								this.length = zentry.getSize();
 								this.lastModified = zentry.getTime();
 								ByteArrayOutputStream bos = new ByteArrayOutputStream();


### PR DESCRIPTION
For Windows deployment, it seems that static resources inside zip files cannot be loaded successfully and the dialog widget as well as the archViewer page cannot be displayed.

It looks like the root cause is when trying to load css/js resources from zip files, the file separator for the zip file is always "/" whereas the file separator for Tomcat is "\\" for Windows and "/" for Linux. 

For example, when loading jquery-ui-1.9.1.custom.min.js for Windows deployment, Tomcat is searching for "js\jquery-ui-1.9.1.custom.min.js" from the zip file, but the entry name in jquery-ui-1.9.1.custom.zip is "js/jquery-ui-1.9.1.custom.min.js", mismatch.

Probably the PR is one solution to fix it, but it assumes that the file separator in zip files is always forward slash "/".

![cannot_load_static_resources](https://github.com/user-attachments/assets/86994669-86ed-4c19-bf6e-1df86b8cba5c)

![cannot_display_dialog](https://github.com/user-attachments/assets/e6466595-3737-4972-a67d-13ca483966cd)
