### PR TITLE
Fix potential deadlocks in EPICS_V3_PV

### DIFF
--- a/src/main/org/epics/archiverappliance/engine/pv/EPICS_V3_PV.java
+++ b/src/main/org/epics/archiverappliance/engine/pv/EPICS_V3_PV.java
@@ -1059,9 +1059,7 @@ public class EPICS_V3_PV implements PV, ControllingPV, ConnectionListener, Monit
                 HashMap<String, String> tempHashMap = new HashMap<>(changedarchiveFieldsData);
                 // dbrtimeevent.s
                 lastEvent.setFieldValues(tempHashMap, true);
-                synchronized (this) {
-                    changedarchiveFieldsData.clear();
-                }
+                changedarchiveFieldsData.clear();
             }
             if (!allarchiveFieldsData.isEmpty()) {
                 long nowES = TimeUtils.getCurrentEpochSeconds();


### PR DESCRIPTION
A reasonable way of validating the various synchronized's in this class is to make sure that every synchronized is done by the JCACommandThread for that PV. That should force an ordering on the locks in EPICS_V3_PV and CAJChannel. Hopefully that minimizes/eliminates any deadlocks. 

The synchronized in aboutToWriteBuffer was not needed at all I think.