### PR TITLE
Fix the issue that error occurs when refreshing pv status

### DIFF
--- a/src/main/org/epics/archiverappliance/mgmt/staticcontent/js/reporttable.js
+++ b/src/main/org/epics/archiverappliance/mgmt/staticcontent/js/reporttable.js
@@ -506,7 +506,8 @@ function setupToolbarActions(reportTable) {
     curpage = 0;
     reportTable.data("paging", { pagesize: pagesize, currentpage: curpage });
     reportTable.children("tbody").empty();
-    getJSONDataAndRefreshTable(reportTable);
+    const json = reportTable.data("json");
+    getJSONDataAndRefreshTable(reportTable, json === undefined ? "GET": "POST");
   });
 }
 


### PR DESCRIPTION
For the latest master branch, error occurs when refreshing pv status. It seems that json data is used for HTTP GET method as follows, but Tomcat does not allow the "[" character.
```http://localhost:17665/mgmt/bpl/getPVStatus?reporttype=short&[{"pv":"ACC_LR_VAC::CCG06:Ps"}]=```

After changing the function invocation
from
```getJSONDataAndRefreshTable(reportTable);```
to 
```getJSONDataAndRefreshTable(reportTable, json === undefined ? "GET": "POST");``` which is also invoked in createReportTableDATA() function
It seems to work normally.

![refresh_button](https://github.com/user-attachments/assets/edb7292f-2f1d-46af-b3fa-29ad991193d6)

![cannot_refresh](https://github.com/user-attachments/assets/f3ea4501-38cb-4f95-8f20-31e5ae91b03a)

![refresh_error](https://github.com/user-attachments/assets/5f0627e4-90c5-43ff-a35c-15add0e7b9b0)

