### PR TITLE
CSSTUDIO-3042 Bugfix: Duplicate and out of order samples when using `optimized` in a query to the archiver

### DIFF
--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/SummaryStatsPostProcessor.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/SummaryStatsPostProcessor.java
@@ -230,7 +230,7 @@ public abstract class SummaryStatsPostProcessor
                     }
 
                     return new SummaryStatsCollectorEventStream(
-                            firstBin,
+                            lastSampleBeforeStartAdded ? firstBin - 1 : firstBin,
                             lastBin,
                             intervalSecs,
                             srcDesc,

--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/SummaryStatsPostProcessor.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/SummaryStatsPostProcessor.java
@@ -111,6 +111,7 @@ public abstract class SummaryStatsPostProcessor
     private boolean inheritValuesFromPreviousBins = true;
     Event lastSampleBeforeStart = null;
     boolean lastSampleBeforeStartAdded = false;
+    boolean shouldAddLastSampleBeforeStart = true;
 
     @Override
     public void initialize(String userarg, String pvName) throws IOException {
@@ -152,7 +153,7 @@ public abstract class SummaryStatsPostProcessor
                     // If we cache the mean/sigma etc, then we should add something to the desc telling us that this is
                     // cached data and then we can replace the stat value for that bin?
                     if (srcDesc == null) srcDesc = (RemotableEventStreamDesc) strm.getDescription();
-                    boolean shouldAddLastSampleBeforeStart = true;
+
                     for (Event e : strm) {
                         try {
                             DBRTimeEvent dbrTimeEvent = (DBRTimeEvent) e;


### PR DESCRIPTION
This pull request is intended to fix the bug described in https://github.com/archiver-appliance/epicsarchiverap/issues/324.

The pull request fixes three things, the last of which I am not sure is correct:

1. The datapoint `lastSampleBeforeStart` (if it exists) is added  to a bin _before_ any of the datapoints that lie in the timeinterval specified by the query. The reason this needs to be done is that even if the bin number is lower than any other bin number, the final output seems to be sorted in the order of insertion, _not_ according to bin number. (A clause has also been added that adds `lastSampleBeforeStart` in those cases where there are no datapoints in the timeinterval specified in the query.)
2. Adding of `lastSampleBeforeStart` to a bin is ensured to be done only once by checking that `lastSampleBeforeStartAdded` is false before adding `lastSampleBeforeStart`. This is needed since the `Callable<EventStream>` that is returned by `SummaryStatsPostProcessor.wrap()` seems to be called _twice_ when a query is processed. I am not familiar enough with the codebase to understand why this is the case, but the reason that it works seems to be that the code for adding datapoints to the response is enclosed within a `for (Event e : strm) { ... }` loop, and the second time the code is executed `strm` is already empty, so no data is duplicated.
3. On line `240` in the original code which is line `233` in the code submitted in this pull request, I have replaced `firstBin` by `lastSampleBeforeStartAdded ? firstBin - 1 : firstBin` in the call to the constructor `SummaryStatsCollectorEventStream`. _I am not sure that this is correct_, however, based on the variable names, I believe this is correct.

I would like to ask for feedback on these fixes, especially point 3. of which I am not sure. If someone who has encountered the issue described in https://github.com/archiver-appliance/epicsarchiverap/issues/324 could test that these changes resolve the issue(s), that would be great.