### PR TITLE
defaultsitespecificpath is not resolved correctly in some environments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ def apiDocsDir = layout.projectDirectory.file("docs/api")
 def archapplsite = System.getenv("ARCHAPPL_SITEID") ?: "tests"
 def defaultsitespecificpath = "src/sitespecific/${archapplsite}"
 // Allow the site to be outside of the repository
-def sitespecificpath = (new File("${defaultsitespecificpath}").exists()) ? defaultsitespecificpath : archapplsite
+def sitespecificpath = file("${defaultsitespecificpath}").exists() ? defaultsitespecificpath : archapplsite
 
 ant.stage = stageDir
 ant.archapplsite = archapplsite


### PR DESCRIPTION
This PR attempts to fix the issue occurs in my NetBeans environment, but it may also be relevant to Issue #284 

When running `gradlew.bat` from NetBeans IDE, the following info shows up,
```
[ant:echo] Building the archiver appliance for the site tests with path tests
```

instead of,
```
[ant:echo] Building the archiver appliance for the site tests with path src/sitespecific/tests
```

Which means that `sitespecificpath`  is resolved as `tests` instead of `src/sitespecific/tests`. As a result, the following Gradle statement does not execute successfully and the five files (`appliances.xml; archappl.properties`; `failover_dest.xml`; `failover_other.xml` and `policies.py`) do not show up in `mgmt/WEB-INF/classes`.
```
from("${sitespecificpath}/classpathfiles") {
	into "WEB-INF/classes"
}
```

Probably file() can be used instead of new File() as recommended on Gradle website.

```
//def sitespecificpath = (new File("${defaultsitespecificpath}").exists()) ? defaultsitespecificpath : archapplsite
def sitespecificpath = file("${defaultsitespecificpath}").exists() ? defaultsitespecificpath : archapplsite
```

![图片](https://github.com/user-attachments/assets/93e73b1f-eb6d-48db-9723-5e2d2035fddc)
