### PR TITLE
Use queryPVTypeInfos to determine the breakdown of pvcounts in a cluster

### DIFF
--- a/src/main/org/epics/archiverappliance/mgmt/bpl/reports/ApplianceMetrics.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/reports/ApplianceMetrics.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.epics.archiverappliance.mgmt.bpl.reports;
 
+import com.hazelcast.projection.Projections;
+import com.hazelcast.query.Predicates;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.BPLAction;
@@ -18,19 +20,14 @@ import org.epics.archiverappliance.utils.ui.MimeTypeConstants;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 
-import com.hazelcast.projection.Projections;
-import com.hazelcast.query.Predicates;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -72,18 +69,14 @@ public class ApplianceMetrics implements BPLAction {
     /*
      * Return a map of appliance identity -> PV counts.
      */
-    static Map<String, Long> getAppliancePVCounts(ConfigService configService) { 
-        Map<String, Long> pvCounts = configService.queryPVTypeInfos(
-            Predicates.alwaysTrue(), 
-            Projections.<Map.Entry<String, PVTypeInfo>, String>singleAttribute("applianceIdentity"))
-            .stream()
-            .collect(
-                Collectors.groupingBy(
-                    Function.identity(),
-                    Collectors.counting()
-                )
-        );
-        for(String applianceIdentity : pvCounts.keySet()) {
+    static Map<String, Long> getAppliancePVCounts(ConfigService configService) {
+        Map<String, Long> pvCounts = configService
+                .queryPVTypeInfos(
+                        Predicates.alwaysTrue(),
+                        Projections.<Map.Entry<String, PVTypeInfo>, String>singleAttribute("applianceIdentity"))
+                .stream()
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        for (String applianceIdentity : pvCounts.keySet()) {
             logger.info("PVCount {} Count {}", applianceIdentity, pvCounts.get(applianceIdentity));
         }
         return pvCounts;
@@ -91,7 +84,7 @@ public class ApplianceMetrics implements BPLAction {
 
     static HashMap<String, String> getBasicMetrics(
             ConfigService configService,
-            LinkedList<Map<String, String>> result, 
+            LinkedList<Map<String, String>> result,
             ApplianceInfo info,
             Map<String, Long> pvCounts) {
         HashMap<String, String> applianceInfo = new HashMap<String, String>();

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/reports/InstanceReport.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/reports/InstanceReport.java
@@ -29,10 +29,11 @@ public class InstanceReport implements BPLAction {
             throws IOException {
         logger.info("Generating Instance report");
         resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
-        try (PrintWriter out = resp.getWriter()) {
+        try (PrintWriter out = resp.getWriter()) {                
             LinkedList<Map<String, String>> result = new LinkedList<Map<String, String>>();
+            Map<String, Long> pvCounts = ApplianceMetrics.getAppliancePVCounts(configService);
             for (ApplianceInfo info : configService.getAppliancesInCluster()) {
-                var applianceInfo = ApplianceMetrics.getBasicMetrics(configService, result, info);
+                var applianceInfo = ApplianceMetrics.getBasicMetrics(configService, result, info, pvCounts);
                 JSONObject mgmtMetrics =
                         GetUrlContent.getURLContentAsJSONObject(info.getMgmtURL() + "/getMgmtMetricsForAppliance");
                 applianceInfo.put(

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/reports/InstanceReport.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/reports/InstanceReport.java
@@ -1,6 +1,5 @@
 package org.epics.archiverappliance.mgmt.bpl.reports;
 
-import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.BPLAction;
@@ -13,9 +12,6 @@ import org.json.simple.JSONValue;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.lang.management.ManagementFactory;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.LinkedList;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
@@ -29,7 +25,7 @@ public class InstanceReport implements BPLAction {
             throws IOException {
         logger.info("Generating Instance report");
         resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
-        try (PrintWriter out = resp.getWriter()) {                
+        try (PrintWriter out = resp.getWriter()) {
             LinkedList<Map<String, String>> result = new LinkedList<Map<String, String>>();
             Map<String, Long> pvCounts = ApplianceMetrics.getAppliancePVCounts(configService);
             for (ApplianceInfo info : configService.getAppliancesInCluster()) {
@@ -37,9 +33,11 @@ public class InstanceReport implements BPLAction {
                 JSONObject mgmtMetrics =
                         GetUrlContent.getURLContentAsJSONObject(info.getMgmtURL() + "/getMgmtMetricsForAppliance");
                 applianceInfo.put(
-                        "MGMT_uptime",((String) mgmtMetrics.get("uptime")).substring(2)
-                        .replaceAll("(\\d[HMS])(?!$)", "$1 ")
-                        .toLowerCase());
+                        "MGMT_uptime",
+                        ((String) mgmtMetrics.get("uptime"))
+                                .substring(2)
+                                .replaceAll("(\\d[HMS])(?!$)", "$1 ")
+                                .toLowerCase());
 
                 // The getApplianceMetrics here is not a typo. We redisplay some of the appliance metrics in this page.
                 JSONObject engineMetrics =

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/reports/StorageReport.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/reports/StorageReport.java
@@ -27,8 +27,9 @@ public class StorageReport implements BPLAction {
         resp.setContentType(MimeTypeConstants.APPLICATION_JSON);
         try (PrintWriter out = resp.getWriter()) {
             LinkedList<Map<String, String>> result = new LinkedList<Map<String, String>>();
+            Map<String, Long> pvCounts = ApplianceMetrics.getAppliancePVCounts(configService);
             for (ApplianceInfo info : configService.getAppliancesInCluster()) {
-                var applianceInfo = ApplianceMetrics.getBasicMetrics(configService, result, info);
+                var applianceInfo = ApplianceMetrics.getBasicMetrics(configService, result, info, pvCounts);
 
                 // The getApplianceMetrics here is not a typo. We redisplay some of the appliance metrics in this page.
                 JSONObject engineMetrics =


### PR DESCRIPTION
Hoping to improve the performance of the metrics page in a large cluster with many appliances a little by using a query to compute the PV counts by appliance once.