### PR TITLE
Convert emailHandler.py to python3

### DIFF
--- a/docs/docs/source/samples/emailHandler.py
+++ b/docs/docs/source/samples/emailHandler.py
@@ -4,6 +4,26 @@ We expect these variables in the dict
 from - The from address
 to - A list of destination email addresses
 smtphost - Your local SMTP host.
+port - Your local SMTP port
+use_ssl - Whether to use SSL from the start
+use_tls - Whether to upgrade the connection to secure when connected
+username - username for SMTP authentication
+password" - password for SMTP authentication
+
+This is an example of the JSON configuration file,
+{
+  "from": "user@example.com",
+  "to": [
+    "admin1@example.com",
+    "admin2@example.com"
+  ],
+  "smtphost": "smtp.example.com",
+  "port": 587,
+  "use_ssl": false,
+  "use_tls": true,
+  "username": "your_username",
+  "password": "your_password"
+}
 
 Note Nagios already has a lot of the email functionality so you do not need this module at all.
 These are samples that you can use  
@@ -26,6 +46,23 @@ def sendEmail(subject, message, pvNameList):
     msg['Subject'] = '' + subject
     msg['From'] = emailConfig['from']
     msg['To'] = emailConfig['to'][0]
-    s = smtplib.SMTP(emailConfig['smtphost'])
+
+    s = None
+    if emailConfig['use_ssl']:
+        # Used when SSL is required from the beginning of the connection and using starttls() is not appropriate
+        s = smtplib.SMTP_SSL(emailConfig['smtphost'], emailConfig['port'])
+    else:
+        s = smtplib.SMTP(emailConfig['smtphost'], emailConfig['port'])
+
+    if emailConfig['use_tls']:
+        # Put the SMTP connection in TLS (Transport Layer Security) mode
+        s.starttls()
+
+    username = emailConfig['username']
+    password = emailConfig['password']
+    if username and password:
+        # Log in on an SMTP server that requires authentication
+        s.login(username, password)
+
     s.sendmail(emailConfig['from'], emailConfig['to'], msg.as_string())
     s.quit()


### PR DESCRIPTION
This script should already be runnable under Python 3, so only some improvements have been made.
This PR has been tested with the IHEP mail server (mail.ihep.ac.cn) for Port 25 and 465.