### PR TITLE
PV name cannot be converted to key for Windows

### DIFF
--- a/src/main/org/epics/archiverappliance/config/ConvertPVNameToKey.java
+++ b/src/main/org/epics/archiverappliance/config/ConvertPVNameToKey.java
@@ -99,7 +99,8 @@ public class ConvertPVNameToKey implements PVNameToKeyMapping {
 	 * @return pvName  &emsp;
 	 */
 	protected String generateChunkKey(String pvName) { 
-		return pvName.replaceAll(siteNameSpaceSeparators, File.separator) + terminatorChar;
+		String separator = File.separator.equals("/") ? "/" : "\\\\";
+		return pvName.replaceAll(siteNameSpaceSeparators, separator) + terminatorChar;
 	}
 
 
@@ -108,7 +109,8 @@ public class ConvertPVNameToKey implements PVNameToKeyMapping {
 	 */
 	@Override
 	public boolean containsSiteSeparators(String pvName) {
-		String afterConversion = pvName.replaceAll(siteNameSpaceSeparators, File.separator);
+		String separator = File.separator.equals("/") ? "/" : "\\\\";
+		String afterConversion = pvName.replaceAll(siteNameSpaceSeparators, separator);
 		return !afterConversion.equals(pvName);
 	}
 

--- a/src/main/org/epics/archiverappliance/config/ConvertPVNameToKey.java
+++ b/src/main/org/epics/archiverappliance/config/ConvertPVNameToKey.java
@@ -40,6 +40,7 @@ public class ConvertPVNameToKey implements PVNameToKeyMapping {
 	private static final String SITE_NAME_SPACE_TERMINATOR = "org.epics.archiverappliance.config.ConvertPVNameToKey.siteNameSpaceTerminator";
 	private String siteNameSpaceSeparators;
 	private char terminatorChar = ':';
+	private String fileSeparator;
 	
 	private ConfigService configService;
 	private ConcurrentHashMap<String, String> chunkKeys = new ConcurrentHashMap<String, String>();
@@ -86,6 +87,7 @@ public class ConvertPVNameToKey implements PVNameToKeyMapping {
 			throw new ConfigException("The appliance archiver cannot function without knowning the character that terminates the translated path name ");
 		}
 		this.terminatorChar = terminatorStr.charAt(0);
+		this.fileSeparator = File.separator.equals("/") ? "/" : "\\\\";
 		
 		configlogger.info("The pv name components in this installation are separated by these characters " + this.siteNameSpaceSeparators + 
 				" and the key names are terminated by " + this.terminatorChar);
@@ -99,8 +101,7 @@ public class ConvertPVNameToKey implements PVNameToKeyMapping {
 	 * @return pvName  &emsp;
 	 */
 	protected String generateChunkKey(String pvName) { 
-		String separator = File.separator.equals("/") ? "/" : "\\\\";
-		return pvName.replaceAll(siteNameSpaceSeparators, separator) + terminatorChar;
+		return pvName.replaceAll(siteNameSpaceSeparators, fileSeparator) + terminatorChar;
 	}
 
 

--- a/src/main/org/epics/archiverappliance/config/ConvertPVNameToKey.java
+++ b/src/main/org/epics/archiverappliance/config/ConvertPVNameToKey.java
@@ -109,9 +109,7 @@ public class ConvertPVNameToKey implements PVNameToKeyMapping {
 	 */
 	@Override
 	public boolean containsSiteSeparators(String pvName) {
-		String separator = File.separator.equals("/") ? "/" : "\\\\";
-		String afterConversion = pvName.replaceAll(siteNameSpaceSeparators, separator);
-		return !afterConversion.equals(pvName);
+		return pvName.matches(siteNameSpaceSeparators);
 	}
 
 


### PR DESCRIPTION
This PR is intended to fix the issue that PV name cannot be converted to key for Windows deployment and the following error info is displayed when the PV starts to be archived.

It occurs because File.separator is used as an argument in replaceAll() method which accepts arguments as regular expression, but File.separator for Windows is "\\", which means character to be escaped is missing.

![image](https://github.com/user-attachments/assets/0f988671-2251-4aaa-80fa-3cfada795a3b)
 