### PR TITLE
Convert resumePausedPVsMatchingPattern.py to python3

### DIFF
--- a/docs/docs/source/samples/resumePausedPVsMatchingPattern.py
+++ b/docs/docs/source/samples/resumePausedPVsMatchingPattern.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''Given a list of PVs matching  pattern, this resumes all the PVs in that list that are paused'''
 
 import os
@@ -12,11 +12,9 @@ import time
 def resumePVs(bplURL, pvNames):
     '''Resumes the pvs specified by list pvNames'''
     url = bplURL + '/resumeArchivingPV'
-    req = urllib2.Request(url)
-    req.add_header('Content-Type', 'application/json')
-    response = urllib2.urlopen(req, json.dumps(pvNames))
-    the_page = response.read()
-    resumePVResponse = json.loads(the_page)
+    response = requests.post(url, json=pvNames)
+    response.raise_for_status()
+    resumePVResponse = response.json()
     return resumePVResponse
 
 
@@ -25,12 +23,15 @@ if __name__ == "__main__":
     parser.add_argument("url", help="This is the URL to the mgmt bpl interface of the appliance cluster. For example, http://arch.slac.stanford.edu/mgmt/bpl")
     parser.add_argument("pattern", help="A GLOB pattern")
     args = parser.parse_args()
-    pvstat = requests.get(args.url + "getPVStatus", params={"pv": args.pattern})
+    pvstat = requests.get(args.url + "/getPVStatus", params={"pv": args.pattern})
     pvstat.raise_for_status()
     pvs = pvstat.json()
     for pv in pvs:
         if pv.get("status", "") == "Paused":
             pvName = pv["pvName"]
             print("Resuming PV " + pvName)
-            rsmstat = requests.get(args.url + "resumeArchivingPV", params={"pv": pvName})
+            rsmstat = requests.get(args.url + "/resumeArchivingPV", params={"pv": pvName})
             rsmstat.raise_for_status()
+    '''The for loop above can also be replaced with the resumePVs() function as follows'''
+    # pvNames = [pv['pvName'] for pv in pvs if 'pvName' in pv]
+    # resumePVs(args.url, pvNames)


### PR DESCRIPTION
This PR made the following modifications,
1. Replaced `urllib` with `requests` in resumePVs() function although it is not actually used.
2. Added the missing `/` to the URL.
3. Showed an example of how to use `resumePVs()` function at the end.