### PR TITLE
GitHub release

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -93,6 +93,7 @@ jobs:
             latest=false
             prefix=${{matrix.imagetag}}-
           tags: |
+            type=ref,event=tag,prefix=${{ matrix.imagetag }}-
             type=ref,event=pr,prefix=${{ matrix.imagetag }}-pr-
             type=sha,prefix=${{ matrix.imagetag }}-
       - name: Set up Docker Buildx

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -109,3 +109,20 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+  create-prerelease:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: build-jar-release
+    steps:
+      - name: Download the built artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: default-package
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: github.ref_type == 'tag'
+        with:
+          files: "*.tar.gz"
+          prerelease: true
+          generate_release_notes: true


### PR DESCRIPTION
Adds a github action that will create a prerelease when pushing a tag

Also updates the docker action to add the tag to the names, i.e. mgmt-{tagname} rather than just mgmt-{sha}

See https://github.com/jacomago/epicsarchiverap/releases/tag/testtag for the example release