### PR TITLE
Skip data store for retrieval based on named flag.

### DIFF
--- a/docs/docs/source/sysadmin/admin.md
+++ b/docs/docs/source/sysadmin/admin.md
@@ -168,3 +168,25 @@ Channel Access ( and PVAccess ). Here\'s an example of this process
 - Pausing and resuming the PV during packet capture will also enable
   the `cashark` plugin to track the life cycle of the Channel Access
   channel.
+
+## Temporarily suspend using a store
+
+If one of your data stores uses storage from elsewhere and you expect 
+an outage or disruption of connectivity, you can 
+temporarily suspend using the store for retrieval requests. 
+This is especially useful if you mount the remote location using NFS
+which can sometimes suspend threads forever during
+periods of network disruptions ( see the hard/soft/intr options for NFS clients).
+For example, if you have a data store named `LTS`, you can set the
+`SKIP_LTS_FOR_RETRIEVAL` named flag to `true` and this will stop adding the `LTS`
+to retrieval requests ( both `getData` and `getDataAtTime` ). Once the outage
+is over, you can turn `LTS` back on by setting the `SKIP_LTS_FOR_RETRIEVAL`
+named flag to `false`. Named flags are `false` by default; so restarting the
+appliances should also accomplish the same.
+
+
+
+Use a named flag based on the storage plugin's name.
+    For example, if the name is LTS, the named flag
+    SKIP_LTS_FOR_RETRIEVAL can used to temporarily turn off
+    using the LTS for retrieval.

--- a/src/main/org/epics/archiverappliance/mgmt/BPLServlet.java
+++ b/src/main/org/epics/archiverappliance/mgmt/BPLServlet.java
@@ -50,6 +50,7 @@ import org.epics.archiverappliance.mgmt.bpl.ImportDataFromPlugin;
 import org.epics.archiverappliance.mgmt.bpl.MergeInDataFromExternalStore;
 import org.epics.archiverappliance.mgmt.bpl.ModifyMetaFieldsAction;
 import org.epics.archiverappliance.mgmt.bpl.ModifyStoreURLForPV;
+import org.epics.archiverappliance.mgmt.bpl.NamedFlagsAll;
 import org.epics.archiverappliance.mgmt.bpl.NamedFlagsGet;
 import org.epics.archiverappliance.mgmt.bpl.NamedFlagsSet;
 import org.epics.archiverappliance.mgmt.bpl.PauseArchivingPV;
@@ -149,6 +150,7 @@ public class BPLServlet extends HttpServlet {
         addAction("/resetFailoverCaches", ResetFailoverCaches.class);
         addAction("/getVersions", GetVersions.class);
         addAction("/modifyMetaFields", ModifyMetaFieldsAction.class);
+        addAction("/getAllNamedFlags", NamedFlagsAll.class);
         addAction("/getNamedFlag", NamedFlagsGet.class);
         addAction("/setNamedFlag", NamedFlagsSet.class);
         addAction("/getTypeInfoKeys", GetPVTypeInfoKeys.class);

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/NamedFlagsAll.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/NamedFlagsAll.java
@@ -1,0 +1,43 @@
+package org.epics.archiverappliance.mgmt.bpl;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashMap;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.epics.archiverappliance.common.BPLAction;
+import org.epics.archiverappliance.config.ConfigService;
+import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
+import org.json.simple.JSONObject;
+
+/**
+ * 
+ * @epics.BPLAction - Get all the named flags in the system and their values as a JSON dict
+ * @epics.BPLActionEnd
+ * 
+ * @author mshankar
+ *
+ */
+public class NamedFlagsAll implements BPLAction {
+	private static Logger logger = LogManager.getLogger(NamedFlagsAll.class.getName());
+	@Override
+	public void execute(HttpServletRequest req, HttpServletResponse resp, ConfigService configService) throws IOException {
+		HashMap<String, Boolean> ret = new HashMap<String, Boolean>();
+		for(String namedFlagName : configService.getNamedFlagNames()){
+			boolean namedValue = configService.getNamedFlag(namedFlagName);
+			ret.put(namedFlagName, namedValue);
+		}
+
+		resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
+		try (PrintWriter out = resp.getWriter()) {
+			out.println(JSONObject.toJSONString(ret));
+		} catch(Exception ex) {
+			logger.error("Exception getting all named flags", ex);
+			resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+		}		
+	}
+}

--- a/src/main/org/epics/archiverappliance/retrieval/DataSourceResolution.java
+++ b/src/main/org/epics/archiverappliance/retrieval/DataSourceResolution.java
@@ -103,6 +103,13 @@ public class DataSourceResolution {
 
 			for(TimeSpanDependentProcessor spannedProcessor : spannedProcessors) {
 				for(DataSourceforPV dataSource : dataSources) {
+					// Check to see if there is a named flag that turns off this data source. 
+					String namedFlagForSkippingDataSource = "SKIP_" + dataSource.getStoragePlugin().getName() + "_FOR_RETRIEVAL";
+					if(configService.getNamedFlag(namedFlagForSkippingDataSource)) {
+						logger.warn("Skipping " + dataSource.getStoragePlugin().getName() + " as the named flag " + namedFlagForSkippingDataSource + " is set");
+						continue;
+					}
+
 					// Ideally we'd check to see if this data source has data in this time span.
 					// However, this means we have to keep all the various infos updated. 
 					// The MergeDedup now takes care of merging from multiple sources.

--- a/src/main/org/epics/archiverappliance/retrieval/GetDataAtTime.java
+++ b/src/main/org/epics/archiverappliance/retrieval/GetDataAtTime.java
@@ -410,6 +410,13 @@ public class GetDataAtTime {
             Collections.reverse(datastores);
             for (String store : datastores) {
                 StoragePlugin storagePlugin = StoragePluginURLParser.parseStoragePlugin(store, configService);
+                // Check to see if there is a named flag that turns off this data source. 
+                String namedFlagForSkippingDataSource = "SKIP_" + storagePlugin.getName() + "_FOR_RETRIEVAL";
+                if(configService.getNamedFlag(namedFlagForSkippingDataSource)) {
+                    logger.warn("Skipping " + storagePlugin.getName() + " as the named flag " + namedFlagForSkippingDataSource + " is set");
+                    continue;
+                }
+
                 try (BasicContext context = new BasicContext()) {
                     if(storagePlugin instanceof BiDirectionalIterable) {
                         Instant startAtTime = atTime.plus(5, ChronoUnit.MINUTES);


### PR DESCRIPTION
Use a named flag based on the storage plugin's name. For example, if the name is LTS, the named flag
SKIP_LTS_FOR_RETRIEVAL can used to temporarily turn off using the LTS for retrieval.

Also add a BPL to get all named flags and their values.
This addresses #327 