### PR TITLE
#386 - Use a different name for the array count from the API

### DIFF
--- a/src/main/org/epics/archiverappliance/config/MetaInfo.java
+++ b/src/main/org/epics/archiverappliance/config/MetaInfo.java
@@ -712,7 +712,7 @@ public class MetaInfo {
 		retVal.put("DRVH", Double.toString(upperCtrlLimit));
 		retVal.put("PREC", Double.toString(precision));
 		if(unit != null) { retVal.put("EGU", unit); } 
-		retVal.put("NELM", Integer.toString(count));
+		retVal.put("EAA_COUNT", Integer.toString(count));
 		for(String fieldName : otherMetaInfo.keySet()) {
 			retVal.put(fieldName, otherMetaInfo.get(fieldName));
 		}


### PR DESCRIPTION
Change the name of the field to EAA_COUNT.
