### PR TITLE
Do not throw a AlreadyRegisteredException when reassigning a PV

### DIFF
--- a/src/main/org/epics/archiverappliance/config/ConfigService.java
+++ b/src/main/org/epics/archiverappliance/config/ConfigService.java
@@ -310,10 +310,10 @@ public interface ConfigService {
      * Make changes in the config service to register this PV to an appliance
      * @param pvName The name of PV.
      * @param applianceInfo ApplianceInfo
-     * @param amReassigning If reassigning; then an AlreadyRegisteredException is not raised
+     * @param registrationType If reassigning; then an AlreadyRegisteredException is not raised
      * @throws AlreadyRegisteredException  &emsp;
      */
-    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo, boolean amReassigning)
+    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo, PVRegistrationType registrationType)
             throws AlreadyRegisteredException;
 
     /*
@@ -324,7 +324,7 @@ public interface ConfigService {
      */
     public default void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo)
             throws AlreadyRegisteredException {
-        this.registerPVToAppliance(pvName, applianceInfo, false);
+        this.registerPVToAppliance(pvName, applianceInfo, PVRegistrationType.ARCHIVNG);
     }
 
     /**

--- a/src/main/org/epics/archiverappliance/config/ConfigService.java
+++ b/src/main/org/epics/archiverappliance/config/ConfigService.java
@@ -310,9 +310,20 @@ public interface ConfigService {
      * Make changes in the config service to register this PV to an appliance
      * @param pvName The name of PV.
      * @param applianceInfo ApplianceInfo
+     * @param amReassigning If reassigning; then an AlreadyRegisteredException is not raised
      * @throws AlreadyRegisteredException  &emsp;
      */
-    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo) throws AlreadyRegisteredException;
+    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo, boolean amReassigning) throws AlreadyRegisteredException;
+
+    /*
+     * Make changes in the config service to register this PV to an appliance
+     * @param pvName The name of PV.
+     * @param applianceInfo ApplianceInfo
+     * @throws AlreadyRegisteredException  &emsp;
+     */
+    public default void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo) throws AlreadyRegisteredException {
+        this.registerPVToAppliance(pvName, applianceInfo, false);
+    }
 
     /**
      * Gets information about a PV's type, i.e its DBR type, graphic limits etc.

--- a/src/main/org/epics/archiverappliance/config/ConfigService.java
+++ b/src/main/org/epics/archiverappliance/config/ConfigService.java
@@ -313,7 +313,8 @@ public interface ConfigService {
      * @param amReassigning If reassigning; then an AlreadyRegisteredException is not raised
      * @throws AlreadyRegisteredException  &emsp;
      */
-    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo, boolean amReassigning) throws AlreadyRegisteredException;
+    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo, boolean amReassigning)
+            throws AlreadyRegisteredException;
 
     /*
      * Make changes in the config service to register this PV to an appliance
@@ -321,7 +322,8 @@ public interface ConfigService {
      * @param applianceInfo ApplianceInfo
      * @throws AlreadyRegisteredException  &emsp;
      */
-    public default void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo) throws AlreadyRegisteredException {
+    public default void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo)
+            throws AlreadyRegisteredException {
         this.registerPVToAppliance(pvName, applianceInfo, false);
     }
 

--- a/src/main/org/epics/archiverappliance/config/ConfigServiceForTests.java
+++ b/src/main/org/epics/archiverappliance/config/ConfigServiceForTests.java
@@ -217,7 +217,7 @@ public class ConfigServiceForTests extends DefaultConfigService {
      * @throws AlreadyRegisteredException pv already registered.
      */
     @Override
-    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo) throws AlreadyRegisteredException {
+    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo, boolean amReassigning) throws AlreadyRegisteredException {
         // When we register a PV to an appliance in the unit tests, we often forget to set the appliance identity
         PVTypeInfo typeInfo = this.getTypeInfoForPV(pvName);
         if (typeInfo != null) {
@@ -227,7 +227,7 @@ public class ConfigServiceForTests extends DefaultConfigService {
                 typeInfos.put(pvName, typeInfo);
             }
         }
-        super.registerPVToAppliance(pvName, applianceInfo);
+        super.registerPVToAppliance(pvName, applianceInfo, amReassigning);
         Set<String> queryResult = this.getPVsForAppliance(applianceInfo);
         if (!queryResult.contains(pvName)) {
             throw new RuntimeException(

--- a/src/main/org/epics/archiverappliance/config/ConfigServiceForTests.java
+++ b/src/main/org/epics/archiverappliance/config/ConfigServiceForTests.java
@@ -217,7 +217,8 @@ public class ConfigServiceForTests extends DefaultConfigService {
      * @throws AlreadyRegisteredException pv already registered.
      */
     @Override
-    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo, boolean amReassigning) throws AlreadyRegisteredException {
+    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo, boolean amReassigning)
+            throws AlreadyRegisteredException {
         // When we register a PV to an appliance in the unit tests, we often forget to set the appliance identity
         PVTypeInfo typeInfo = this.getTypeInfoForPV(pvName);
         if (typeInfo != null) {

--- a/src/main/org/epics/archiverappliance/config/ConfigServiceForTests.java
+++ b/src/main/org/epics/archiverappliance/config/ConfigServiceForTests.java
@@ -217,7 +217,7 @@ public class ConfigServiceForTests extends DefaultConfigService {
      * @throws AlreadyRegisteredException pv already registered.
      */
     @Override
-    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo, boolean amReassigning)
+    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo, PVRegistrationType registrationType)
             throws AlreadyRegisteredException {
         // When we register a PV to an appliance in the unit tests, we often forget to set the appliance identity
         PVTypeInfo typeInfo = this.getTypeInfoForPV(pvName);
@@ -228,7 +228,7 @@ public class ConfigServiceForTests extends DefaultConfigService {
                 typeInfos.put(pvName, typeInfo);
             }
         }
-        super.registerPVToAppliance(pvName, applianceInfo, amReassigning);
+        super.registerPVToAppliance(pvName, applianceInfo, registrationType);
         Set<String> queryResult = this.getPVsForAppliance(applianceInfo);
         if (!queryResult.contains(pvName)) {
             throw new RuntimeException(

--- a/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
+++ b/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
@@ -1204,10 +1204,13 @@ public class DefaultConfigService implements ConfigService {
     }
 
     @Override
-    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo) throws AlreadyRegisteredException {
+    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo, boolean amReassigning) throws AlreadyRegisteredException {
         ApplianceInfo info = pv2appliancemapping.get(pvName);
-        if (info != null && !info.getIdentity().equals(applianceInfo.getIdentity()))
-            throw new AlreadyRegisteredException(info);
+        if (info != null && !info.getIdentity().equals(applianceInfo.getIdentity())) {
+            if(!amReassigning) {
+                throw new AlreadyRegisteredException(info);
+            }
+        }
         pv2appliancemapping.put(pvName, applianceInfo);
     }
 

--- a/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
+++ b/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
@@ -1204,11 +1204,11 @@ public class DefaultConfigService implements ConfigService {
     }
 
     @Override
-    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo, boolean amReassigning)
+    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo, PVRegistrationType registrationType)
             throws AlreadyRegisteredException {
         ApplianceInfo info = pv2appliancemapping.get(pvName);
         if (info != null && !info.getIdentity().equals(applianceInfo.getIdentity())) {
-            if (!amReassigning) {
+            if (registrationType == PVRegistrationType.ARCHIVNG) {
                 throw new AlreadyRegisteredException(info);
             }
         }

--- a/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
+++ b/src/main/org/epics/archiverappliance/config/DefaultConfigService.java
@@ -1204,10 +1204,11 @@ public class DefaultConfigService implements ConfigService {
     }
 
     @Override
-    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo, boolean amReassigning) throws AlreadyRegisteredException {
+    public void registerPVToAppliance(String pvName, ApplianceInfo applianceInfo, boolean amReassigning)
+            throws AlreadyRegisteredException {
         ApplianceInfo info = pv2appliancemapping.get(pvName);
         if (info != null && !info.getIdentity().equals(applianceInfo.getIdentity())) {
-            if(!amReassigning) {
+            if (!amReassigning) {
                 throw new AlreadyRegisteredException(info);
             }
         }

--- a/src/main/org/epics/archiverappliance/config/PVRegistrationType.java
+++ b/src/main/org/epics/archiverappliance/config/PVRegistrationType.java
@@ -1,0 +1,6 @@
+package org.epics.archiverappliance.config;
+
+public enum PVRegistrationType {
+    ARCHIVNG,
+    REASSIGNING
+}

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ReassignAppliance.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ReassignAppliance.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.BPLAction;
 import org.epics.archiverappliance.config.ApplianceInfo;
 import org.epics.archiverappliance.config.ConfigService;
+import org.epics.archiverappliance.config.PVRegistrationType;
 import org.epics.archiverappliance.config.PVTypeInfo;
 import org.json.simple.JSONValue;
 
@@ -108,7 +109,7 @@ public class ReassignAppliance implements BPLAction {
             try {
                 typeInfo.setApplianceIdentity(destApplianceInfo.getIdentity());
                 configService.updateTypeInfoForPV(pvName, typeInfo);
-                configService.registerPVToAppliance(pvName, destApplianceInfo, true);
+                configService.registerPVToAppliance(pvName, destApplianceInfo, PVRegistrationType.REASSIGNING);
                 statuses.put(pvNameFromRequest, "Success");
             } catch (Exception ex) {
                 String msg = "Exception reassiging PV " + pvName + " to appliance " + destApplianceIdentity;

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ReassignAppliance.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ReassignAppliance.java
@@ -115,8 +115,8 @@ public class ReassignAppliance implements BPLAction {
                 logger.error(msg, ex);
                 statuses.put(pvNameFromRequest, msg);
             }
-            
-            try(PrintWriter out = resp.getWriter()) {
+
+            try (PrintWriter out = resp.getWriter()) {
                 out.println(JSONValue.toJSONString(statuses));
             }
         }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ReassignAppliance.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ReassignAppliance.java
@@ -6,8 +6,10 @@ import org.epics.archiverappliance.common.BPLAction;
 import org.epics.archiverappliance.config.ApplianceInfo;
 import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.config.PVTypeInfo;
+import org.json.simple.JSONValue;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import javax.servlet.http.HttpServletRequest;
@@ -112,6 +114,10 @@ public class ReassignAppliance implements BPLAction {
                 String msg = "Exception reassiging PV " + pvName + " to appliance " + destApplianceIdentity;
                 logger.error(msg);
                 statuses.put(pvNameFromRequest, msg);
+            }
+            
+            try(PrintWriter out = resp.getWriter()) {
+                out.println(JSONValue.toJSONString(statuses));
             }
         }
     }

--- a/src/main/org/epics/archiverappliance/mgmt/bpl/ReassignAppliance.java
+++ b/src/main/org/epics/archiverappliance/mgmt/bpl/ReassignAppliance.java
@@ -108,11 +108,11 @@ public class ReassignAppliance implements BPLAction {
             try {
                 typeInfo.setApplianceIdentity(destApplianceInfo.getIdentity());
                 configService.updateTypeInfoForPV(pvName, typeInfo);
-                configService.registerPVToAppliance(pvName, destApplianceInfo);
+                configService.registerPVToAppliance(pvName, destApplianceInfo, true);
                 statuses.put(pvNameFromRequest, "Success");
             } catch (Exception ex) {
                 String msg = "Exception reassiging PV " + pvName + " to appliance " + destApplianceIdentity;
-                logger.error(msg);
+                logger.error(msg, ex);
                 statuses.put(pvNameFromRequest, msg);
             }
             


### PR DESCRIPTION
Various small changes for a working reassign appliance. Will test these changes out in production next week