### PR TITLE
Remove computing ApplianceAggregateInfo on startup.

### DIFF
--- a/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
+++ b/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
@@ -755,16 +755,6 @@ public class DefaultConfigService implements ConfigService {
 
             registerForNewExternalServers(hzinstance.getMap("channelArchiverDataServers"));
 
-            // Cache the aggregate of all the PVs that are registered to this appliance.
-            logger.debug(() -> "Building a local aggregate of PV infos that are registered to this appliance");
-            try {
-                for (String pvName : getPVsForThisAppliance()) {
-                    applianceAggregateInfo.addInfoForPV(pvName, this.getTypeInfoForPV(pvName), this);
-                }
-            } catch (Exception ex) {
-                logger.error("Exception building data for capacity planning", ex);
-            }
-
         } else if (this.warFile == WAR_FILE.RETRIEVAL) {
             initializeFailoverServerCache();
         }


### PR DESCRIPTION
This slows down the startup in large clusters and we are doing this anyway in loadTypeInfosFromPersistence. In case we need to do this in the future, we should do this in the background