### PR TITLE
Remove Selenium from the unit tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,10 +100,6 @@ dependencies {
 	// github
 	viewer("archiver-appliance:svg_viewer:v1.2.1@zip") // Not compileOnly to avoid check by analyze
 	// Maven dependencies
-	testImplementation("org.seleniumhq.selenium:selenium-java:4.22.0")
-	testImplementation("org.seleniumhq.selenium:selenium-firefox-driver:4.22.0")
-	testImplementation("org.seleniumhq.selenium:selenium-support:4.22.0")
-	testImplementation("io.github.bonigarcia:webdrivermanager:5.9.1")
 	testImplementation("org.apache.commons:commons-compress:1.23.0")
 	testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.3")
 	implementation("org.apache.tomcat:tomcat-servlet-api:9.0.74")// Only needed for tests, but inbuilt to main)

--- a/src/main/org/epics/archiverappliance/engine/pv/EngineContext.java
+++ b/src/main/org/epics/archiverappliance/engine/pv/EngineContext.java
@@ -290,6 +290,7 @@ public class EngineContext {
 
         // Add an assertion in case we accidentally set this to 0 from the props file.
         assert (disconnectCheckerPeriodInSeconds > 0);
+        logger.info("Running the disconnect checker every {} seconds", disconnectCheckerPeriodInSeconds);
         disconnectFuture = miscTasksScheduler.scheduleAtFixedRate(
                 new DisconnectChecker(configService),
                 disconnectCheckerPeriodInSeconds,
@@ -614,6 +615,9 @@ public class EngineContext {
                                 JSONObject connectedPVCount =
                                         GetUrlContent.getURLContentAsJSONObject(connectedPVCountURL);
                                 int applianceTotalPVCount = Integer.parseInt((String) connectedPVCount.get("total"));
+                                // This really needs to be based on some cluster-wide event where all the appliances have had their chance at connecting to their PVs.
+                                // All of these approaches are only approximations
+                                if(applianceTotalPVCount <= 0) continue;
                                 int applianceDisconnectedPVCount =
                                         Integer.parseInt((String) connectedPVCount.get("disconnected"));
                                 if ((applianceDisconnectedPVCount * 100.0 / applianceTotalPVCount)

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivePVAction.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ArchivePVAction.java
@@ -507,8 +507,8 @@ public class ArchivePVAction implements BPLAction {
     private void breakDownPVRequestsByAssignedAppliance(
             JSONArray pvArchiveParams, String myIdentity, ConfigService configService, HttpServletResponse resp)
             throws IOException {
-        HashMap<String, LinkedList<JSONObject>> archiveRequestsByAppliance =
-                new HashMap<String, LinkedList<JSONObject>>();
+        HashMap<String, List<JSONObject>> archiveRequestsByAppliance =
+                new HashMap<String, List<JSONObject>>();
         archiveRequestsByAppliance.put(myIdentity, new LinkedList<JSONObject>());
         for (Object pvArchiveParamObj : pvArchiveParams) {
             JSONObject pvArchiveParam = (JSONObject) pvArchiveParamObj;
@@ -533,11 +533,11 @@ public class ArchivePVAction implements BPLAction {
         // Route them appropriately and combine the results...
         JSONArray finalResult = new JSONArray();
         for (String appliance : archiveRequestsByAppliance.keySet()) {
-            LinkedList<JSONObject> requestsForAppliance = archiveRequestsByAppliance.get(appliance);
+            List<JSONObject> requestsForAppliance = archiveRequestsByAppliance.get(appliance);
             if (!requestsForAppliance.isEmpty()) {
                 String archiveURL = configService.getAppliance(appliance).getMgmtURL() + "/archivePV";
                 JSONArray archiveResponse =
-                        GetUrlContent.postDataAndGetContentAsJSONArray(archiveURL, requestsForAppliance);
+                        GetUrlContent.postDataAndGetContentAsJSONArray(archiveURL, GetUrlContent.from(requestsForAppliance));
                 finalResult.addAll(archiveResponse);
             }
         }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ImportConfig.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ImportConfig.java
@@ -70,7 +70,7 @@ public class ImportConfig implements BPLAction {
 			if(pvsForAppliance.size() > 1) {
 				ApplianceInfo applianceInfo = configService.getAppliance(applianceIdentity);
 				String importConfigURL = applianceInfo.getMgmtURL() + "/importConfigForAppliance";
-				JSONObject response = GetUrlContent.postDataAndGetContentAsJSONObject(importConfigURL, pvsForAppliance);
+				JSONObject response = GetUrlContent.postDataAndGetContentAsJSONObject(importConfigURL, GetUrlContent.from(pvsForAppliance));
 				responses.add(response);
 			} else {
 				logger.warn("No pvs when importing configuration for appliance " + applianceIdentity);

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/PutPVTypeInfo.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/PutPVTypeInfo.java
@@ -134,7 +134,7 @@ public class PutPVTypeInfo implements BPLAction {
 					+ URLEncoder.encode(pvName, "UTF-8") 
 					+ "&override=" + Boolean.toString(override)
 					+ "&createnew=" + Boolean.toString(createnew);
-			GetUrlContent.postObjectAndGetContentAsJSONObject(updateTypeInfoURL, updatedTypeInfo.jsonObject);
+			GetUrlContent.postDataAndGetContentAsJSONObject(updateTypeInfoURL, updatedTypeInfo.jsonObject);
 		} else { 
 			logger.info("Updating typeInfo for PV " + pvName);
 			if(newPVTypeInfo) {

--- a/src/test/org/epics/archiverappliance/common/FailoverETLTest.java
+++ b/src/test/org/epics/archiverappliance/common/FailoverETLTest.java
@@ -91,7 +91,7 @@ public class FailoverETLTest {
 		destPVTypeInfo.setChunkKey(configService.getPVNameToKeyConverter().convertPVNameToKey(pvName));
 		destPVTypeInfo.setCreationTime(TimeUtils.convertFromISO8601String("2020-11-11T14:49:58.523Z"));
 		destPVTypeInfo.setModificationTime(TimeUtils.now());
-		GetUrlContent.postObjectAndGetContentAsJSONObject(applURL + "/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, "UTF-8") + "&override=true&createnew=true", encoder.encode(destPVTypeInfo));
+		GetUrlContent.postDataAndGetContentAsJSONObject(applURL + "/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, "UTF-8") + "&override=true&createnew=true", encoder.encode(destPVTypeInfo));
 		logger.info("Added " + pvName + " to the appliance " + applianceName);
 
 		int genEventCount = generateData(applianceName, lastMonth, startingOffset);

--- a/src/test/org/epics/archiverappliance/common/FailoverMultiStepETLTest.java
+++ b/src/test/org/epics/archiverappliance/common/FailoverMultiStepETLTest.java
@@ -100,7 +100,7 @@ public class FailoverMultiStepETLTest {
         destPVTypeInfo.setChunkKey(configService.getPVNameToKeyConverter().convertPVNameToKey(pvName));
         destPVTypeInfo.setCreationTime(TimeUtils.convertFromISO8601String("2020-11-11T14:49:58.523Z"));
         destPVTypeInfo.setModificationTime(TimeUtils.now());
-        GetUrlContent.postObjectAndGetContentAsJSONObject(
+        GetUrlContent.postDataAndGetContentAsJSONObject(
                 applURL + "/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, "UTF-8")
                         + "&override=true&createnew=true",
                 encoder.encode(destPVTypeInfo));

--- a/src/test/org/epics/archiverappliance/common/FailoverRetrievalTest.java
+++ b/src/test/org/epics/archiverappliance/common/FailoverRetrievalTest.java
@@ -108,7 +108,7 @@ public class FailoverRetrievalTest {
         destPVTypeInfo.setChunkKey(configService.getPVNameToKeyConverter().convertPVNameToKey(pvName));
         destPVTypeInfo.setCreationTime(TimeUtils.convertFromISO8601String("2020-11-11T14:49:58.523Z"));
         destPVTypeInfo.setModificationTime(TimeUtils.now());
-        GetUrlContent.postObjectAndGetContentAsJSONObject(
+        GetUrlContent.postDataAndGetContentAsJSONObject(
                 applURL + "/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, "UTF-8")
                         + "&override=true&createnew=true",
                 encoder.encode(destPVTypeInfo));
@@ -165,7 +165,7 @@ public class FailoverRetrievalTest {
                 + "&other=" + URLEncoder.encode(otherURL, "UTF-8");
         logger.info("Data store is " + destPVTypeInfo.getDataStores()[1]);
 
-        GetUrlContent.postObjectAndGetContentAsJSONObject(
+        GetUrlContent.postDataAndGetContentAsJSONObject(
                 "http://localhost:17665/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, "UTF-8")
                         + "&override=true&createnew=true",
                 encoder.encode(destPVTypeInfo));

--- a/src/test/org/epics/archiverappliance/common/FailoverScoreAPITest.java
+++ b/src/test/org/epics/archiverappliance/common/FailoverScoreAPITest.java
@@ -30,10 +30,10 @@ import org.json.simple.JSONValue;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.net.URLEncoder;
@@ -49,6 +49,7 @@ import java.util.Map;
  *
  */
 @Tag("integration")
+@Disabled("This is a complex use case and we don't support this in the main code yet; keeping this test around just in case")
 public class FailoverScoreAPITest {
     private static final Logger logger = LogManager.getLogger(FailoverScoreAPITest.class.getName());
     String pvName = "FailoverScoreAPITest";
@@ -129,7 +130,7 @@ public class FailoverScoreAPITest {
         destPVTypeInfo.setChunkKey(configService.getPVNameToKeyConverter().convertPVNameToKey(pvName));
         destPVTypeInfo.setCreationTime(TimeUtils.convertFromISO8601String("2020-11-11T14:49:58.523Z"));
         destPVTypeInfo.setModificationTime(TimeUtils.now());
-        GetUrlContent.postObjectAndGetContentAsJSONObject(
+        GetUrlContent.postDataAndGetContentAsJSONObject(
                 applURL + "/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, StandardCharsets.UTF_8)
                         + "&override=true&createnew=true",
                 encoder.encode(destPVTypeInfo));
@@ -178,7 +179,7 @@ public class FailoverScoreAPITest {
                 + "&other=" + URLEncoder.encode(otherURL, StandardCharsets.UTF_8);
         logger.info("Data store is " + destPVTypeInfo.getDataStores()[1]);
 
-        GetUrlContent.postObjectAndGetContentAsJSONObject(
+        GetUrlContent.postDataAndGetContentAsJSONObject(
                 "http://localhost:17665/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, StandardCharsets.UTF_8)
                         + "&override=true&createnew=true",
                 encoder.encode(destPVTypeInfo));
@@ -192,8 +193,8 @@ public class FailoverScoreAPITest {
         JSONArray array = new JSONArray();
         array.add(pvName);
         Map<String, Map<String, Object>> ret =
-                (Map<String, Map<String, Object>>) GetUrlContent.postDataAndGetContentAsJSONArray(scoreURL, array);
-        Assertions.assertTrue(ret.size() > 0, "We expected some data back from getDataAtTime");
+                (Map<String, Map<String, Object>>) GetUrlContent.postDataAndGetContentAsJSONObject(scoreURL, array);
+        Assertions.assertTrue(ret.size() > 0, "We expected some data back from getDataAtTime at " + TimeUtils.convertToISO8601String(epochSecs));
         for (String retpvName : ret.keySet()) {
             Map<String, Object> val = ret.get(retpvName);
             if (retpvName.equals(pvName)) {

--- a/src/test/org/epics/archiverappliance/common/FailoverUpgradeTest.java
+++ b/src/test/org/epics/archiverappliance/common/FailoverUpgradeTest.java
@@ -129,7 +129,7 @@ public class FailoverUpgradeTest {
 		destPVTypeInfo.setChunkKey(configService.getPVNameToKeyConverter().convertPVNameToKey(pvName));
 		destPVTypeInfo.setCreationTime(TimeUtils.convertFromISO8601String("2020-11-11T14:49:58.523Z"));
 		destPVTypeInfo.setModificationTime(TimeUtils.now());
-		GetUrlContent.postObjectAndGetContentAsJSONObject(applURL + "/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, "UTF-8") + "&override=true&createnew=true", encoder.encode(destPVTypeInfo));
+		GetUrlContent.postDataAndGetContentAsJSONObject(applURL + "/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, "UTF-8") + "&override=true&createnew=true", encoder.encode(destPVTypeInfo));
 		logger.info("Added " + pvName + " to the appliance " + applianceName);
 		
 		RawDataRetrievalAsEventStream rawDataRetrieval = new RawDataRetrievalAsEventStream(applURL + "/retrieval/data/getData.raw");
@@ -172,7 +172,7 @@ public class FailoverUpgradeTest {
 			logger.info("Data store is " + destPVTypeInfo.getDataStores()[1]);
 		}
 		
-		GetUrlContent.postObjectAndGetContentAsJSONObject("http://localhost:17665/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, "UTF-8") + "&override=true&createnew=true", encoder.encode(destPVTypeInfo));
+		GetUrlContent.postDataAndGetContentAsJSONObject("http://localhost:17665/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, "UTF-8") + "&override=true&createnew=true", encoder.encode(destPVTypeInfo));
 		logger.info("Changed " + pvName + " to a merge dedup plugin");
 
 	}
@@ -189,7 +189,7 @@ public class FailoverUpgradeTest {
 					+ URLEncoder.encode(destPVTypeInfo.getDataStores()[0], "UTF-8") 
 					+ "&other=" + URLEncoder.encode(otherURL, "UTF-8");
 		}
-		GetUrlContent.postObjectAndGetContentAsJSONObject("http://localhost:17665/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, "UTF-8") + "&override=true&createnew=true", encoder.encode(destPVTypeInfo));
+		GetUrlContent.postDataAndGetContentAsJSONObject("http://localhost:17665/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, "UTF-8") + "&override=true&createnew=true", encoder.encode(destPVTypeInfo));
 		logger.info("Changed " + pvName + " to a merge dedup plugin");
 
 	}

--- a/src/test/org/epics/archiverappliance/common/MergeDataFromExternalStoreTest.java
+++ b/src/test/org/epics/archiverappliance/common/MergeDataFromExternalStoreTest.java
@@ -108,7 +108,7 @@ public class MergeDataFromExternalStoreTest {
         destPVTypeInfo.setChunkKey(configService.getPVNameToKeyConverter().convertPVNameToKey(pvName));
         destPVTypeInfo.setCreationTime(TimeUtils.convertFromISO8601String("2020-11-11T14:49:58.523Z"));
         destPVTypeInfo.setModificationTime(TimeUtils.now());
-        GetUrlContent.postObjectAndGetContentAsJSONObject(
+        GetUrlContent.postDataAndGetContentAsJSONObject(
                 applURL + "/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, "UTF-8")
                         + "&override=true&createnew=true",
                 encoder.encode(destPVTypeInfo));

--- a/src/test/org/epics/archiverappliance/engine/V4/PVAccessUtil.java
+++ b/src/test/org/epics/archiverappliance/engine/V4/PVAccessUtil.java
@@ -181,6 +181,26 @@ public class PVAccessUtil {
         return curentStatus;
     }
 
+    public static void waitForPVDetail(
+            String pvName, String detailName, String expectedValue, int maxTries, String mgmtUrl, long waitPeriodSeconds) {
+        Awaitility.await()
+                .pollInterval(waitPeriodSeconds, TimeUnit.SECONDS)
+                .atMost(maxTries * waitPeriodSeconds, TimeUnit.SECONDS)
+                .untilAsserted(() -> Assertions.assertEquals(expectedValue, getPVDetail(pvName, mgmtUrl, detailName)));
+    }
+
+    public static String getPVDetail(String pvName, String mgmtUrl, String detailName) {
+        String pvDetailsURL = mgmtUrl + "getPVDetails?pv=" + URLEncoder.encode(pvName, StandardCharsets.UTF_8);
+        List<Map<String, String>> pvDetails = (List<Map<String, String>>) GetUrlContent.getURLContentAsJSONArray(pvDetailsURL);
+        for(Map<String, String> pvDetail : pvDetails){
+            if(pvDetail.get("name").equals(detailName)) {
+                return pvDetail.get("value");
+            }
+        }
+        return null;
+    }
+
+
     /**
      * Bytes to string method for debugging the byte buffers.
      *

--- a/src/test/org/epics/archiverappliance/mgmt/AddRemoveAliasTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/AddRemoveAliasTest.java
@@ -1,6 +1,5 @@
 package org.epics.archiverappliance.mgmt;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.Event;
@@ -9,23 +8,21 @@ import org.epics.archiverappliance.SIOCSetup;
 import org.epics.archiverappliance.TomcatSetup;
 import org.epics.archiverappliance.common.TimeUtils;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
+import org.epics.archiverappliance.engine.V4.PVAccessUtil;
 import org.epics.archiverappliance.retrieval.client.RawDataRetrievalAsEventStream;
 import org.epics.archiverappliance.utils.ui.GetUrlContent;
+import org.json.simple.JSONAware;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 import java.io.IOException;
-import java.net.URLEncoder;
 import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Check addAlias and removeAlias functionality.
@@ -40,92 +37,73 @@ public class AddRemoveAliasTest {
 	private static Logger logger = LogManager.getLogger(AddRemoveAliasTest.class.getName());
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	SIOCSetup siocSetup = new SIOCSetup();
-	WebDriver driver;
-
-	@BeforeAll
-	public static void setupClass() {
-		WebDriverManager.firefoxdriver().setup();
-	}
 
 	@BeforeEach
 	public void setUp() throws Exception {
 		siocSetup.startSIOCWithDefaultDB();
 		tomcatSetup.setUpWebApps(this.getClass().getSimpleName());
-		driver = new FirefoxDriver();
 	}
 
 	@AfterEach
 	public void tearDown() throws Exception {
-		driver.quit();
 		tomcatSetup.tearDown();
 		siocSetup.stopSIOC();
 	}
 
 	@Test
 	public void testSimpleArchivePV() throws Exception {
-		 driver.get("http://localhost:17665/mgmt/ui/index.html");
-		 WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
-		 String pvNameToArchive = "UnitTestNoNamingConvention:sine";
-		 pvstextarea.sendKeys(pvNameToArchive);
-		 WebElement archiveButton = driver.findElement(By.id("archstatArchive"));
-		 logger.debug("About to submit");
-		 archiveButton.click();
-		 // We have to wait for a few minutes here as it does take a while for the workflow to complete.
-		 // In addition, we are also getting .HIHI etc the monitors for which get established many minutes after the beginning of archiving 
-		 Thread.sleep(15*60*1000);
-		 WebElement checkStatusButton = driver.findElement(By.id("archstatCheckStatus"));
-		 checkStatusButton.click();
-		 Thread.sleep(2*1000);
-		 WebElement statusPVName = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(1)"));
-		 String pvNameObtainedFromTable = statusPVName.getText();
-		 String expectedPVName = "UnitTestNoNamingConvention:sine";
-		 Assertions.assertTrue(expectedPVName.equals(pvNameObtainedFromTable), "Expecting PV name to be " + expectedPVName + "; instead we get " + pvNameObtainedFromTable);
-		 WebElement statusPVStatus = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(2)"));
-		 String pvArchiveStatusObtainedFromTable = statusPVStatus.getText();
-		 String expectedPVStatus = "Being archived";
-		 Assertions.assertTrue(expectedPVStatus.equals(pvArchiveStatusObtainedFromTable), "Expecting PV archive status to be " + expectedPVStatus + "; instead it is " + pvArchiveStatusObtainedFromTable);
+        String pvNameToArchive = "UnitTestNoNamingConvention:sine";
+        String mgmtURL = "http://localhost:17665/mgmt/bpl/";
+        GetUrlContent.postDataAndGetContentAsJSONArray(mgmtURL + "/archivePV", GetUrlContent.from(List.of(new JSONObject(Map.of("pv", pvNameToArchive)))));
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, "Being archived", 10, mgmtURL, 15);
 		 
-		 SIOCSetup.caput("UnitTestNoNamingConvention:sine.HIHI", 2.0);
-		 Thread.sleep(2*1000);
-		 SIOCSetup.caput("UnitTestNoNamingConvention:sine.HIHI", 3.0);
-		 Thread.sleep(2*1000);
-		 SIOCSetup.caput("UnitTestNoNamingConvention:sine.HIHI", 4.0);
-		 Thread.sleep(2*1000);
-		 logger.info("Done updating UnitTestNoNamingConvention:sine.HIHI");
-		 Thread.sleep(2*60*1000);
-		 
-		 // Test retrieval of data using the real name and the aliased name
-		 testRetrievalCount("UnitTestNoNamingConvention:sine", true);
-		 testRetrievalCount("UnitTestNoNamingConvention:arandomalias", false);
-		 testRetrievalCount("UnitTestNoNamingConvention:sine.HIHI", true);
-		 testRetrievalCount("UnitTestNoNamingConvention:arandomalias.HIHI", false);
-		 
-		 String addAliasURL = "http://localhost:17665/mgmt/bpl/addAlias" 
-		 + "?pv="+ URLEncoder.encode("UnitTestNoNamingConvention:sine", "UTF-8")
-		 + "&aliasname="+ URLEncoder.encode("UnitTestNoNamingConvention:arandomalias", "UTF-8");
-		 JSONObject addAliasStatus = GetUrlContent.getURLContentAsJSONObject(addAliasURL);
-		 logger.debug("Add alias response " + addAliasStatus.toJSONString());
-		 
-		 Thread.sleep(2*1000);
+		SIOCSetup.caput("UnitTestNoNamingConvention:sine.HIHI", 2.0);
+		Thread.sleep(2*1000);
+		SIOCSetup.caput("UnitTestNoNamingConvention:sine.HIHI", 3.0);
+		Thread.sleep(2*1000);
+		SIOCSetup.caput("UnitTestNoNamingConvention:sine.HIHI", 4.0);
+		Thread.sleep(2*1000);
+		logger.info("Done updating UnitTestNoNamingConvention:sine.HIHI");
+		Thread.sleep(2*60*1000);
+		
+		// Test retrieval of data using the real name and the aliased name
+		testRetrievalCount("UnitTestNoNamingConvention:sine", true);
+		testRetrievalCount("UnitTestNoNamingConvention:arandomalias", false);
+		testRetrievalCount("UnitTestNoNamingConvention:sine.HIHI", true);
+		testRetrievalCount("UnitTestNoNamingConvention:arandomalias.HIHI", false);
+		
+		JSONAware addAliasStatus = GetUrlContent.getURLContentWithQueryParameters(
+			mgmtURL + "addAlias", 
+			Map.of(
+				"pv", pvNameToArchive, 
+				"aliasname", "UnitTestNoNamingConvention:arandomalias"
+			), 
+			false
+		);
 
-		 testRetrievalCount("UnitTestNoNamingConvention:sine", true);
-		 testRetrievalCount("UnitTestNoNamingConvention:arandomalias", true);
-		 testRetrievalCount("UnitTestNoNamingConvention:sine.HIHI", true);
-		 testRetrievalCount("UnitTestNoNamingConvention:arandomalias.HIHI", true);
-		 
-		 String removeAliasURL = "http://localhost:17665/mgmt/bpl/removeAlias" 
-		 + "?pv="+ URLEncoder.encode("UnitTestNoNamingConvention:sine", "UTF-8")
-		 + "&aliasname="+ URLEncoder.encode("UnitTestNoNamingConvention:arandomalias", "UTF-8");
-		 JSONObject removeAliasStatus = GetUrlContent.getURLContentAsJSONObject(removeAliasURL);
-		 logger.debug("Remove alias response " + removeAliasStatus.toJSONString());
-		 
-		 Thread.sleep(2*1000);
-
-		 testRetrievalCount("UnitTestNoNamingConvention:sine", true);
-		 testRetrievalCount("UnitTestNoNamingConvention:arandomalias", false);
-		 testRetrievalCount("UnitTestNoNamingConvention:sine.HIHI", true);
-		 testRetrievalCount("UnitTestNoNamingConvention:arandomalias.HIHI", false);
-
+		logger.debug("Add alias response " + addAliasStatus.toJSONString());
+		
+		Thread.sleep(2*1000);
+		testRetrievalCount("UnitTestNoNamingConvention:sine", true);
+		testRetrievalCount("UnitTestNoNamingConvention:arandomalias", true);
+		testRetrievalCount("UnitTestNoNamingConvention:sine.HIHI", true);
+		testRetrievalCount("UnitTestNoNamingConvention:arandomalias.HIHI", true);
+		
+		JSONAware removeAliasStatus = GetUrlContent.getURLContentWithQueryParameters(
+			mgmtURL + "removeAlias", 
+			Map.of(
+				"pv", pvNameToArchive, 
+				"aliasname", "UnitTestNoNamingConvention:arandomalias"
+			), 
+			false
+		);
+		logger.debug("Remove alias response " + removeAliasStatus.toJSONString());
+		
+		Thread.sleep(2*1000);
+		testRetrievalCount("UnitTestNoNamingConvention:sine", true);
+		testRetrievalCount("UnitTestNoNamingConvention:arandomalias", false);
+		testRetrievalCount("UnitTestNoNamingConvention:sine.HIHI", true);
+		testRetrievalCount("UnitTestNoNamingConvention:arandomalias.HIHI", false);
 	}
 
 	/**

--- a/src/test/org/epics/archiverappliance/mgmt/ArchiveFieldsWorkflowTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/ArchiveFieldsWorkflowTest.java
@@ -1,21 +1,20 @@
 package org.epics.archiverappliance.mgmt;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.SIOCSetup;
 import org.epics.archiverappliance.TomcatSetup;
+import org.epics.archiverappliance.engine.V4.PVAccessUtil;
+import org.epics.archiverappliance.utils.ui.GetUrlContent;
+import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 /**
  * Test archiving of fields - this should include standard field like HIHI and also non-standard fields.
@@ -28,33 +27,22 @@ public class ArchiveFieldsWorkflowTest {
     private static Logger logger = LogManager.getLogger(ArchiveFieldsWorkflowTest.class.getName());
     TomcatSetup tomcatSetup = new TomcatSetup();
     SIOCSetup siocSetup = new SIOCSetup();
-    WebDriver driver;
-
-    @BeforeAll
-    public static void setupClass() {
-        WebDriverManager.firefoxdriver().setup();
-    }
 
     @BeforeEach
     public void setUp() throws Exception {
         siocSetup.startSIOCWithDefaultDB();
         tomcatSetup.setUpWebApps(this.getClass().getSimpleName());
-        driver = new FirefoxDriver();
     }
 
     @AfterEach
     public void tearDown() throws Exception {
-        driver.quit();
         tomcatSetup.tearDown();
         siocSetup.stopSIOC();
     }
 
     @Test
     public void testArchiveFieldsPV() throws Exception {
-        driver.get("http://localhost:17665/mgmt/ui/index.html");
-        ((JavascriptExecutor) driver).executeScript("window.skipAutoRefresh = true;");
-        WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
-        String[] fieldsToArchive = new String[] {
+        String[] pvs = new String[] {
             "UnitTestNoNamingConvention:sine",
             "UnitTestNoNamingConvention:sine.EOFF",
             "UnitTestNoNamingConvention:sine.EGU",
@@ -63,36 +51,17 @@ public class ArchiveFieldsWorkflowTest {
             "UnitTestNoNamingConvention:sine.DESC",
             "UnitTestNoNamingConvention:sine.YYZ"
         };
-        pvstextarea.sendKeys(String.join("\n", fieldsToArchive));
-        WebElement archiveButton = driver.findElement(By.id("archstatArchive"));
-        logger.debug("About to submit");
-        archiveButton.click();
-        Thread.sleep(5 * 60 * 1000);
-        WebElement checkStatusButton = driver.findElement(By.id("archstatCheckStatus"));
-        checkStatusButton.click();
-        Thread.sleep(17 * 1000);
-        for (int i = 0; i < fieldsToArchive.length; i++) {
-            int rowWithInfo = i + 1;
-            WebElement statusPVName = driver.findElement(
-                    By.cssSelector("#archstatsdiv_table tr:nth-child(" + rowWithInfo + ") td:nth-child(1)"));
-            String pvNameObtainedFromTable = statusPVName.getText();
-            Assertions.assertTrue(
-                    fieldsToArchive[i].equals(pvNameObtainedFromTable),
-                    "PV Name is not " + fieldsToArchive[i] + "; instead we get " + pvNameObtainedFromTable);
-            WebElement statusPVStatus = driver.findElement(
-                    By.cssSelector("#archstatsdiv_table tr:nth-child(" + rowWithInfo + ") td:nth-child(2)"));
-            String pvArchiveStatusObtainedFromTable = statusPVStatus.getText();
-            String expectedPVStatus = "Being archived";
-            if (fieldsToArchive[i].equals("UnitTestNoNamingConvention:sine.YYZ")) {
-                Assertions.assertTrue(
-                        !expectedPVStatus.equals(pvArchiveStatusObtainedFromTable),
-                        "Expecting PV archive status to NOT be " + expectedPVStatus + "; instead it is "
-                                + pvArchiveStatusObtainedFromTable + " for field " + fieldsToArchive[i]);
+
+        List<JSONObject> arSpecs = List.of(pvs).stream().map((x) -> new JSONObject(Map.of("pv", x))).collect(Collectors.toList());
+        String mgmtURL = "http://localhost:17665/mgmt/bpl/";
+        logger.info("Archiving multiple PVs");
+        GetUrlContent.postDataAndGetContentAsJSONArray(mgmtURL + "archivePV", GetUrlContent.from(arSpecs));
+        for(String pv : pvs) {
+            logger.info("Checking to see if PV is being archived {}", pv);
+            if(!pv.equals("UnitTestNoNamingConvention:sine.YYZ")) {
+                PVAccessUtil.waitForStatusChange(pv, "Being archived", 10, mgmtURL, 15);
             } else {
-                Assertions.assertTrue(
-                        expectedPVStatus.equals(pvArchiveStatusObtainedFromTable),
-                        "Expecting PV archive status to be " + expectedPVStatus + "; instead it is "
-                                + pvArchiveStatusObtainedFromTable + " for field " + fieldsToArchive[i]);
+                PVAccessUtil.waitForStatusChange(pv, "Initial sampling", 10, mgmtURL, 15);
             }
         }
     }

--- a/src/test/org/epics/archiverappliance/mgmt/ArchivePVClusterTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/ArchivePVClusterTest.java
@@ -1,6 +1,5 @@
 package org.epics.archiverappliance.mgmt;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -10,18 +9,18 @@ import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.epics.archiverappliance.config.PVTypeInfo;
 import org.epics.archiverappliance.config.persistence.JDBM2Persistence;
+import org.epics.archiverappliance.engine.V4.PVAccessUtil;
+import org.epics.archiverappliance.utils.ui.GetUrlContent;
+import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 import java.io.File;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Test archiving using a simple cluster of tomcat servers.
@@ -35,12 +34,7 @@ public class ArchivePVClusterTest {
 	File persistenceFolder = new File(ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "InactiveClusterMemberArchivePVTest");
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	SIOCSetup siocSetup = new SIOCSetup();
-	WebDriver driver;
 
-	@BeforeAll
-	public static void setupClass() {
-		WebDriverManager.firefoxdriver().setup();
-	}
 	@BeforeEach
 	public void setUp() throws Exception {
 		if(persistenceFolder.exists()) {
@@ -51,12 +45,10 @@ public class ArchivePVClusterTest {
 		System.getProperties().put(ConfigService.ARCHAPPL_PERSISTENCE_LAYER, "org.epics.archiverappliance.config.persistence.JDBM2Persistence");
 		System.getProperties().put(JDBM2Persistence.ARCHAPPL_JDBM2_FILENAME, persistenceFolder.getPath() + File.separator + "testconfig.jdbm2");
 		tomcatSetup.setUpClusterWithWebApps(this.getClass().getSimpleName(), 2);
-		driver = new FirefoxDriver();
 	}
 
 	@AfterEach
 	public void tearDown() throws Exception {
-		driver.quit();
 		tomcatSetup.tearDown();
 		siocSetup.stopSIOC();
 		FileUtils.deleteDirectory(persistenceFolder);
@@ -64,29 +56,13 @@ public class ArchivePVClusterTest {
 
 	@Test
 	public void testSimpleArchivePV() throws Exception {
-		 int port = ConfigServiceForTests.RETRIEVAL_TEST_PORT+1;
-		 driver.get("http://localhost:" + port + "/mgmt/ui/index.html");
-		 WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
-		 String pvNameToArchive = "UnitTestNoNamingConvention:sine";
-		 pvstextarea.sendKeys(pvNameToArchive);
-		 WebElement archiveButton = driver.findElement(By.id("archstatArchive"));
-		 logger.debug("About to submit");
-		 archiveButton.click();
-		 // We have to wait for a few minutes here as it does take a while for the workflow to complete.
-		 Thread.sleep(4*60*1000);
-		 WebElement checkStatusButton = driver.findElement(By.id("archstatCheckStatus"));
-		 checkStatusButton.click();
-		 Thread.sleep(2*1000);
-		 WebElement statusPVName = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(1)"));
-		 String pvNameObtainedFromTable = statusPVName.getText();
-		 Assertions.assertTrue(pvNameToArchive.equals(pvNameObtainedFromTable), "PV Name is not " + pvNameToArchive + "; instead we get " + pvNameObtainedFromTable);
-		 WebElement statusPVStatus = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(2)"));
-		 String pvArchiveStatusObtainedFromTable = statusPVStatus.getText();
-		 String expectedPVStatus = "Being archived";
-		 Assertions.assertTrue(expectedPVStatus.equals(pvArchiveStatusObtainedFromTable), "Expecting PV archive status to be " + expectedPVStatus + "; instead it is " + pvArchiveStatusObtainedFromTable);
-		 String aapl0 = checkInPersistence(pvNameToArchive, 0);
-		 String aapl1 = checkInPersistence(pvNameToArchive, 1);
-		 Assertions.assertTrue(aapl0.equals(aapl1), "Expecting the same appliance indetity in both typeinfos, instead it is " + aapl0 + " in cluster member 0 and " + aapl1 + " in cluster member 1");
+        String pvNameToArchive = "UnitTestNoNamingConvention:sine";
+        String mgmtURL = "http://localhost:17665/mgmt/bpl/";
+        GetUrlContent.postDataAndGetContentAsJSONArray(mgmtURL + "/archivePV", GetUrlContent.from(List.of(new JSONObject(Map.of("pv", pvNameToArchive)))));
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, "Being archived", 10, mgmtURL, 15);
+		String aapl0 = checkInPersistence(pvNameToArchive, 0);
+		String aapl1 = checkInPersistence(pvNameToArchive, 1);
+		Assertions.assertTrue(aapl0.equals(aapl1), "Expecting the same appliance indetity in both typeinfos, instead it is " + aapl0 + " in cluster member 0 and " + aapl1 + " in cluster member 1");
 	}
 	
 	private String checkInPersistence(String pvName, int clusterIndex) throws Exception {

--- a/src/test/org/epics/archiverappliance/mgmt/ArchivePVTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/ArchivePVTest.java
@@ -1,20 +1,22 @@
 package org.epics.archiverappliance.mgmt;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.SIOCSetup;
 import org.epics.archiverappliance.TomcatSetup;
+import org.epics.archiverappliance.engine.V4.PVAccessUtil;
+import org.epics.archiverappliance.utils.ui.GetUrlContent;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
+
 
 /**
  * Use the firefox driver to test operator's adding a PV to the system.
@@ -27,54 +29,31 @@ public class ArchivePVTest {
     private static Logger logger = LogManager.getLogger(ArchivePVTest.class.getName());
     TomcatSetup tomcatSetup = new TomcatSetup();
     SIOCSetup siocSetup = new SIOCSetup();
-    WebDriver driver;
-
-    @BeforeAll
-    public static void setupClass() {
-        WebDriverManager.firefoxdriver().setup();
-    }
 
     @BeforeEach
     public void setUp() throws Exception {
         siocSetup.startSIOCWithDefaultDB();
         tomcatSetup.setUpWebApps(this.getClass().getSimpleName());
-        driver = new FirefoxDriver();
     }
 
     @AfterEach
     public void tearDown() throws Exception {
-        driver.quit();
         tomcatSetup.tearDown();
         siocSetup.stopSIOC();
     }
 
     @Test
     public void testSimpleArchivePV() throws Exception {
-        driver.get("http://localhost:17665/mgmt/ui/index.html");
-        WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
         String pvNameToArchive = "UnitTestNoNamingConvention:sine";
-        pvstextarea.sendKeys(pvNameToArchive);
-        WebElement archiveButton = driver.findElement(By.id("archstatArchive"));
-        logger.debug("About to submit");
-        archiveButton.click();
-        // We have to wait for about 10 minutes here as it does take a while for the workflow to complete.
-        Thread.sleep(2 * 60 * 1000);
-        WebElement checkStatusButton = driver.findElement(By.id("archstatCheckStatus"));
-        checkStatusButton.click();
-        Thread.sleep(2 * 1000);
-        WebElement statusPVName =
-                driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(1)"));
-        String pvNameObtainedFromTable = statusPVName.getText();
-        Assertions.assertTrue(
-                pvNameToArchive.equals(pvNameObtainedFromTable),
-                "PV Name is not " + pvNameToArchive + "; instead we get " + pvNameObtainedFromTable);
-        WebElement statusPVStatus =
-                driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(2)"));
-        String pvArchiveStatusObtainedFromTable = statusPVStatus.getText();
-        String expectedPVStatus = "Being archived";
-        Assertions.assertTrue(
-                expectedPVStatus.equals(pvArchiveStatusObtainedFromTable),
-                "Expecting PV archive status to be " + expectedPVStatus + "; instead it is "
-                        + pvArchiveStatusObtainedFromTable);
+        String mgmtURL = "http://localhost:17665/mgmt/bpl/";
+        GetUrlContent.postDataAndGetContentAsJSONArray(mgmtURL + "/archivePV", GetUrlContent.from(List.of(new JSONObject(Map.of("pv", pvNameToArchive)))));
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, "Being archived", 10, mgmtURL, 15);
+        JSONArray statuses = GetUrlContent.getURLContentAsJSONArray(mgmtURL + "/getPVStatus?pv="+pvNameToArchive);
+        Assertions.assertNotNull(statuses);
+        Assertions.assertTrue(statuses.size() > 0);
+        @SuppressWarnings("unchecked")
+        Map<String, String> status = (Map<String, String>) statuses.get(0);
+        Assertions.assertEquals(status.getOrDefault("pvName", ""), pvNameToArchive, 
+            "PV Name is not " + pvNameToArchive + "; instead we get " + status.getOrDefault("pvName", ""));
     }
 }

--- a/src/test/org/epics/archiverappliance/mgmt/ArchiveWithSamplingPeriodPVTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/ArchiveWithSamplingPeriodPVTest.java
@@ -1,87 +1,48 @@
 package org.epics.archiverappliance.mgmt;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+
 import org.epics.archiverappliance.SIOCSetup;
 import org.epics.archiverappliance.TomcatSetup;
+import org.epics.archiverappliance.engine.V4.PVAccessUtil;
+import org.epics.archiverappliance.utils.ui.GetUrlContent;
+import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 @Tag("integration")
 @Tag("localEpics")
 public class ArchiveWithSamplingPeriodPVTest {
-    private static Logger logger = LogManager.getLogger(ArchiveWithSamplingPeriodPVTest.class.getName());
     TomcatSetup tomcatSetup = new TomcatSetup();
     SIOCSetup siocSetup = new SIOCSetup();
-    WebDriver driver;
-
-    @BeforeAll
-    public static void setupClass() {
-        WebDriverManager.firefoxdriver().setup();
-    }
 
     @BeforeEach
     public void setUp() throws Exception {
         siocSetup.startSIOCWithDefaultDB();
         tomcatSetup.setUpWebApps(this.getClass().getSimpleName());
-        driver = new FirefoxDriver();
     }
 
     @AfterEach
     public void tearDown() throws Exception {
-        driver.quit();
         tomcatSetup.tearDown();
         siocSetup.stopSIOC();
     }
 
     @Test
     public void testArchiveWithSamplingPeriod() throws Exception {
-        driver.get("http://localhost:17665/mgmt/ui/index.html");
-        WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
         String pvNameToArchive = "UnitTestNoNamingConvention:sine";
-        pvstextarea.sendKeys(pvNameToArchive);
-        WebElement archiveWithPeriodButton = driver.findElement(By.id("archstatArchiveWithPeriod"));
-        logger.debug("About to start dialog");
-        archiveWithPeriodButton.click();
-        WebElement samplingPeriodTextBox = driver.findElement(By.id("pvDetailsSamplingPeriod"));
-        samplingPeriodTextBox.sendKeys("10"); // A sample every 10 seconds
-        WebElement dialogOkButton = driver.findElement(By.id("pvDetailsParamsOk"));
-        logger.debug("About to submit");
-        dialogOkButton.click();
-        // We have to wait for about 10 minutes here as it does take a while for the workflow to complete.
-        Thread.sleep(10 * 60 * 1000);
-        WebElement checkStatusButton = driver.findElement(By.id("archstatCheckStatus"));
-        checkStatusButton.click();
-        Thread.sleep(2 * 1000);
-        WebElement statusPVName =
-                driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(1)"));
-        String pvNameObtainedFromTable = statusPVName.getText();
+        String mgmtURL = "http://localhost:17665/mgmt/bpl/";
+        GetUrlContent.postDataAndGetContentAsJSONArray(mgmtURL + "/archivePV", GetUrlContent.from(List.of(new JSONObject(Map.of("pv", pvNameToArchive, "samplingperiod", "10.0")))));
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, "Being archived", 10, mgmtURL, 15);
+        @SuppressWarnings("unchecked")
+        Map<String, String> status = (Map<String, String>) GetUrlContent.getURLContentWithQueryParametersAsJSONArray(mgmtURL + "getPVStatus", Map.of("pv", pvNameToArchive)).get(0);
         Assertions.assertTrue(
-                pvNameToArchive.equals(pvNameObtainedFromTable),
-                "PV Name is not " + pvNameToArchive + "; instead we get " + pvNameObtainedFromTable);
-        WebElement statusPVStatus =
-                driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(2)"));
-        String pvArchiveStatusObtainedFromTable = statusPVStatus.getText();
-        String expectedPVStatus = "Being archived";
-        Assertions.assertTrue(
-                expectedPVStatus.equals(pvArchiveStatusObtainedFromTable),
-                "Expecting PV archive status to be " + expectedPVStatus + "; instead it is "
-                        + pvArchiveStatusObtainedFromTable);
-        WebElement samplingRateTD =
-                driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(6)"));
-        String samplingRateStr = samplingRateTD.getText();
-        String expectedsamplingRateStr = "10.0";
-        Assertions.assertTrue(
-                expectedsamplingRateStr.equals(samplingRateStr),
-                "Expecting sampling rate to be " + expectedsamplingRateStr + "; instead it is " + samplingRateStr);
+                "10.0".equals(status.get("samplingPeriod")),
+                "Expecting sampling rate to be 10.0; instead it is " + status.get("samplingPeriod"));
     }
 }

--- a/src/test/org/epics/archiverappliance/mgmt/ChangeArchivalParamsTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/ChangeArchivalParamsTest.java
@@ -1,22 +1,20 @@
 package org.epics.archiverappliance.mgmt;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.SIOCSetup;
 import org.epics.archiverappliance.TomcatSetup;
+import org.epics.archiverappliance.engine.V4.PVAccessUtil;
+import org.epics.archiverappliance.utils.ui.GetUrlContent;
+import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 import java.util.List;
+import java.util.Map;
 
 @Tag("integration")
 @Tag("localEpics")
@@ -24,67 +22,32 @@ public class ChangeArchivalParamsTest {
     private static Logger logger = LogManager.getLogger(ChangeArchivalParamsTest.class.getName());
     TomcatSetup tomcatSetup = new TomcatSetup();
     SIOCSetup siocSetup = new SIOCSetup();
-    WebDriver driver;
 
-    @BeforeAll
-    public static void setupClass() {
-        WebDriverManager.firefoxdriver().setup();
-    }
 
     @BeforeEach
     public void setUp() throws Exception {
         siocSetup.startSIOCWithDefaultDB();
         tomcatSetup.setUpWebApps(this.getClass().getSimpleName());
-        driver = new FirefoxDriver();
     }
 
     @AfterEach
     public void tearDown() throws Exception {
-        driver.quit();
         tomcatSetup.tearDown();
         siocSetup.stopSIOC();
     }
 
     @Test
     public void testChangeArchivalParams() throws Exception {
-        driver.get("http://localhost:17665/mgmt/ui/index.html");
-        WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
         String pvNameToArchive = "UnitTestNoNamingConvention:sine";
-        pvstextarea.sendKeys(pvNameToArchive);
-        WebElement archiveButton = driver.findElement(By.id("archstatArchive"));
-        logger.info("About to submit");
-        archiveButton.click();
-        Thread.sleep(10 * 1000);
-        WebElement checkStatusButton = driver.findElement(By.id("archstatCheckStatus"));
-        checkStatusButton.click();
-        // We have to wait for a few minutes here as it does take a while for the workflow to complete.
-        Thread.sleep(5 * 60 * 1000);
-        driver.get("http://localhost:17665/mgmt/ui/pvdetails.html?pv=" + pvNameToArchive);
-        Thread.sleep(2 * 1000);
-        WebElement changePVParams = driver.findElement(By.id("pvDetailsParamChange"));
-        logger.info("About to start dialog");
-        changePVParams.click();
-        WebElement samplingPeriodTextBox = driver.findElement(By.id("pvDetailsSamplingPeriod"));
-        samplingPeriodTextBox.clear();
-        samplingPeriodTextBox.sendKeys("11"); // A sample every 11 seconds
-        WebElement dialogOkButton = driver.findElement(By.id("pvDetailsParamsOk"));
-        logger.info("About to submit");
-        dialogOkButton.click();
-        Thread.sleep(10 * 1000);
-        WebElement pvDetailsTable = driver.findElement(By.id("pvDetailsTable"));
-        List<WebElement> pvDetailsTableRows = pvDetailsTable.findElements(By.cssSelector("tbody tr"));
-        for (WebElement pvDetailsTableRow : pvDetailsTableRows) {
-            WebElement pvDetailsTableFirstCol = pvDetailsTableRow.findElement(By.cssSelector("td:nth-child(1)"));
-            if (pvDetailsTableFirstCol.getText().contains("Sampling period")) {
-                WebElement pvDetailsTableSecondCol = pvDetailsTableRow.findElement(By.cssSelector("td:nth-child(2)"));
-                String obtainedSamplingPeriod = pvDetailsTableSecondCol.getText();
-                String expectedSamplingPeriod = "11.0";
-                Assertions.assertTrue(
-                        expectedSamplingPeriod.equals(obtainedSamplingPeriod),
-                        "Expecting sampling period to be " + expectedSamplingPeriod + "; instead it is "
-                                + obtainedSamplingPeriod);
-                break;
-            }
-        }
+        String mgmtURL = "http://localhost:17665/mgmt/bpl/";
+        GetUrlContent.postDataAndGetContentAsJSONArray(mgmtURL + "archivePV", GetUrlContent.from(List.of(new JSONObject(Map.of("pv", pvNameToArchive)))));
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, "Being archived", 10, mgmtURL, 15);
+        @SuppressWarnings("unchecked")
+        Map<String, String> chst = (Map<String, String>) GetUrlContent.getURLContentWithQueryParametersAsJSONObject(mgmtURL + "changeArchivalParameters",
+            Map.of("pv", pvNameToArchive, "samplingperiod", "11")); // A sample every 11 seconds
+        Assertions.assertEquals(chst.get("status"), "ok");
+        @SuppressWarnings("unchecked")
+        Map<String, String> pvst = (Map<String, String>)(GetUrlContent.getURLContentWithQueryParametersAsJSONArray(mgmtURL + "getPVStatus", Map.of("pv", pvNameToArchive)).get(0));
+        Assertions.assertEquals(pvst.get("samplingPeriod"), "11.0");
     }
 }

--- a/src/test/org/epics/archiverappliance/mgmt/InactiveClusterMemberArchivePVTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/InactiveClusterMemberArchivePVTest.java
@@ -1,6 +1,5 @@
 package org.epics.archiverappliance.mgmt;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -11,18 +10,17 @@ import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.epics.archiverappliance.config.PVTypeInfo;
 import org.epics.archiverappliance.config.persistence.JDBM2Persistence;
+import org.epics.archiverappliance.engine.V4.PVAccessUtil;
+import org.epics.archiverappliance.utils.ui.GetUrlContent;
+import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 import java.io.File;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Complex unit test for testing what happens when we ask to archive a PV when the member that is currently archiving it is inactive.
@@ -46,13 +44,7 @@ public class InactiveClusterMemberArchivePVTest {
     private String pvNameToArchive1 = "UnitTestNoNamingConvention:inactive1";
     private String pvNameToArchive2 = "UnitTestNoNamingConvention:inactive2";
     TomcatSetup tomcatSetup = new TomcatSetup();
-    WebDriver driver;
     SIOCSetup siocSetup = new SIOCSetup();
-
-    @BeforeAll
-    public static void setupClass() {
-        WebDriverManager.firefoxdriver().setup();
-    }
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -64,13 +56,22 @@ public class InactiveClusterMemberArchivePVTest {
                 .put(
                         ConfigService.ARCHAPPL_PERSISTENCE_LAYER,
                         "org.epics.archiverappliance.config.persistence.JDBM2Persistence");
-        System.getProperties()
+        {
+            System.getProperties()
                 .put(
-                        JDBM2Persistence.ARCHAPPL_JDBM2_FILENAME,
-                        persistenceFolder.getPath() + File.separator + "testconfig_appliance0.jdbm2");
-        JDBM2Persistence persistenceLayer = new JDBM2Persistence();
-        persistenceLayer.putTypeInfo(pvNameToArchive1, generatePVTypeInfo(pvNameToArchive1, "appliance0"));
-        persistenceLayer.putTypeInfo(pvNameToArchive2, generatePVTypeInfo(pvNameToArchive2, "appliance1"));
+                    JDBM2Persistence.ARCHAPPL_JDBM2_FILENAME,
+                    persistenceFolder.getPath() + File.separator + "testconfig_appliance0.jdbm2");
+            JDBM2Persistence persistenceLayer = new JDBM2Persistence();
+            persistenceLayer.putTypeInfo(pvNameToArchive1, generatePVTypeInfo(pvNameToArchive1, "appliance0"));
+        }
+        {
+            System.getProperties()
+                .put(
+                    JDBM2Persistence.ARCHAPPL_JDBM2_FILENAME,
+                    persistenceFolder.getPath() + File.separator + "testconfig_appliance1.jdbm2");
+            JDBM2Persistence persistenceLayer = new JDBM2Persistence();
+            persistenceLayer.putTypeInfo(pvNameToArchive2, generatePVTypeInfo(pvNameToArchive2, "appliance1"));
+        }
 
         siocSetup.startSIOCWithDefaultDB();
         // Replace the testconfig_appliance0.jdbm2 with testconfig.jdbm2 as TomcatSetup adds this to the JDBM2 file name
@@ -79,13 +80,11 @@ public class InactiveClusterMemberArchivePVTest {
                 .put(
                         JDBM2Persistence.ARCHAPPL_JDBM2_FILENAME,
                         persistenceFolder.getPath() + File.separator + "testconfig.jdbm2");
-        tomcatSetup.setUpWebApps(this.getClass().getSimpleName());
-        driver = new FirefoxDriver();
+        tomcatSetup.setUpClusterWithWebApps(this.getClass().getSimpleName(), 2);
     }
 
     @AfterEach
     public void tearDown() throws Exception {
-        driver.quit();
         tomcatSetup.tearDown();
         siocSetup.stopSIOC();
 
@@ -94,66 +93,27 @@ public class InactiveClusterMemberArchivePVTest {
 
     @Test
     public void testRequestForArchivingThatAlreadyExistsOnInactiveMember() throws Exception {
-        checkPVStatus(pvNameToArchive1, "Paused");
+        checkPVStatus(pvNameToArchive1, "Appliance assigned");
+        checkPVStatus(pvNameToArchive2, "Appliance assigned");
+        tomcatSetup.shutDownAppliance("appliance1");
+        checkPVStatus(pvNameToArchive1, "Appliance assigned");
         checkPVStatus(pvNameToArchive2, "Appliance Down");
-        archivePV(pvNameToArchive1, "Paused");
+        archivePV(pvNameToArchive1, "Appliance assigned");
         archivePV(pvNameToArchive2, "Appliance Down");
     }
 
     private void checkPVStatus(String pvName, String expectedPVStatus) throws Exception {
-        logger.info("Checking status for pv " + pvName);
-        driver.get("http://localhost:17665/mgmt/ui/index.html");
-        WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
         String pvNameToArchive = pvName;
-        pvstextarea.clear();
-        pvstextarea.sendKeys(pvNameToArchive);
-        Thread.sleep(1 * 1000);
-        WebElement checkStatusButton = driver.findElement(By.id("archstatCheckStatus"));
-        checkStatusButton.click();
-        Thread.sleep(2 * 1000);
-        WebElement statusPVName =
-                driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(1)"));
-        String pvNameObtainedFromTable = statusPVName.getText();
-        Assertions.assertTrue(
-                pvNameToArchive.equals(pvNameObtainedFromTable),
-                "PV Name is not " + pvNameToArchive + "; instead we get " + pvNameObtainedFromTable);
-        WebElement statusPVStatus =
-                driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(2)"));
-        String pvArchiveStatusObtainedFromTable = statusPVStatus.getText();
-        Assertions.assertTrue(
-                expectedPVStatus.equals(pvArchiveStatusObtainedFromTable),
-                "Expecting PV archive status to be " + expectedPVStatus + " for PV" + pvName + " instead it is "
-                        + pvArchiveStatusObtainedFromTable);
+        String mgmtURL = "http://localhost:17665/mgmt/bpl/";
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, expectedPVStatus, 10, mgmtURL, 15);
     }
 
     private void archivePV(String pvName, String expectedPVStatus) throws Exception {
         logger.info("Asking to archive pv " + pvName);
-        driver.get("http://localhost:17665/mgmt/ui/index.html");
-        WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
         String pvNameToArchive = pvName;
-        pvstextarea.clear();
-        pvstextarea.sendKeys(pvNameToArchive);
-        Thread.sleep(1 * 1000);
-        WebElement archiveButton = driver.findElement(By.id("archstatArchive"));
-        logger.debug("About to submit");
-        archiveButton.click();
-        Thread.sleep(30 * 1000);
-        WebElement checkStatusButton = driver.findElement(By.id("archstatCheckStatus"));
-        checkStatusButton.click();
-        Thread.sleep(2 * 1000);
-        WebElement statusPVName =
-                driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(1)"));
-        String pvNameObtainedFromTable = statusPVName.getText();
-        Assertions.assertTrue(
-                pvNameToArchive.equals(pvNameObtainedFromTable),
-                "PV Name is not " + pvNameToArchive + "; instead we get " + pvNameObtainedFromTable);
-        WebElement statusPVStatus =
-                driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(2)"));
-        String pvArchiveStatusObtainedFromTable = statusPVStatus.getText();
-        Assertions.assertTrue(
-                expectedPVStatus.equals(pvArchiveStatusObtainedFromTable),
-                "Expecting PV archive status to be " + expectedPVStatus + "; instead it is "
-                        + pvArchiveStatusObtainedFromTable);
+        String mgmtURL = "http://localhost:17665/mgmt/bpl/";
+        GetUrlContent.postDataAndGetContentAsJSONArray(mgmtURL + "/archivePV", GetUrlContent.from(List.of(new JSONObject(Map.of("pv", pvNameToArchive)))));
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, expectedPVStatus, 10, mgmtURL, 15);
     }
 
     private static PVTypeInfo generatePVTypeInfo(String pvName, String applianceIdentity) {
@@ -167,7 +127,7 @@ public class InactiveClusterMemberArchivePVTest {
         typeInfo.setApplianceIdentity(applianceIdentity);
         typeInfo.addArchiveField("HIHI");
         typeInfo.addArchiveField("LOLO");
-        typeInfo.setPaused(true);
+        typeInfo.setPaused(false);
         return typeInfo;
     }
 }

--- a/src/test/org/epics/archiverappliance/mgmt/appxml/FQDNApplianceXMLTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/appxml/FQDNApplianceXMLTest.java
@@ -1,24 +1,21 @@
 package org.epics.archiverappliance.mgmt.appxml;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.TomcatSetup;
 import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
+import org.epics.archiverappliance.utils.ui.GetUrlContent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 import java.io.File;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
 import java.io.PrintWriter;
 import java.net.InetAddress;
 
@@ -32,12 +29,6 @@ public class FQDNApplianceXMLTest {
     private static Logger logger = LogManager.getLogger(FQDNApplianceXMLTest.class.getName());
     File testFolder = new File(ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "ApplianceXMLTest");
     TomcatSetup tomcatSetup = new TomcatSetup();
-    WebDriver driver;
-
-    @BeforeAll
-    public static void setupClass() {
-        WebDriverManager.firefoxdriver().setup();
-    }
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -69,13 +60,19 @@ public class FQDNApplianceXMLTest {
         System.getProperties().put(ConfigService.ARCHAPPL_APPLIANCES, appliancesFilename);
 
         tomcatSetup.setUpWebApps(this.getClass().getSimpleName());
-        driver = new FirefoxDriver();
+        boolean found = false;
+        try(LineNumberReader rdr = new LineNumberReader(new InputStreamReader(GetUrlContent.getURLContentAsStream("http://localhost:17665/mgmt/ui/index.html")))) {
+            String line = rdr.readLine();
+            while(line != null) {
+                if(line.contains("id=\"archstatpVNames\"")) {
+                    found = true;
+                    break;
+                }
+                line = rdr.readLine();
+            }
+        }
 
-        driver.get("http://localhost:17665/mgmt/ui/index.html");
-        WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
-        Assertions.assertTrue(pvstextarea != null, "Cannot get to the home page...");
-
-        driver.quit();
+        Assertions.assertTrue(found, "Cannot find the element with id archstatpVNames");
         tomcatSetup.tearDown();
     }
 }

--- a/src/test/org/epics/archiverappliance/mgmt/appxml/IPApplianceXMLTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/appxml/IPApplianceXMLTest.java
@@ -1,24 +1,21 @@
 package org.epics.archiverappliance.mgmt.appxml;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.TomcatSetup;
 import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
+import org.epics.archiverappliance.utils.ui.GetUrlContent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 import java.io.File;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
 import java.io.PrintWriter;
 import java.net.InetAddress;
 
@@ -32,12 +29,6 @@ public class IPApplianceXMLTest {
     private static Logger logger = LogManager.getLogger(IPApplianceXMLTest.class.getName());
     File testFolder = new File(ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "ApplianceXMLTest");
     TomcatSetup tomcatSetup = new TomcatSetup();
-    WebDriver driver;
-
-    @BeforeAll
-    public static void setupClass() {
-        WebDriverManager.firefoxdriver().setup();
-    }
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -69,13 +60,19 @@ public class IPApplianceXMLTest {
         System.getProperties().put(ConfigService.ARCHAPPL_APPLIANCES, appliancesFilename);
 
         tomcatSetup.setUpWebApps(this.getClass().getSimpleName());
-        driver = new FirefoxDriver();
+        boolean found = false;
+        try(LineNumberReader rdr = new LineNumberReader(new InputStreamReader(GetUrlContent.getURLContentAsStream("http://localhost:17665/mgmt/ui/index.html")))) {
+            String line = rdr.readLine();
+            while(line != null) {
+                if(line.contains("id=\"archstatpVNames\"")) {
+                    found = true;
+                    break;
+                }
+                line = rdr.readLine();
+            }
+        }
 
-        driver.get("http://localhost:17665/mgmt/ui/index.html");
-        WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
-        Assertions.assertTrue(pvstextarea != null, "Cannot get to the home page...");
-
-        driver.quit();
+        Assertions.assertTrue(found, "Cannot find the element with id archstatpVNames");
         tomcatSetup.tearDown();
     }
 }

--- a/src/test/org/epics/archiverappliance/mgmt/appxml/LocalhostApplianceXMLTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/appxml/LocalhostApplianceXMLTest.java
@@ -1,24 +1,21 @@
 package org.epics.archiverappliance.mgmt.appxml;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.TomcatSetup;
 import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
+import org.epics.archiverappliance.utils.ui.GetUrlContent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 import java.io.File;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
 import java.io.PrintWriter;
 
 /**
@@ -31,12 +28,6 @@ public class LocalhostApplianceXMLTest {
     private static Logger logger = LogManager.getLogger(LocalhostApplianceXMLTest.class.getName());
     File testFolder = new File(ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "ApplianceXMLTest");
     TomcatSetup tomcatSetup = new TomcatSetup();
-    WebDriver driver;
-
-    @BeforeAll
-    public static void setupClass() {
-        WebDriverManager.firefoxdriver().setup();
-    }
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -68,13 +59,19 @@ public class LocalhostApplianceXMLTest {
         System.getProperties().put(ConfigService.ARCHAPPL_APPLIANCES, appliancesFilename);
 
         tomcatSetup.setUpWebApps(this.getClass().getSimpleName());
-        driver = new FirefoxDriver();
+        boolean found = false;
+        try(LineNumberReader rdr = new LineNumberReader(new InputStreamReader(GetUrlContent.getURLContentAsStream("http://localhost:17665/mgmt/ui/index.html")))) {
+            String line = rdr.readLine();
+            while(line != null) {
+                if(line.contains("id=\"archstatpVNames\"")) {
+                    found = true;
+                    break;
+                }
+                line = rdr.readLine();
+            }
+        }
 
-        driver.get("http://localhost:17665/mgmt/ui/index.html");
-        WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
-        Assertions.assertTrue(pvstextarea != null, "Cannot get to the home page...");
-
-        driver.quit();
+        Assertions.assertTrue(found, "Cannot find the element with id archstatpVNames");
         tomcatSetup.tearDown();
     }
 }

--- a/src/test/org/epics/archiverappliance/mgmt/pauseresume/DeletePVAfterRestartTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/pauseresume/DeletePVAfterRestartTest.java
@@ -1,6 +1,5 @@
 package org.epics.archiverappliance.mgmt.pauseresume;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -11,19 +10,16 @@ import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.epics.archiverappliance.config.PVTypeInfo;
 import org.epics.archiverappliance.config.persistence.JDBM2Persistence;
+import org.epics.archiverappliance.engine.V4.PVAccessUtil;
 import org.epics.archiverappliance.mgmt.policy.PolicyConfig.SamplingMethod;
+import org.epics.archiverappliance.utils.ui.GetUrlContent;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 import java.io.File;
+import java.util.Map;
 
 /**
  * Create a paused PV in persistence; start the appserver and make sure we can delete
@@ -40,12 +36,6 @@ public class DeletePVAfterRestartTest {
     private final String pvNameToArchive = pvPrefix + "UnitTestNoNamingConvention:sine";
     TomcatSetup tomcatSetup = new TomcatSetup();
     SIOCSetup siocSetup = new SIOCSetup(pvPrefix);
-    WebDriver driver;
-
-	@BeforeAll
-	public static void setupClass() {
-		WebDriverManager.firefoxdriver().setup();
-	}
 
 	@BeforeEach
 	public void setUp() throws Exception {
@@ -62,58 +52,21 @@ public class DeletePVAfterRestartTest {
 		// Replace the testconfig_appliance0.jdbm2 with testconfig.jdbm2 as TomcatSetup adds this to the JDBM2 file name to make the tests work in a cluster
 		System.getProperties().put(JDBM2Persistence.ARCHAPPL_JDBM2_FILENAME, persistenceFolder.getPath() + File.separator + "testconfig.jdbm2");
 		tomcatSetup.setUpWebApps(this.getClass().getSimpleName());
-		driver = new FirefoxDriver();
 	}
 
 	@AfterEach
 	public void tearDown() throws Exception {
-		driver.quit();
 		tomcatSetup.tearDown();
 		siocSetup.stopSIOC();
 	}
 
 	@Test
 	public void testSimpleDeletePV() throws Exception {
-		 driver.get("http://localhost:17665/mgmt/ui/index.html");
-		 WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
-		 pvstextarea.sendKeys(pvNameToArchive);
-		 WebElement checkStatusButton = driver.findElement(By.id("archstatCheckStatus"));
-		 checkStatusButton.click();
-		 Thread.sleep(2*1000);
-		 WebElement statusPVName = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(1)"));
-		 String pvNameObtainedFromTable = statusPVName.getText();
-		 Assertions.assertTrue(pvNameToArchive.equals(pvNameObtainedFromTable), "PV Name is not " + pvNameToArchive + "; instead we get " + pvNameObtainedFromTable);
-		 WebElement statusPVStatus = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(2)"));
-		 String pvArchiveStatusObtainedFromTable = statusPVStatus.getText();
-		 String expectedPVStatus = "Paused";
-		 Assertions.assertTrue(expectedPVStatus.equals(pvArchiveStatusObtainedFromTable), "Expecting PV archive status to be " + expectedPVStatus + "; instead it is " + pvArchiveStatusObtainedFromTable);
-
-		 logger.info("Let's go to the details page and resume the PV");
-		 driver.get("http://localhost:17665/mgmt/ui/pvdetails.html?pv=" + pvNameToArchive);
-		 { 
-			 Thread.sleep(2 * 1000);
-			 WebElement deletePVButn = driver.findElement(By.id("pvDetailsStopArchiving"));
-			 logger.info("Clicking on the button to delete/stop archiving the PV");
-			 deletePVButn.click();
-			 Thread.sleep(2 * 1000);
-			 WebElement dialogOkButton = driver.findElement(By.id("pvStopArchivingOk"));
-			 logger.info("About to submit");
-			 dialogOkButton.click();
-			 Thread.sleep(10 * 1000);
-		 }
-		 { 
-			 driver.get("http://localhost:17665/mgmt/ui/index.html");
-			 checkStatusButton = driver.findElement(By.id("archstatCheckStatus"));
-			 checkStatusButton.click();
-			 Thread.sleep(2 * 1000);
-			 statusPVName = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(1)"));
-			 pvNameObtainedFromTable = statusPVName.getText();
-			 Assertions.assertTrue(pvNameToArchive.equals(pvNameObtainedFromTable), "PV Name is not " + pvNameToArchive + "; instead we get " + pvNameObtainedFromTable);
-			 statusPVStatus = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(2)"));
-			 pvArchiveStatusObtainedFromTable = statusPVStatus.getText();
-			 expectedPVStatus = "Not being archived";
-			 Assertions.assertTrue(expectedPVStatus.equals(pvArchiveStatusObtainedFromTable), "Expecting PV archive status to be " + expectedPVStatus + "; instead it is " + pvArchiveStatusObtainedFromTable);
-		 }
+        String mgmtURL = "http://localhost:17665/mgmt/bpl/";
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, "Paused", 10, mgmtURL, 15);
+        GetUrlContent.getURLContentWithQueryParameters(mgmtURL + "deletePV", Map.of("pv", pvNameToArchive), false);
+		Thread.sleep(2 * 1000);
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, "Not being archived", 10, mgmtURL, 15);
 	}
 	
 	

--- a/src/test/org/epics/archiverappliance/mgmt/pauseresume/DeletePVTest.java
+++ b/src/test/org/epics/archiverappliance/mgmt/pauseresume/DeletePVTest.java
@@ -1,6 +1,5 @@
 package org.epics.archiverappliance.mgmt.pauseresume;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -9,19 +8,17 @@ import org.epics.archiverappliance.TomcatSetup;
 import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.epics.archiverappliance.config.persistence.JDBM2Persistence;
+import org.epics.archiverappliance.engine.V4.PVAccessUtil;
+import org.epics.archiverappliance.utils.ui.GetUrlContent;
+import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Start an appserver with persistence; start archiving a PV and then pause it and delete it
@@ -37,12 +34,6 @@ public class DeletePVTest {
             new File(ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "DeletePVTest");
     TomcatSetup tomcatSetup = new TomcatSetup();
     SIOCSetup siocSetup = new SIOCSetup();
-    WebDriver driver;
-
-    @BeforeAll
-    public static void setupClass() {
-        WebDriverManager.firefoxdriver().setup();
-    }
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -61,144 +52,36 @@ public class DeletePVTest {
 
         siocSetup.startSIOCWithDefaultDB();
         tomcatSetup.setUpWebApps(this.getClass().getSimpleName());
-        driver = new FirefoxDriver();
     }
 
     @AfterEach
     public void tearDown() throws Exception {
-        driver.quit();
         tomcatSetup.tearDown();
         siocSetup.stopSIOC();
     }
 
     @Test
     public void testSimpleDeletePV() throws Exception {
-        driver.get("http://localhost:17665/mgmt/ui/index.html");
-        WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
         String pvNameToArchive = "UnitTestNoNamingConvention:sine";
-        pvstextarea.sendKeys(pvNameToArchive);
-        WebElement archiveButton = driver.findElement(By.id("archstatArchive"));
-        logger.debug("About to submit");
-        archiveButton.click();
-        // We have to wait for about 10 minutes here as it does take a while for the workflow to complete.
-        Thread.sleep(4 * 60 * 1000);
-        WebElement checkStatusButton = driver.findElement(By.id("archstatCheckStatus"));
-        checkStatusButton.click();
-        Thread.sleep(2 * 1000);
-        WebElement statusPVName =
-                driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(1)"));
-        String pvNameObtainedFromTable = statusPVName.getText();
-        Assertions.assertTrue(
-                pvNameToArchive.equals(pvNameObtainedFromTable),
-                "PV Name is not " + pvNameToArchive + "; instead we get " + pvNameObtainedFromTable);
-        WebElement statusPVStatus =
-                driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(2)"));
-        String pvArchiveStatusObtainedFromTable = statusPVStatus.getText();
-        String expectedPVStatus = "Being archived";
-        Assertions.assertTrue(
-                expectedPVStatus.equals(pvArchiveStatusObtainedFromTable),
-                "Expecting PV archive status to be " + expectedPVStatus + "; instead it is "
-                        + pvArchiveStatusObtainedFromTable);
-
+        String mgmtURL = "http://localhost:17665/mgmt/bpl/";
+        GetUrlContent.postDataAndGetContentAsJSONArray(mgmtURL + "/archivePV", GetUrlContent.from(List.of(new JSONObject(Map.of("pv", pvNameToArchive)))));
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, "Being archived", 10, mgmtURL, 15);
         logger.info("We are now archiving the PV; let's go into the details page; pause and delete");
-        driver.get("http://localhost:17665/mgmt/ui/pvdetails.html?pv=" + pvNameToArchive);
-        {
-            Thread.sleep(2 * 1000);
-            WebElement pauseArchivingButn = driver.findElement(By.id("pvDetailsPauseArchiving"));
-            logger.info("Clicking on the button to pause archiving the PV");
-            pauseArchivingButn.click();
-            Thread.sleep(10 * 1000);
-            WebElement pvDetailsTable = driver.findElement(By.id("pvDetailsTable"));
-            List<WebElement> pvDetailsTableRows = pvDetailsTable.findElements(By.cssSelector("tbody tr"));
-            for (WebElement pvDetailsTableRow : pvDetailsTableRows) {
-                WebElement pvDetailsTableFirstCol = pvDetailsTableRow.findElement(By.cssSelector("td:nth-child(1)"));
-                if (pvDetailsTableFirstCol.getText().contains("Is this PV paused:")) {
-                    WebElement pvDetailsTableSecondCol =
-                            pvDetailsTableRow.findElement(By.cssSelector("td:nth-child(2)"));
-                    String obtainedPauseStatus = pvDetailsTableSecondCol.getText();
-                    String expectedPauseStatus = "Yes";
-                    Assertions.assertTrue(
-                            expectedPauseStatus.equals(obtainedPauseStatus),
-                            "Expecting paused status to be " + expectedPauseStatus + "; instead it is "
-                                    + obtainedPauseStatus);
-                    break;
-                }
-            }
-        }
-        {
-            Thread.sleep(2 * 1000);
-            WebElement resumeArchivingButn = driver.findElement(By.id("pvDetailsResumeArchiving"));
-            logger.info("Clicking on the button to resume archiving the PV");
-            resumeArchivingButn.click();
-            Thread.sleep(10 * 1000);
-            WebElement pvDetailsTable = driver.findElement(By.id("pvDetailsTable"));
-            List<WebElement> pvDetailsTableRows = pvDetailsTable.findElements(By.cssSelector("tbody tr"));
-            for (WebElement pvDetailsTableRow : pvDetailsTableRows) {
-                WebElement pvDetailsTableFirstCol = pvDetailsTableRow.findElement(By.cssSelector("td:nth-child(1)"));
-                if (pvDetailsTableFirstCol.getText().contains("Is this PV paused:")) {
-                    WebElement pvDetailsTableSecondCol =
-                            pvDetailsTableRow.findElement(By.cssSelector("td:nth-child(2)"));
-                    String obtainedPauseStatus = pvDetailsTableSecondCol.getText();
-                    String expectedPauseStatus = "No";
-                    Assertions.assertTrue(
-                            expectedPauseStatus.equals(obtainedPauseStatus),
-                            "Expecting paused status to be " + expectedPauseStatus + "; instead it is "
-                                    + obtainedPauseStatus);
-                    break;
-                }
-            }
-        }
-        {
-            Thread.sleep(2 * 1000);
-            WebElement pauseArchivingButn = driver.findElement(By.id("pvDetailsPauseArchiving"));
-            logger.info("Clicking on the button to pause archiving the PV");
-            pauseArchivingButn.click();
-            Thread.sleep(10 * 1000);
-            WebElement pvDetailsTable = driver.findElement(By.id("pvDetailsTable"));
-            List<WebElement> pvDetailsTableRows = pvDetailsTable.findElements(By.cssSelector("tbody tr"));
-            for (WebElement pvDetailsTableRow : pvDetailsTableRows) {
-                WebElement pvDetailsTableFirstCol = pvDetailsTableRow.findElement(By.cssSelector("td:nth-child(1)"));
-                if (pvDetailsTableFirstCol.getText().contains("Is this PV paused:")) {
-                    WebElement pvDetailsTableSecondCol =
-                            pvDetailsTableRow.findElement(By.cssSelector("td:nth-child(2)"));
-                    String obtainedPauseStatus = pvDetailsTableSecondCol.getText();
-                    String expectedPauseStatus = "Yes";
-                    Assertions.assertTrue(
-                            expectedPauseStatus.equals(obtainedPauseStatus),
-                            "Expecting paused status to be " + expectedPauseStatus + "; instead it is "
-                                    + obtainedPauseStatus);
-                    break;
-                }
-            }
-        }
-        {
-            Thread.sleep(2 * 1000);
-            WebElement deletePVButn = driver.findElement(By.id("pvDetailsStopArchiving"));
-            logger.info("Clicking on the button to delete/stop archiving the PV");
-            deletePVButn.click();
-            Thread.sleep(2 * 1000);
-            WebElement dialogOkButton = driver.findElement(By.id("pvStopArchivingOk"));
-            logger.info("About to submit");
-            dialogOkButton.click();
-            Thread.sleep(10 * 1000);
-        }
-        {
-            driver.get("http://localhost:17665/mgmt/ui/index.html");
-            checkStatusButton = driver.findElement(By.id("archstatCheckStatus"));
-            checkStatusButton.click();
-            Thread.sleep(2 * 1000);
-            statusPVName = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(1)"));
-            pvNameObtainedFromTable = statusPVName.getText();
-            Assertions.assertTrue(
-                    pvNameToArchive.equals(pvNameObtainedFromTable),
-                    "PV Name is not " + pvNameToArchive + "; instead we get " + pvNameObtainedFromTable);
-            statusPVStatus = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(2)"));
-            pvArchiveStatusObtainedFromTable = statusPVStatus.getText();
-            expectedPVStatus = "Not being archived";
-            Assertions.assertTrue(
-                    expectedPVStatus.equals(pvArchiveStatusObtainedFromTable),
-                    "Expecting PV archive status to be " + expectedPVStatus + "; instead it is "
-                            + pvArchiveStatusObtainedFromTable);
-        }
+
+        GetUrlContent.getURLContentWithQueryParameters(mgmtURL + "pauseArchivingPV", Map.of("pv", pvNameToArchive), false);
+        Thread.sleep(2 * 1000);
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, "Paused", 10, mgmtURL, 15);
+
+        GetUrlContent.getURLContentWithQueryParameters(mgmtURL + "resumeArchivingPV", Map.of("pv", pvNameToArchive), false);
+        Thread.sleep(2 * 1000);
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, "Being archived", 10, mgmtURL, 15);
+
+        GetUrlContent.getURLContentWithQueryParameters(mgmtURL + "pauseArchivingPV", Map.of("pv", pvNameToArchive), false);
+        Thread.sleep(2 * 1000);
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, "Paused", 10, mgmtURL, 15);
+
+        GetUrlContent.getURLContentWithQueryParameters(mgmtURL + "deletePV", Map.of("pv", pvNameToArchive), false);
+		Thread.sleep(2 * 1000);
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, "Not being archived", 10, mgmtURL, 15);
     }
 }

--- a/src/test/org/epics/archiverappliance/reshard/AppendAndAliasPVTest.java
+++ b/src/test/org/epics/archiverappliance/reshard/AppendAndAliasPVTest.java
@@ -103,7 +103,7 @@ public class AppendAndAliasPVTest {
 		newPVTypeInfo.setCreationTime(creationTime);
 		Assertions.assertTrue(newPVTypeInfo.getPvName().equals(pvName), "Expecting PV typeInfo for " + pvName + "; instead it is " + srcPVTypeInfo.getPvName());
 		JSONEncoder<PVTypeInfo> encoder = JSONEncoder.getEncoder(PVTypeInfo.class);
-		GetUrlContent.postObjectAndGetContentAsJSONObject("http://localhost:17665/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, "UTF-8") + "&createnew=true", encoder.encode(newPVTypeInfo));
+		GetUrlContent.postDataAndGetContentAsJSONObject("http://localhost:17665/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, "UTF-8") + "&createnew=true", encoder.encode(newPVTypeInfo));
 	}
 
     private void generateData(String pvName, Instant startTime, Instant endTime) throws IOException {

--- a/src/test/org/epics/archiverappliance/retrieval/MultiPVClusterRetrievalTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/MultiPVClusterRetrievalTest.java
@@ -132,7 +132,7 @@ public class MultiPVClusterRetrievalTest {
         pvTypeInfo1.setCreationTime(TimeUtils.convertFromISO8601String("2013-11-11T14:49:58.523Z"));
         pvTypeInfo1.setModificationTime(TimeUtils.now());
         pvTypeInfo1.setApplianceIdentity("appliance0");
-        GetUrlContent.postObjectAndGetContentAsJSONObject(
+        GetUrlContent.postDataAndGetContentAsJSONObject(
                 MGMT_URL + "/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, StandardCharsets.UTF_8)
                         + "&override=false&createnew=true",
                 encoder.encode(pvTypeInfo1));
@@ -144,7 +144,7 @@ public class MultiPVClusterRetrievalTest {
         pvTypeInfo2.setCreationTime(TimeUtils.convertFromISO8601String("2013-11-11T14:49:58.523Z"));
         pvTypeInfo2.setModificationTime(TimeUtils.now());
         pvTypeInfo2.setApplianceIdentity("appliance1");
-        GetUrlContent.postObjectAndGetContentAsJSONObject(
+        GetUrlContent.postDataAndGetContentAsJSONObject(
                 MGMT_URL + "/putPVTypeInfo?pv=" + URLEncoder.encode(pvName2, StandardCharsets.UTF_8)
                         + "&override=false&createnew=true",
                 encoder.encode(pvTypeInfo2));

--- a/src/test/org/epics/archiverappliance/retrieval/client/Mean600Test.java
+++ b/src/test/org/epics/archiverappliance/retrieval/client/Mean600Test.java
@@ -1,7 +1,6 @@
 package org.epics.archiverappliance.retrieval.client;
 
 import edu.stanford.slac.archiverappliance.PB.EPICSEvent.PayloadInfo;
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -14,25 +13,25 @@ import org.epics.archiverappliance.config.ArchDBRTypes;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.epics.archiverappliance.config.StoragePluginURLParser;
 import org.epics.archiverappliance.data.ScalarValue;
+import org.epics.archiverappliance.engine.V4.PVAccessUtil;
 import org.epics.archiverappliance.engine.membuf.ArrayListEventStream;
 import org.epics.archiverappliance.retrieval.RemotableEventStreamDesc;
 import org.epics.archiverappliance.utils.simulation.SimulationEvent;
+import org.epics.archiverappliance.utils.ui.GetUrlContent;
+import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Testing mean_600 and making sure we get expected results in the client.
@@ -46,17 +45,11 @@ public class Mean600Test {
 	private static Logger logger = LogManager.getLogger(Mean600Test.class.getName());
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	SIOCSetup siocSetup = new SIOCSetup();
-	WebDriver driver;
 	private String pvName = "UnitTestNoNamingConvention:inactive1";
 	private short currentYear = TimeUtils.getCurrentYear();
 	private File ltsFolder = new File(System.getenv("ARCHAPPL_LONG_TERM_FOLDER") + "/UnitTestNoNamingConvention");
 	StoragePlugin storageplugin;
 	private ConfigServiceForTests configService;
-
-	@BeforeAll
-	public static void setupClass() {
-		WebDriverManager.firefoxdriver().setup();
-	}
 
 	@BeforeEach
 	public void setUp() throws Exception {
@@ -64,7 +57,6 @@ public class Mean600Test {
 		storageplugin = StoragePluginURLParser.parseStoragePlugin("pb://localhost?name=LTS&rootFolder=${ARCHAPPL_LONG_TERM_FOLDER}&partitionGranularity=PARTITION_YEAR", configService);
 		siocSetup.startSIOCWithDefaultDB();
 		tomcatSetup.setUpWebApps(this.getClass().getSimpleName());
-		driver = new FirefoxDriver();
 		
 		if(ltsFolder.exists()) { 
 			FileUtils.deleteDirectory(ltsFolder);
@@ -87,7 +79,6 @@ public class Mean600Test {
 
 	@AfterEach
 	public void tearDown() throws Exception {
-		driver.quit();
 		tomcatSetup.tearDown();
 		siocSetup.stopSIOC();
 
@@ -98,29 +89,14 @@ public class Mean600Test {
 
 	@Test
 	public void testSimpleArchivePV() throws Exception {
-		 driver.get("http://localhost:17665/mgmt/ui/index.html");
-		 WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
-		 pvstextarea.sendKeys(pvName);
-		 WebElement archiveButton = driver.findElement(By.id("archstatArchive"));
-		 logger.debug("About to submit");
-		 archiveButton.click();
-		 // We have to wait for a few minutes here here as it does take a while for the workflow to complete.
-		 Thread.sleep(5*60*1000);
-		 WebElement checkStatusButton = driver.findElement(By.id("archstatCheckStatus"));
-		 checkStatusButton.click();
-		 Thread.sleep(2*1000);
-		 WebElement statusPVName = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(1)"));
-		 String pvNameObtainedFromTable = statusPVName.getText();
-		 Assertions.assertTrue(pvName.equals(pvNameObtainedFromTable), "PV Name is not " + pvName + "; instead we get " + pvNameObtainedFromTable);
-		 WebElement statusPVStatus = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(2)"));
-		 String pvArchiveStatusObtainedFromTable = statusPVStatus.getText();
-		 String expectedPVStatus = "Being archived";
-		 Assertions.assertTrue(expectedPVStatus.equals(pvArchiveStatusObtainedFromTable), "Expecting PV archive status to be " + expectedPVStatus + "; instead it is " + pvArchiveStatusObtainedFromTable);
-		 Thread.sleep(1*60*1000);
+        String pvNameToArchive = pvName;
+        String mgmtURL = "http://localhost:17665/mgmt/bpl/";
+        GetUrlContent.postDataAndGetContentAsJSONArray(mgmtURL + "/archivePV", GetUrlContent.from(List.of(new JSONObject(Map.of("pv", pvNameToArchive)))));
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, "Being archived", 10, mgmtURL, 15);
 		 
-		 // We have now archived this PV, get some data and validate we got the expected number of events
-		 checkRetrieval(pvName, 366*86400);
-		 checkRetrieval("mean_600(" + pvName + ")", 366*24*6);
+		// We have now archived this PV, get some data and validate we got the expected number of events
+		checkRetrieval(pvName, 366*86400);
+		checkRetrieval("mean_600(" + pvName + ")", 366*24*6);
 	}
 
 	private void checkRetrieval(String retrievalPVName, int expectedAtLeastEvents) throws IOException {

--- a/src/test/org/epics/archiverappliance/retrieval/cluster/ClusterAliasSpanApplianceTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/cluster/ClusterAliasSpanApplianceTest.java
@@ -1,6 +1,5 @@
 package org.epics.archiverappliance.retrieval.cluster;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -13,24 +12,22 @@ import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.epics.archiverappliance.config.PVTypeInfo;
 import org.epics.archiverappliance.config.persistence.JDBM2Persistence;
+import org.epics.archiverappliance.engine.V4.PVAccessUtil;
 import org.epics.archiverappliance.retrieval.client.RawDataRetrievalAsEventStream;
 import org.epics.archiverappliance.utils.ui.GetUrlContent;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Test data retrieval with aliasing and clustering.
@@ -45,12 +42,6 @@ public class ClusterAliasSpanApplianceTest {
 	File persistenceFolder = new File(ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "ClusterAliasSpanApplianceTest");
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	SIOCSetup siocSetup = new SIOCSetup();
-	WebDriver driver;
-
-	@BeforeAll
-	public static void setupClass() {
-		WebDriverManager.firefoxdriver().setup();
-	}
 
 	@BeforeEach
 	public void setUp() throws Exception {
@@ -62,12 +53,10 @@ public class ClusterAliasSpanApplianceTest {
 		System.getProperties().put(ConfigService.ARCHAPPL_PERSISTENCE_LAYER, "org.epics.archiverappliance.config.persistence.JDBM2Persistence");
 		System.getProperties().put(JDBM2Persistence.ARCHAPPL_JDBM2_FILENAME, persistenceFolder.getPath() + File.separator + "testconfig.jdbm2");
 		tomcatSetup.setUpClusterWithWebApps(this.getClass().getSimpleName(), 2);
-		driver = new FirefoxDriver();
 	}
 
 	@AfterEach
 	public void tearDown() throws Exception {
-		driver.quit();
 		tomcatSetup.tearDown();
 		siocSetup.stopSIOC();
 		FileUtils.deleteDirectory(persistenceFolder);
@@ -75,27 +64,11 @@ public class ClusterAliasSpanApplianceTest {
 
 	@Test
 	public void testSimpleArchivePV() throws Exception {
-		 int port = ConfigServiceForTests.RETRIEVAL_TEST_PORT+1;
-		 driver.get("http://localhost:" + port + "/mgmt/ui/index.html");
-		 WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
-		 String pvNameToArchive = "UnitTestNoNamingConvention:sine";
-		 pvstextarea.sendKeys(pvNameToArchive);
-		 WebElement archiveButton = driver.findElement(By.id("archstatArchive"));
-		 logger.debug("About to submit");
-		 archiveButton.click();
-		 // We have to wait for a few minutes here as it does take a while for the workflow to complete.
-		 // In addition, we are also getting .HIHI etc the monitors for which get established many minutes after the beginning of archiving 
-		 Thread.sleep(10*60*1000);
-		 WebElement checkStatusButton = driver.findElement(By.id("archstatCheckStatus"));
-		 checkStatusButton.click();
-		 Thread.sleep(2*1000);
-		 WebElement statusPVName = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(1)"));
-		 String pvNameObtainedFromTable = statusPVName.getText();
-		 Assertions.assertTrue(pvNameToArchive.equals(pvNameObtainedFromTable), "PV Name is not " + pvNameToArchive + "; instead we get " + pvNameObtainedFromTable);
-		 WebElement statusPVStatus = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(2)"));
-		 String pvArchiveStatusObtainedFromTable = statusPVStatus.getText();
-		 String expectedPVStatus = "Being archived";
-		 Assertions.assertTrue(expectedPVStatus.equals(pvArchiveStatusObtainedFromTable), "Expecting PV archive status to be " + expectedPVStatus + "; instead it is " + pvArchiveStatusObtainedFromTable);
+        String pvNameToArchive = "UnitTestNoNamingConvention:sine";
+        String mgmtURL = "http://localhost:17665/mgmt/bpl/";
+        GetUrlContent.postDataAndGetContentAsJSONArray(mgmtURL + "/archivePV", GetUrlContent.from(List.of(new JSONObject(Map.of("pv", pvNameToArchive)))));
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, "Being archived", 10, mgmtURL, 15);
+
 		 String aapl0 = checkInPersistence("UnitTestNoNamingConvention:sine", 0);
 		 String aapl1 = checkInPersistence("UnitTestNoNamingConvention:sine", 1);
 		 Assertions.assertTrue(aapl0.equals(aapl1), "Expecting the same appliance identity in both typeinfos, instead it is " + aapl0 + " in cluster member 0 and " + aapl1 + " in cluster member 1");

--- a/src/test/org/epics/archiverappliance/retrieval/cluster/ClusterSinglePVTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/cluster/ClusterSinglePVTest.java
@@ -129,7 +129,7 @@ public class ClusterSinglePVTest {
         pvTypeInfo1.setCreationTime(TimeUtils.convertFromISO8601String("2013-11-11T14:49:58.523Z"));
         pvTypeInfo1.setModificationTime(TimeUtils.now());
         pvTypeInfo1.setApplianceIdentity("appliance1");
-        GetUrlContent.postObjectAndGetContentAsJSONObject(
+        GetUrlContent.postDataAndGetContentAsJSONObject(
                 MGMT_URL + "/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, StandardCharsets.UTF_8)
                         + "&override=false&createnew=true",
                 encoder.encode(pvTypeInfo1));

--- a/src/test/org/epics/archiverappliance/retrieval/extrafields/EGUChangeTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/extrafields/EGUChangeTest.java
@@ -1,13 +1,13 @@
 package org.epics.archiverappliance.retrieval.extrafields;
 
 import edu.stanford.slac.archiverappliance.PB.EPICSEvent.PayloadInfo;
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.SIOCSetup;
 import org.epics.archiverappliance.TomcatSetup;
 import org.epics.archiverappliance.common.TimeUtils;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
+import org.epics.archiverappliance.engine.V4.PVAccessUtil;
 import org.epics.archiverappliance.retrieval.client.EpicsMessage;
 import org.epics.archiverappliance.retrieval.client.GenMsgIterator;
 import org.epics.archiverappliance.retrieval.client.InfoChangeHandler;
@@ -16,20 +16,17 @@ import org.epics.archiverappliance.utils.ui.GetUrlContent;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * We want to make sure we capture changes in EGU and return them as part of the retrieval request.
@@ -44,68 +41,45 @@ public class EGUChangeTest {
 	private static Logger logger = LogManager.getLogger(EGUChangeTest.class.getName());
 	TomcatSetup tomcatSetup = new TomcatSetup();
 	SIOCSetup siocSetup = new SIOCSetup();
-	WebDriver driver;
 	private String pvName = "UnitTestNoNamingConvention:sine";
-
-	@BeforeAll
-	public static void setupClass() {
-		WebDriverManager.firefoxdriver().setup();
-	}
 
 	@BeforeEach
 	public void setUp() throws Exception {
 		siocSetup.startSIOCWithDefaultDB();
 		tomcatSetup.setUpWebApps(this.getClass().getSimpleName());
-		driver = new FirefoxDriver();
 	}
 
 	@AfterEach
 	public void tearDown() throws Exception {
-		driver.quit();
 		tomcatSetup.tearDown();
 		siocSetup.stopSIOC();
 	}
 
 	@Test
 	public void testSimpleArchivePV() throws Exception {
-		 driver.get("http://localhost:17665/mgmt/ui/index.html");
-		 WebElement pvstextarea = driver.findElement(By.id("archstatpVNames"));
-		 pvstextarea.sendKeys(pvName);
-		 WebElement archiveButton = driver.findElement(By.id("archstatArchive"));
-		 logger.debug("About to submit");
-		 archiveButton.click();
-		 // We have to wait for a few minutes here here as it does take a while for the workflow to complete.
-		 Thread.sleep(5*60*1000);
-		 WebElement checkStatusButton = driver.findElement(By.id("archstatCheckStatus"));
-		 checkStatusButton.click();
-		 Thread.sleep(2*1000);
-		 WebElement statusPVName = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(1)"));
-		 String pvNameObtainedFromTable = statusPVName.getText();
-		 Assertions.assertTrue(pvName.equals(pvNameObtainedFromTable), "PV Name is not " + pvName + "; instead we get " + pvNameObtainedFromTable);
-		 WebElement statusPVStatus = driver.findElement(By.cssSelector("#archstatsdiv_table tr:nth-child(1) td:nth-child(2)"));
-		 String pvArchiveStatusObtainedFromTable = statusPVStatus.getText();
-		 String expectedPVStatus = "Being archived";
-		 Assertions.assertTrue(expectedPVStatus.equals(pvArchiveStatusObtainedFromTable), "Expecting PV archive status to be " + expectedPVStatus + "; instead it is " + pvArchiveStatusObtainedFromTable);
-		 Thread.sleep(1*60*1000);
-		 
-		 // We have now archived this PV, get some data and make sure the EGU is as expected.
-		 checkEGU("apples");
-		 SIOCSetup.caput(pvName + ".EGU", "oranges");
-		 Thread.sleep(5*1000);
-		 // Pause and resume the PV to reget the meta data
-		 String pausePVURL = "http://localhost:17665/mgmt/bpl/pauseArchivingPV?pv=" + URLEncoder.encode(pvName, "UTF-8");
-		 JSONObject pauseStatus = GetUrlContent.getURLContentAsJSONObject(pausePVURL);
-		 Assertions.assertTrue(pauseStatus.containsKey("status") && pauseStatus.get("status").equals("ok"), "Cannot pause PV");
-		 logger.info("Done pausing PV " + pvName);
-		 Thread.sleep(5*1000);
-		 String resumePVURL = "http://localhost:17665/mgmt/bpl/resumeArchivingPV?pv=" + URLEncoder.encode(pvName, "UTF-8");
-		 JSONObject resumeStatus = GetUrlContent.getURLContentAsJSONObject(resumePVURL);
-		 Assertions.assertTrue(resumeStatus.containsKey("status") && resumeStatus.get("status").equals("ok"), "Cannot resume PV");
-		 logger.info("Done resuming PV " + pvName);
+        String pvNameToArchive = pvName;
+        String mgmtURL = "http://localhost:17665/mgmt/bpl/";
+        GetUrlContent.postDataAndGetContentAsJSONArray(mgmtURL + "/archivePV", GetUrlContent.from(List.of(new JSONObject(Map.of("pv", pvNameToArchive)))));
+        PVAccessUtil.waitForStatusChange(pvNameToArchive, "Being archived", 10, mgmtURL, 15);
 
-		 // Now check the EGU again...
-		 Thread.sleep(1*60*1000);
-		 checkEGU("oranges");		 
+		// We have now archived this PV, get some data and make sure the EGU is as expected.
+		checkEGU("apples");
+		SIOCSetup.caput(pvName + ".EGU", "oranges");
+		Thread.sleep(5*1000);
+		// Pause and resume the PV to reget the meta data
+		String pausePVURL = "http://localhost:17665/mgmt/bpl/pauseArchivingPV?pv=" + URLEncoder.encode(pvName, "UTF-8");
+		JSONObject pauseStatus = GetUrlContent.getURLContentAsJSONObject(pausePVURL);
+		Assertions.assertTrue(pauseStatus.containsKey("status") && pauseStatus.get("status").equals("ok"), "Cannot pause PV");
+		logger.info("Done pausing PV " + pvName);
+		Thread.sleep(5*1000);
+		String resumePVURL = "http://localhost:17665/mgmt/bpl/resumeArchivingPV?pv=" + URLEncoder.encode(pvName, "UTF-8");
+		JSONObject resumeStatus = GetUrlContent.getURLContentAsJSONObject(resumePVURL);
+		Assertions.assertTrue(resumeStatus.containsKey("status") && resumeStatus.get("status").equals("ok"), "Cannot resume PV");
+		logger.info("Done resuming PV " + pvName);
+
+		// Now check the EGU again...
+		Thread.sleep(1*60*1000);
+		checkEGU("oranges");		 
 	}
 
 	private void checkEGU(String expectedEGUValue) throws IOException {

--- a/src/test/org/epics/archiverappliance/retrieval/postprocessor/DataDrivenPostProcessorTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/postprocessor/DataDrivenPostProcessorTest.java
@@ -84,7 +84,7 @@ public class DataDrivenPostProcessorTest {
 		newPVTypeInfo.setPaused(true);
 		newPVTypeInfo.setChunkKey("LN/AM/RadMon/2/DoseRate/I:");
 		JSONEncoder<PVTypeInfo> encoder = JSONEncoder.getEncoder(PVTypeInfo.class);
-		GetUrlContent.postObjectAndGetContentAsJSONObject("http://localhost:17665/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(newPVName, "UTF-8") + "&createnew=true", encoder.encode(newPVTypeInfo));
+		GetUrlContent.postDataAndGetContentAsJSONObject("http://localhost:17665/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(newPVName, "UTF-8") + "&createnew=true", encoder.encode(newPVTypeInfo));
 
 		logger.info("Sample file copied to " + destFile.getAbsolutePath());
 

--- a/src/test/org/epics/archiverappliance/retrieval/postprocessor/DeadBandTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/postprocessor/DeadBandTest.java
@@ -108,7 +108,7 @@ public class DeadBandTest {
         newPVTypeInfo.setPaused(true);
         newPVTypeInfo.setChunkKey("TST-CT{}Sig/1-I:");
         JSONEncoder<PVTypeInfo> encoder = JSONEncoder.getEncoder(PVTypeInfo.class);
-        GetUrlContent.postObjectAndGetContentAsJSONObject(
+        GetUrlContent.postDataAndGetContentAsJSONObject(
                 MGMT_URL + "/putPVTypeInfo?pv=" + URLEncoder.encode(newPVName, "UTF-8") + "&createnew=true",
                 encoder.encode(newPVTypeInfo));
 


### PR DESCRIPTION
This addresses #362 . 

While this commit changes a lot of files, most of these are unit tests and the changes here deal with removing Selenium. A few src/main files have also changed; most of these have to do with refactoring GetUrlContent to make that more Python "requests" like. 

With this change, we should be able to run the entire suite of unit tests in a docker container without any X dependencies.