### PR TITLE
Convert addPostProcessingOperator.py to python3

### DIFF
--- a/docs/docs/source/samples/addPostProcessingOperator.py
+++ b/docs/docs/source/samples/addPostProcessingOperator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This script demonstrates how to change PVTypeInfo from python and uses as an example the use case of adding a post processing operator to a store named LTS
 # We take any number of arguments (which can be wildcards) 
@@ -7,12 +7,11 @@
 # We append a pp=mean_3600 post processing operator if it does not exist.
 
 import sys
-import urllib
-import urllib2
+import requests
 import json
 import argparse
 import csv
-import urlparse
+import urllib.parse
 
 # Set up argparse and parse command line options
 parser = argparse.ArgumentParser()
@@ -26,30 +25,33 @@ pvNames = args.pvNames
 
 pvNamesCSV = ",".join(pvNames)
 values = { 'pv' : pvNamesCSV }
-queryString = urllib.urlencode(values)
 
-matchingPVs = json.load(urllib2.urlopen(serverURL + '/bpl/getAllPVs?' + queryString))
+resp = requests.get(f"{serverURL}/bpl/getAllPVs", params=values)
+resp.raise_for_status()
+matchingPVs = resp.json()
 
 for pv in matchingPVs:
-	print pv
+	print(pv)
 	values = { 'pv' : pv }
-	queryString = urllib.urlencode(values)
-	typeInfo = json.load(urllib2.urlopen(serverURL + '/bpl/getPVTypeInfo?' + queryString))
+	resp = requests.get(f"{serverURL}/bpl/getPVTypeInfo", params=values)
+	resp.raise_for_status()
+	typeInfo = resp.json()
 	if typeInfo: 
 		dataStores = typeInfo['dataStores']
 		for index, dataStore in enumerate(dataStores):
-		# urlparse wants to put the querystring into the path with the ? also present.
-			dataStoreQS = urlparse.urlparse(dataStore).path.replace("?", "")
-			qsargs = urlparse.parse_qs(dataStoreQS)
+			dataStoreQS = urllib.parse.urlparse(dataStore).query
+			qsargs = urllib.parse.parse_qs(dataStoreQS)
 			if qsargs['name'][0] == 'LTS':
 				if 'pp' not in qsargs or 'mean_3600' not in qsargs['pp']:
 					modifiedDataStore = dataStore + '&pp=mean_3600'
-					print modifiedDataStore
+					print(modifiedDataStore)
 					dataStores[index] = modifiedDataStore
-					data = json.dumps(typeInfo)
+					json_data = typeInfo
 					headers = {"Content-type": "application/json", "Accept": "text/plain"}
-					req = urllib2.Request(serverURL + '/bpl/putPVTypeInfo?' + queryString, data, headers)
-					updatedTypeInfo = json.load(urllib2.urlopen(req))
-					print updatedTypeInfo['dataStores']
+					values = { 'pv' : pv, 'override' : 'true' }
+					resp = requests.post(f"{serverURL}/bpl/putPVTypeInfo", params=values, json=json_data, headers=headers)
+					resp.raise_for_status()
+					updatedTypeInfo = resp.json()
+					print(updatedTypeInfo['dataStores'])
 				else:
-					print 'mean_3600 already exists as a post processing operator for PV ', pv
+					print('mean_3600 already exists as a post processing operator for PV ', pv)


### PR DESCRIPTION
This PR made the following modifications,

1. Change `print` statement to `print()` function.
2. Change `urllib` library to `requests`.
3. Use `urllib.parse.urlparse().query` instead of `urlparse.urlparse().path` to extract the query string from datestore.
4. Add `override=true` query parameter when updating PVTypeInfo to avoid `We already have a typeinfo for PV but the override flag has not been set` error from the Archiver.