### PR TITLE
Rather than supporting bidirectional iterator for plain

### DIFF
--- a/src/main/edu/stanford/slac/archiverappliance/PB/data/PBScalarByte.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/data/PBScalarByte.java
@@ -316,4 +316,9 @@ public class PBScalarByte implements DBRTimeEvent {
     public Class<? extends Message> getProtobufMessageClass() {
         return EPICSEvent.ScalarByte.class;
     }
+
+    @Override
+    public String toString() {
+        return DBRTimeEvent.toString(this);
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PB/data/PBScalarDouble.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/data/PBScalarDouble.java
@@ -308,4 +308,9 @@ public class PBScalarDouble implements DBRTimeEvent {
     public Class<? extends Message> getProtobufMessageClass() {
         return EPICSEvent.ScalarDouble.class;
     }
+
+    @Override
+    public String toString() {
+        return DBRTimeEvent.toString(this);
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PB/data/PBScalarEnum.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/data/PBScalarEnum.java
@@ -308,4 +308,9 @@ public class PBScalarEnum implements DBRTimeEvent {
     public Class<? extends Message> getProtobufMessageClass() {
         return EPICSEvent.ScalarEnum.class;
     }
+
+    @Override
+    public String toString() {
+        return DBRTimeEvent.toString(this);
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PB/data/PBScalarFloat.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/data/PBScalarFloat.java
@@ -314,4 +314,9 @@ public class PBScalarFloat implements DBRTimeEvent {
     public Class<? extends Message> getProtobufMessageClass() {
         return EPICSEvent.ScalarFloat.class;
     }
+
+    @Override
+    public String toString() {
+        return DBRTimeEvent.toString(this);
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PB/data/PBScalarInt.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/data/PBScalarInt.java
@@ -308,4 +308,9 @@ public class PBScalarInt implements DBRTimeEvent {
     public Class<? extends Message> getProtobufMessageClass() {
         return EPICSEvent.ScalarInt.class;
     }
+
+    @Override
+    public String toString() {
+        return DBRTimeEvent.toString(this);
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PB/data/PBScalarShort.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/data/PBScalarShort.java
@@ -308,4 +308,9 @@ public class PBScalarShort implements DBRTimeEvent {
     public Class<? extends Message> getProtobufMessageClass() {
         return EPICSEvent.ScalarShort.class;
     }
+
+    @Override
+    public String toString() {
+        return DBRTimeEvent.toString(this);
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PB/data/PBScalarString.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/data/PBScalarString.java
@@ -309,4 +309,9 @@ public class PBScalarString implements DBRTimeEvent {
     public Class<? extends Message> getProtobufMessageClass() {
         return EPICSEvent.ScalarString.class;
     }
+
+    @Override
+    public String toString() {
+        return DBRTimeEvent.toString(this);
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PB/data/PBV4GenericBytes.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/data/PBV4GenericBytes.java
@@ -304,4 +304,9 @@ public class PBV4GenericBytes implements DBRTimeEvent, PartionedTime {
     public Class<? extends Message> getProtobufMessageClass() {
         return EPICSEvent.V4GenericBytes.class;
     }
+
+    @Override
+    public String toString() {
+        return DBRTimeEvent.toString(this);
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PB/data/PBVectorByte.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/data/PBVectorByte.java
@@ -334,4 +334,9 @@ public class PBVectorByte implements DBRTimeEvent {
     public Class<? extends Message> getProtobufMessageClass() {
         return EPICSEvent.VectorChar.class;
     }
+
+    @Override
+    public String toString() {
+        return DBRTimeEvent.toString(this);
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PB/data/PBVectorDouble.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/data/PBVectorDouble.java
@@ -317,4 +317,9 @@ public class PBVectorDouble implements DBRTimeEvent {
     public Class<? extends Message> getProtobufMessageClass() {
         return EPICSEvent.VectorDouble.class;
     }
+
+    @Override
+    public String toString() {
+        return DBRTimeEvent.toString(this);
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PB/data/PBVectorEnum.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/data/PBVectorEnum.java
@@ -323,4 +323,9 @@ public class PBVectorEnum implements DBRTimeEvent {
     public Class<? extends Message> getProtobufMessageClass() {
         return EPICSEvent.VectorEnum.class;
     }
+
+    @Override
+    public String toString() {
+        return DBRTimeEvent.toString(this);
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PB/data/PBVectorFloat.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/data/PBVectorFloat.java
@@ -317,4 +317,9 @@ public class PBVectorFloat implements DBRTimeEvent {
     public Class<? extends Message> getProtobufMessageClass() {
         return EPICSEvent.VectorFloat.class;
     }
+
+    @Override
+    public String toString() {
+        return DBRTimeEvent.toString(this);
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PB/data/PBVectorInt.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/data/PBVectorInt.java
@@ -317,4 +317,9 @@ public class PBVectorInt implements DBRTimeEvent {
     public Class<? extends Message> getProtobufMessageClass() {
         return EPICSEvent.VectorInt.class;
     }
+
+    @Override
+    public String toString() {
+        return DBRTimeEvent.toString(this);
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PB/data/PBVectorShort.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/data/PBVectorShort.java
@@ -322,4 +322,9 @@ public class PBVectorShort implements DBRTimeEvent {
     public Class<? extends Message> getProtobufMessageClass() {
         return EPICSEvent.VectorShort.class;
     }
+
+    @Override
+    public String toString() {
+        return DBRTimeEvent.toString(this);
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/PB/data/PBVectorString.java
+++ b/src/main/edu/stanford/slac/archiverappliance/PB/data/PBVectorString.java
@@ -316,4 +316,9 @@ public class PBVectorString implements DBRTimeEvent {
     public Class<? extends Message> getProtobufMessageClass() {
         return EPICSEvent.VectorString.class;
     }
+
+    @Override
+    public String toString() {
+        return DBRTimeEvent.toString(this);
+    }
 }

--- a/src/main/edu/stanford/slac/archiverappliance/plain/EventStreamIterator.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/EventStreamIterator.java
@@ -1,0 +1,8 @@
+package edu.stanford.slac.archiverappliance.plain;
+
+import org.epics.archiverappliance.Event;
+
+import java.io.Closeable;
+import java.util.Iterator;
+
+public interface EventStreamIterator extends Iterator<Event>, Closeable {}

--- a/src/main/edu/stanford/slac/archiverappliance/plain/FileStreamCreator.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/FileStreamCreator.java
@@ -7,16 +7,13 @@
  *******************************************************************************/
 package edu.stanford.slac.archiverappliance.plain;
 
-import edu.stanford.slac.archiverappliance.plain.pb.ArrayListEventStreamWithPositionedIterator;
 import edu.stanford.slac.archiverappliance.plain.pb.FileBackedPBEventStream;
 import edu.stanford.slac.archiverappliance.plain.pb.PBFileInfo;
 import org.epics.archiverappliance.EventStream;
-import org.epics.archiverappliance.common.BiDirectionalIterable;
 import org.epics.archiverappliance.config.ArchDBRTypes;
 import org.epics.archiverappliance.etl.ETLStreamCreator;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 
@@ -26,8 +23,6 @@ import java.time.Instant;
  *
  */
 public class FileStreamCreator implements ETLStreamCreator {
-    /* A file that has at most a few events and is faster when loaded completely in memory */
-    public static int SIZE_THAT_DETERMINES_A_SMALL_FILE = 4 * 1024;
     private final String pvName;
     private final Path path;
     private final PBFileInfo info;
@@ -55,20 +50,6 @@ public class FileStreamCreator implements ETLStreamCreator {
     public static EventStream getStream(String pvName, Path path, ArchDBRTypes dbrType) throws IOException {
 
         return new FileBackedPBEventStream(pvName, path, dbrType);
-    }
-
-    public static EventStream getStreamForIteration(
-            String pvName,
-            Path path,
-            Instant startAtTime,
-            ArchDBRTypes archDBRTypes,
-            BiDirectionalIterable.IterationDirection direction)
-            throws IOException {
-        if (Files.size(path) < SIZE_THAT_DETERMINES_A_SMALL_FILE) {
-            return new ArrayListEventStreamWithPositionedIterator(pvName, path, startAtTime, archDBRTypes, direction);
-        }
-
-        return new FileBackedPBEventStream(pvName, path, archDBRTypes, startAtTime, direction);
     }
 
     @Override

--- a/src/main/edu/stanford/slac/archiverappliance/plain/PlainStreams.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/PlainStreams.java
@@ -1,0 +1,33 @@
+package edu.stanford.slac.archiverappliance.plain;
+
+import edu.stanford.slac.archiverappliance.plain.pb.PBFileInfo;
+import org.epics.archiverappliance.Event;
+import org.epics.archiverappliance.EventStream;
+import org.epics.archiverappliance.common.BiDirectionalIterable;
+import org.epics.archiverappliance.config.ArchDBRTypes;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+public interface PlainStreams {
+
+    EventStream getTimeStream(
+            String pvName, Path path, ArchDBRTypes dbrType, Instant start, Instant end, boolean skipSearch)
+            throws IOException;
+
+    EventStream getTimeStream(
+            String pvName, Path path, Instant start, Instant end, boolean skipSearch, PBFileInfo fileInfo)
+            throws IOException;
+
+    EventStream getStream(String pvName, Path path, ArchDBRTypes dbrType) throws IOException;
+
+    Event dataAtTime(
+            List<Path> pathList,
+            String pvName,
+            Instant atTime,
+            Instant startAtTime,
+            BiDirectionalIterable.IterationDirection iterationDirection)
+            throws IOException;
+}

--- a/src/main/edu/stanford/slac/archiverappliance/plain/pb/PBPlainStreams.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/pb/PBPlainStreams.java
@@ -1,0 +1,119 @@
+package edu.stanford.slac.archiverappliance.plain.pb;
+
+import edu.stanford.slac.archiverappliance.plain.PlainStreams;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.epics.archiverappliance.Event;
+import org.epics.archiverappliance.EventStream;
+import org.epics.archiverappliance.common.BiDirectionalIterable;
+import org.epics.archiverappliance.config.ArchDBRTypes;
+import org.epics.archiverappliance.data.DBRTimeEvent;
+import org.epics.archiverappliance.data.FieldValues;
+import org.epics.archiverappliance.engine.model.ArchiveChannel;
+import org.epics.archiverappliance.retrieval.channelarchiver.HashMapEvent;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+
+public class PBPlainStreams implements PlainStreams {
+    private static final Logger logger = LogManager.getLogger(PBPlainStreams.class);
+
+    public PBFileInfo fileInfo(Path path) throws IOException {
+        return new PBFileInfo(path);
+    }
+
+    @Override
+    public EventStream getTimeStream(
+            String pvName, Path path, ArchDBRTypes dbrType, Instant start, Instant end, boolean skipSearch)
+            throws IOException {
+        return new FileBackedPBEventStream(pvName, path, dbrType, start, end, skipSearch);
+    }
+
+    @Override
+    public EventStream getTimeStream(
+            String pvName, Path path, Instant start, Instant end, boolean skipSearch, PBFileInfo fileInfo)
+            throws IOException {
+        return new FileBackedPBEventStream(pvName, path, fileInfo.getType(), start, end, skipSearch);
+    }
+
+    @Override
+    public EventStream getStream(String pvName, Path path, ArchDBRTypes dbrType) throws IOException {
+        return new FileBackedPBEventStream(pvName, path, dbrType);
+    }
+
+    public Event findByTime(
+            List<Path> pathList,
+            String pvName,
+            Instant atTime,
+            Instant startAtTime,
+            BiDirectionalIterable.IterationDirection direction)
+            throws IOException {
+
+        for (Path path : pathList) {
+            logger.info("Iterating thru {}", path);
+            PBFileInfo fileInfo = fileInfo(path);
+            try (EventStream strm =
+                    new FileBackedPBEventStream(pvName, path, fileInfo.getType(), startAtTime, direction)) {
+                Event e = findByTimeInStream(strm, atTime, direction);
+                if (e != null) {
+                    return e;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static boolean foundEvent(
+            Instant eventTime, Instant atTime, BiDirectionalIterable.IterationDirection direction) {
+        return (direction == BiDirectionalIterable.IterationDirection.BACKWARDS && eventTime.isBefore(atTime))
+                || (direction == BiDirectionalIterable.IterationDirection.FORWARDS && eventTime.isAfter(atTime))
+                || eventTime.equals(atTime);
+    }
+
+    private static Event findByTimeInStream(
+            EventStream strm, Instant atTime, BiDirectionalIterable.IterationDirection direction) throws IOException {
+        Instant maxMetaDataTimeBefore = atTime.minus(ArchiveChannel.SAVE_META_DATA_PERIOD_SECS, ChronoUnit.SECONDS);
+        HashMapEvent resultEvent = null;
+        for (Event event : strm) {
+            if (resultEvent == null && foundEvent(event.getEventTimeStamp(), atTime, direction)) {
+                if (event instanceof DBRTimeEvent dbrTimeEvent) {
+                    resultEvent = new HashMapEvent(strm.getDescription().getArchDBRType(), dbrTimeEvent);
+                }
+            }
+            if (resultEvent != null && event instanceof FieldValues fv) {
+                copyNotSetFieldValues(fv, resultEvent);
+            }
+            if (event.getEventTimeStamp().isBefore(maxMetaDataTimeBefore)) {
+                break;
+            }
+        }
+        return resultEvent;
+    }
+
+    private static void copyNotSetFieldValues(FieldValues fv, HashMapEvent resultEvent) {
+        var evFields = fv.getFields();
+        if (evFields != null && !evFields.isEmpty()) {
+            for (Map.Entry<String, String> fieldValue : evFields.entrySet()) {
+                String fieldValueValue = resultEvent.getFieldValue(fieldValue.getKey());
+                if (fieldValueValue == null) {
+                    resultEvent.addFieldValue(fieldValue.getKey(), fieldValue.getValue());
+                }
+            }
+        }
+    }
+
+    @Override
+    public Event dataAtTime(
+            List<Path> pathList,
+            String pvName,
+            Instant atTime,
+            Instant startAtTime,
+            BiDirectionalIterable.IterationDirection direction)
+            throws IOException {
+        return findByTime(pathList, pvName, atTime, startAtTime, direction);
+    }
+}

--- a/src/main/org/epics/archiverappliance/EventStreamDesc.java
+++ b/src/main/org/epics/archiverappliance/EventStreamDesc.java
@@ -19,52 +19,51 @@ import org.epics.archiverappliance.retrieval.RemotableOverRaw;
  */
 public class EventStreamDesc {
 
-	protected ArchDBRTypes archDBRType;
-	protected String pvName;
-	protected String source;
+    protected ArchDBRTypes archDBRType;
+    protected String pvName;
+    protected String source;
 
-	public EventStreamDesc(ArchDBRTypes archDBRType, String pvName) {
-		super();
-		this.archDBRType = archDBRType;
-		this.pvName = pvName;
-	}
-	
-	public EventStreamDesc(EventStreamDesc other) { 
-		this.archDBRType = other.archDBRType;
-		this.pvName = other.pvName;
-		this.source = other.source;
-	}
+    public EventStreamDesc(ArchDBRTypes archDBRType, String pvName) {
+        super();
+        this.archDBRType = archDBRType;
+        this.pvName = pvName;
+    }
 
-	public ArchDBRTypes getArchDBRType() {
-		return archDBRType;
-	}
+    public EventStreamDesc(EventStreamDesc other) {
+        this.archDBRType = other.archDBRType;
+        this.pvName = other.pvName;
+        this.source = other.source;
+    }
 
-	public void setArchDBRType(ArchDBRTypes archDBRType) {
-		this.archDBRType = archDBRType;
-	}
+    public ArchDBRTypes getArchDBRType() {
+        return archDBRType;
+    }
 
-	public String getPvName() {
-		return pvName;
-	}
+    public void setArchDBRType(ArchDBRTypes archDBRType) {
+        this.archDBRType = archDBRType;
+    }
 
-	public void setPvName(String pvName) {
-		this.pvName = pvName;
-	}
+    public String getPvName() {
+        return pvName;
+    }
 
-	public String getSource() {
-		return source;
-	}
+    public void setPvName(String pvName) {
+        this.pvName = pvName;
+    }
 
-	public void setSource(String source) {
-		this.source = source;
-	}
+    public String getSource() {
+        return source;
+    }
 
-	@Override
-	public String toString() {
-		return "EventStreamDesc{" +
-			"archDBRType=" + archDBRType +
-			", pvName='" + pvName + '\'' +
-			", source='" + source + '\'' +
-			'}';
-	}
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    @Override
+    public String toString() {
+        return "EventStreamDesc{" + "archDBRType="
+                + archDBRType + ", pvName='"
+                + pvName + '\'' + ", source='"
+                + source + '\'' + '}';
+    }
 }

--- a/src/main/org/epics/archiverappliance/EventStreamDesc.java
+++ b/src/main/org/epics/archiverappliance/EventStreamDesc.java
@@ -58,4 +58,13 @@ public class EventStreamDesc {
 	public void setSource(String source) {
 		this.source = source;
 	}
+
+	@Override
+	public String toString() {
+		return "EventStreamDesc{" +
+			"archDBRType=" + archDBRType +
+			", pvName='" + pvName + '\'' +
+			", source='" + source + '\'' +
+			'}';
+	}
 }

--- a/src/main/org/epics/archiverappliance/common/DataAtTime.java
+++ b/src/main/org/epics/archiverappliance/common/DataAtTime.java
@@ -1,0 +1,37 @@
+package org.epics.archiverappliance.common;
+
+import org.epics.archiverappliance.Event;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.Period;
+
+public interface DataAtTime {
+
+    /**
+     * Generic method to iterate over the data for specified PV.
+     * We provide a time to start the iteration at ( inclusive ) and a direction and a Predicate.
+     * The plugin then iterates ( forwards or backwards ) and calls the Predicate for each sample.
+     * The iteration stops when the Predicate returns false or when we run out of samples.
+     * Iteration also stops when we get an exception.
+     * So this mode of traversal is vulnerable to corruption in the data.
+     * We may relax this constraint later by providing a optional bool to ignore exceptions.
+     * @param context  &emsp;
+     * @param pvName The PV name
+     * @param atTime Time looking for.
+     * @param startAtTime Time to start looking from.
+     * @param searchPeriod - An estimate on the amount of time we want to iterate.
+     * This is used to determine the appropriate chunks containing data at a very high level and thus to limit the search.
+     * The predicate itself is the one that controls when the iteration terminates.
+     * So, for example, you could specify a searchPeriod of 1 year but stop the iteration after 1 minute
+     * @throws IOException  &emsp;
+     */
+    Event dataAtTime(
+            BasicContext context,
+            String pvName,
+            Instant atTime,
+            Instant startAtTime,
+            Period searchPeriod,
+            BiDirectionalIterable.IterationDirection iterationDirection)
+            throws IOException;
+}

--- a/src/main/org/epics/archiverappliance/data/DBRTimeEvent.java
+++ b/src/main/org/epics/archiverappliance/data/DBRTimeEvent.java
@@ -22,4 +22,13 @@ public interface DBRTimeEvent extends Event, SamplingInfo, AlarmInfo, FieldValue
     public default YearSecondTimestamp getYearSecondTimestamp() {
         return TimeUtils.convertToYearSecondTimestamp(this.getEventTimeStamp());
     }
+
+    public static String toString(DBRTimeEvent dbrTimeEvent) {
+        return "DBRTimeEvent [getEventTimeStamp()=" + dbrTimeEvent.getEventTimeStamp()
+                + ", getValue()=" + dbrTimeEvent.getSampleValue()
+                + ", getStatus()=" + dbrTimeEvent.getStatus()
+                + ", getSeverity()" + dbrTimeEvent.getSeverity()
+                + ", getFieldValues()" + dbrTimeEvent.getFields()
+                + "]";
+    }
 }

--- a/src/main/org/epics/archiverappliance/data/DBRTimeEvent.java
+++ b/src/main/org/epics/archiverappliance/data/DBRTimeEvent.java
@@ -11,12 +11,17 @@ import edu.stanford.slac.archiverappliance.PB.data.PartionedTime;
 import org.epics.archiverappliance.Event;
 import org.epics.archiverappliance.common.TimeUtils;
 import org.epics.archiverappliance.common.YearSecondTimestamp;
+import org.json.simple.JSONAware;
+import org.json.simple.JSONValue;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A catch all interface that contains the attributes in a EPICS DBR_TIME_XXX from db_access.h.
  * @author mshankar
  */
-public interface DBRTimeEvent extends Event, SamplingInfo, AlarmInfo, FieldValues, PartionedTime {
+public interface DBRTimeEvent extends Event, SamplingInfo, AlarmInfo, FieldValues, PartionedTime, JSONAware {
 
     @Override
     public default YearSecondTimestamp getYearSecondTimestamp() {
@@ -30,5 +35,19 @@ public interface DBRTimeEvent extends Event, SamplingInfo, AlarmInfo, FieldValue
                 + ", getSeverity()" + dbrTimeEvent.getSeverity()
                 + ", getFieldValues()" + dbrTimeEvent.getFields()
                 + "]";
+    }
+
+    @Override
+    public default String toJSONString() {
+
+        HashMap<String, Object> evnt = new HashMap<>();
+        evnt.put("secs", this.getEpochSeconds());
+        evnt.put("val", JSONValue.parse(this.getSampleValue().toJSONString()));
+        evnt.put("nanos", this.getEventTimeStamp().getNano());
+        evnt.put("severity", this.getSeverity());
+        evnt.put("status", this.getStatus());
+        Map<String, Object> fieldValues = new HashMap<>();
+        evnt.put("fields", fieldValues);
+        return JSONValue.toJSONString(evnt);
     }
 }

--- a/src/main/org/epics/archiverappliance/data/SampleValue.java
+++ b/src/main/org/epics/archiverappliance/data/SampleValue.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.epics.archiverappliance.data;
 
+import org.json.simple.JSONAware;
+
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -16,7 +18,7 @@ import java.util.List;
  * The toString for vectors generates a JSON form of the vector...
  * @author mshankar
  */
-public interface SampleValue {
+public interface SampleValue extends JSONAware {
     public String toString();
 
     public int getElementCount();

--- a/src/main/org/epics/archiverappliance/engine/model/ArchiveChannel.java
+++ b/src/main/org/epics/archiverappliance/engine/model/ArchiveChannel.java
@@ -55,6 +55,8 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @SuppressWarnings("nls")
 public abstract class ArchiveChannel {
+    public static final int SAVE_META_DATA_PERIOD_SECS = 86400;
+
     private static final Logger logger = LogManager.getLogger(ArchiveChannel.class);
 
     /**
@@ -145,9 +147,9 @@ public abstract class ArchiveChannel {
     private boolean need_first_sample = true;
 
     /**
-     * Is this channel currently paused? The source of truth for this is the PVTypeInfo in the database. 
+     * Is this channel currently paused? The source of truth for this is the PVTypeInfo in the database.
      * But we cache this value here as a performance optimization for CapacityPlanning/EngineMetrics.
-     * By default, this is false because in DefaultConfigService.archivePVSonStartup, we skip starting PV's that are paused. 
+     * By default, this is false because in DefaultConfigService.archivePVSonStartup, we skip starting PV's that are paused.
      */
     private boolean paused = false;
 
@@ -189,7 +191,9 @@ public abstract class ArchiveChannel {
             final boolean usePVAccess)
             throws Exception {
         this.name = name;
-        this.SERVER_IOC_DRIFT_SECONDS = Integer.parseInt(configservice.getInstallationProperties().getProperty("org.epics.archiverappliance.engine.epics.server_ioc_drift_seconds", "1800"));
+        this.SERVER_IOC_DRIFT_SECONDS = Integer.parseInt(configservice
+                .getInstallationProperties()
+                .getProperty("org.epics.archiverappliance.engine.epics.server_ioc_drift_seconds", "1800"));
         this.controlPVname = controlPVname;
         this.writer = writer;
         this.last_archived_timestamp = last_archived_timestamp;
@@ -475,10 +479,10 @@ public abstract class ArchiveChannel {
             need_first_sample = true;
         }
 
-        if(need_first_sample) {
+        if (need_first_sample) {
             addValueToBuffer(timeevent);
             need_first_sample = false;
-            return true;    
+            return true;
         }
 
         return false; // I did not handle this; subclasses should handle the second sample and onwards.
@@ -576,7 +580,6 @@ public abstract class ArchiveChannel {
         if (SampleBuffer.isInErrorState()) need_write_error_sample = true;
     }
 
-
     @Override
     public String toString() {
         return "Channel " + getName() + ", " + getMechanism();
@@ -597,20 +600,20 @@ public abstract class ArchiveChannel {
             return true;
         }
 
-        if(!this.need_first_sample) {
+        if (!this.need_first_sample) {
             // Second sample onwards
             Instant pastCutOffTimeStamp =
-                TimeUtils.convertFromEpochSeconds(TimeUtils.getCurrentEpochSeconds() - SERVER_IOC_DRIFT_SECONDS, 0);
+                    TimeUtils.convertFromEpochSeconds(TimeUtils.getCurrentEpochSeconds() - SERVER_IOC_DRIFT_SECONDS, 0);
             if (currentEventTimeStamp.isBefore(pastCutOffTimeStamp)) {
-                if(logger.isDebugEnabled()) {
-                    logger.debug("For {}: timestamp {} ( second sample onwards ) is too far in the past {} ",
-                    getName(),
-                    TimeUtils.convertToHumanReadableString(currentEventTimeStamp),
-                    TimeUtils.convertToHumanReadableString(pastCutOffTimeStamp)
-                    );
+                if (logger.isDebugEnabled()) {
+                    logger.debug(
+                            "For {}: timestamp {} ( second sample onwards ) is too far in the past {} ",
+                            getName(),
+                            TimeUtils.convertToHumanReadableString(currentEventTimeStamp),
+                            TimeUtils.convertToHumanReadableString(pastCutOffTimeStamp));
                 }
                 return true;
-            }    
+            }
         }
 
         Instant futureCutOffTimeStamp =
@@ -797,7 +800,7 @@ public abstract class ArchiveChannel {
         this.paused = pausedVal;
     }
 
-    public boolean isPaused() { 
+    public boolean isPaused() {
         return this.paused;
     }
 }

--- a/src/main/org/epics/archiverappliance/retrieval/GetDataAtTime.java
+++ b/src/main/org/epics/archiverappliance/retrieval/GetDataAtTime.java
@@ -379,7 +379,7 @@ public class GetDataAtTime {
                                 pvName,
                                 atTime,
                                 startAtTime,
-                                searchPeriod,
+                                searchPeriod.plusDays(31),
                                 BiDirectionalIterable.IterationDirection.BACKWARDS);
                         if (e != null) {
                             return new PVWithData(pvName, e);

--- a/src/main/org/epics/archiverappliance/retrieval/PVWithData.java
+++ b/src/main/org/epics/archiverappliance/retrieval/PVWithData.java
@@ -1,0 +1,5 @@
+package org.epics.archiverappliance.retrieval;
+
+import org.epics.archiverappliance.Event;
+
+public record PVWithData(String pvName, Event event) {}

--- a/src/main/org/epics/archiverappliance/retrieval/channelarchiver/HashMapEvent.java
+++ b/src/main/org/epics/archiverappliance/retrieval/channelarchiver/HashMapEvent.java
@@ -242,6 +242,6 @@ public class HashMapEvent implements DBRTimeEvent {
 
     @Override
     public String toString() {
-        return "HashMapEvent{" + "values=" + values + ", type=" + type + '}';
+        return HashMapEvent.class.getSimpleName() + DBRTimeEvent.toString(this);
     }
 }

--- a/src/main/org/epics/archiverappliance/retrieval/channelarchiver/HashMapEvent.java
+++ b/src/main/org/epics/archiverappliance/retrieval/channelarchiver/HashMapEvent.java
@@ -37,8 +37,8 @@ public class HashMapEvent implements DBRTimeEvent {
     public static final String FIELD_VALUES_FIELD_NAME = "fields";
     public static final String FIELD_VALUES_ACTUAL_CHANGE = "fieldsAreActualChange";
 
-    private HashMap<String, Object> values;
-    private ArchDBRTypes type;
+    private final HashMap<String, Object> values;
+    private final ArchDBRTypes type;
 
     public HashMapEvent(ArchDBRTypes type, HashMap<String, Object> values) {
         this.values = values;
@@ -47,7 +47,7 @@ public class HashMapEvent implements DBRTimeEvent {
 
     public HashMapEvent(ArchDBRTypes type, DBRTimeEvent event) {
         this.type = type;
-        values = new HashMap<String, Object>();
+        values = new HashMap<>();
         values.put(HashMapEvent.SECS_FIELD_NAME, Long.toString(event.getEpochSeconds()));
         values.put(
                 HashMapEvent.NANO_FIELD_NAME,
@@ -56,6 +56,8 @@ public class HashMapEvent implements DBRTimeEvent {
         values.put(HashMapEvent.SEVR_FIELD_NAME, Integer.toString(event.getSeverity()));
         if (event.hasFieldValues()) {
             values.put(FIELD_VALUES_FIELD_NAME, event.getFields());
+        } else {
+            values.put(FIELD_VALUES_FIELD_NAME, new HashMap<String, String>());
         }
         if (event.isActualChange()) {
             values.put(FIELD_VALUES_ACTUAL_CHANGE, Boolean.TRUE.toString());
@@ -69,7 +71,7 @@ public class HashMapEvent implements DBRTimeEvent {
 
     @Override
     public Event makeClone() {
-        return new HashMapEvent(this.type, new HashMap<String, Object>(this.values));
+        return new HashMapEvent(this.type, new HashMap<>(this.values));
     }
 
     @Override
@@ -176,7 +178,7 @@ public class HashMapEvent implements DBRTimeEvent {
     @Override
     public boolean isActualChange() {
         return this.values.containsKey(FIELD_VALUES_ACTUAL_CHANGE)
-                && Boolean.valueOf((String) this.values.get(FIELD_VALUES_ACTUAL_CHANGE));
+                && Boolean.parseBoolean((String) this.values.get(FIELD_VALUES_ACTUAL_CHANGE));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/org/epics/archiverappliance/retrieval/channelarchiver/HashMapEvent.java
+++ b/src/main/org/epics/archiverappliance/retrieval/channelarchiver/HashMapEvent.java
@@ -11,6 +11,7 @@ import com.google.protobuf.Message;
 import org.epics.archiverappliance.ByteArray;
 import org.epics.archiverappliance.Event;
 import org.epics.archiverappliance.config.ArchDBRTypes;
+import org.epics.archiverappliance.data.ByteBufSampleValue;
 import org.epics.archiverappliance.data.DBRTimeEvent;
 import org.epics.archiverappliance.data.SampleValue;
 import org.epics.archiverappliance.data.ScalarStringSampleValue;
@@ -18,9 +19,11 @@ import org.epics.archiverappliance.data.ScalarValue;
 import org.epics.archiverappliance.data.VectorStringSampleValue;
 import org.epics.archiverappliance.data.VectorValue;
 
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Map;
 
 /**
  * We get a HashMap of NVPairs from the Channel Archiver - this class exposes these as an archiver Event
@@ -37,10 +40,10 @@ public class HashMapEvent implements DBRTimeEvent {
     public static final String FIELD_VALUES_FIELD_NAME = "fields";
     public static final String FIELD_VALUES_ACTUAL_CHANGE = "fieldsAreActualChange";
 
-    private final HashMap<String, Object> values;
+    private final Map<String, Object> values;
     private final ArchDBRTypes type;
 
-    public HashMapEvent(ArchDBRTypes type, HashMap<String, Object> values) {
+    public HashMapEvent(ArchDBRTypes type, Map<String, Object> values) {
         this.values = values;
         this.type = type;
     }
@@ -163,7 +166,7 @@ public class HashMapEvent implements DBRTimeEvent {
                 return new VectorStringSampleValue(vals);
             }
             case DBR_V4_GENERIC_BYTES: {
-                throw new UnsupportedOperationException("Channel Archiver does not support V4 yet.");
+                return new ByteBufSampleValue((ByteBuffer) values.get(VALUE_FIELD_NAME));
             }
             default:
                 throw new UnsupportedOperationException("Unknown DBR type " + type);
@@ -219,12 +222,12 @@ public class HashMapEvent implements DBRTimeEvent {
 
     @Override
     public void setStatus(int status) {
-        values.put(STAT_FIELD_NAME, Integer.valueOf(status).toString());
+        values.put(STAT_FIELD_NAME, Integer.toString(status));
     }
 
     @Override
     public void setSeverity(int severity) {
-        values.put(SEVR_FIELD_NAME, Integer.valueOf(severity).toString());
+        values.put(SEVR_FIELD_NAME, Integer.toString(severity));
     }
 
     @Override
@@ -235,5 +238,10 @@ public class HashMapEvent implements DBRTimeEvent {
     @Override
     public Class<? extends Message> getProtobufMessageClass() {
         return null;
+    }
+
+    @Override
+    public String toString() {
+        return "HashMapEvent{" + "values=" + values + ", type=" + type + '}';
     }
 }

--- a/src/test/org/epics/archiverappliance/retrieval/saverestore/GetDataAtTimeSpanningStoresTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/saverestore/GetDataAtTimeSpanningStoresTest.java
@@ -36,6 +36,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.Period;
 import java.time.temporal.ChronoField;
@@ -126,7 +127,7 @@ public class GetDataAtTimeSpanningStoresTest {
             String getDataAtTimeURL =
                     ConfigServiceForTests.GETDATAATTIME_URL + "?at=" + TimeUtils.convertToISO8601String(atTime);
             JSONObject resp = GetUrlContent.postDataAndGetContentAsJSONObject(getDataAtTimeURL, pvs);
-            Assertions.assertTrue(resp.size() >= 1, "We expected at least one sample back, we got " + resp.size());
+            Assertions.assertFalse(resp.isEmpty(), "We expected at least one sample back, we got " + resp.size());
             Instant expectedTimeStamp = getData.get(i - 1).getEventTimeStamp().with(ChronoField.MILLI_OF_SECOND, 0);
             Instant obtainedTimeStamp = Instant.ofEpochSecond((long) ((JSONObject) resp.get(pvName)).get("secs"));
             Assertions.assertEquals(
@@ -153,12 +154,13 @@ public class GetDataAtTimeSpanningStoresTest {
         newPVTypeInfo.setPaused(true);
         newPVTypeInfo.setApplianceIdentity("appliance0");
         newPVTypeInfo.setChunkKey(pvName + ":");
-        Assertions.assertTrue(
-                newPVTypeInfo.getPvName().equals(pvName),
+        Assertions.assertEquals(
+                newPVTypeInfo.getPvName(),
+                pvName,
                 "Expecting PV typeInfo for " + pvName + "; instead it is " + srcPVTypeInfo.getPvName());
         JSONEncoder<PVTypeInfo> encoder = JSONEncoder.getEncoder(PVTypeInfo.class);
         GetUrlContent.postDataAndGetContentAsJSONObject(
-                "http://localhost:17665/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, "UTF-8")
+                "http://localhost:17665/mgmt/bpl/putPVTypeInfo?pv=" + URLEncoder.encode(pvName, StandardCharsets.UTF_8)
                         + "&createnew=true",
                 encoder.encode(newPVTypeInfo));
         return newPVTypeInfo;


### PR DESCRIPTION
Support the more specific GetDataAtTime api

This allows more flexibility in implementation while still supporting the requirement from the retrieval engine

Another pre PR for #369 

This is partly because its just not natural to go backwards through a parquet file, but to find a specific set of events at a specific time is fine because you can do filtering on the file.