### PR TITLE
Fix null pointer exception in FieldValuesCache

### DIFF
--- a/src/main/org/epics/archiverappliance/engine/pv/FieldValuesCache.java
+++ b/src/main/org/epics/archiverappliance/engine/pv/FieldValuesCache.java
@@ -435,7 +435,10 @@ public class FieldValuesCache {
         }
         Map<String, String> changed = new HashMap<>();
         for (String key : this.lastChangedFields) {
-            changed.put(key, this.cachedFieldValues.get(key));
+            String values = this.cachedFieldValues.get(key);
+            if (values != null) {
+                changed.put(key, this.cachedFieldValues.get(key));
+            }
         }
         if (this.excludeV4Changes) {
             changed = changed.entrySet().stream()


### PR DESCRIPTION
Found with log:

`2025-11-18 07:34:08,823 ERROR [JCA Command Thread 6] pv.EPICS_V4_PV (EPICS_V4_PV.java:442) - exception when reading pv
java.lang.NullPointerException: null
	at java.util.Objects.requireNonNull(Objects.java:233) ~[?:?]
	at java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:180) ~[?:?]
	at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169) ~[?:?]
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179) ~[?:?]
	at java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1858) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
	at org.epics.archiverappliance.engine.pv.FieldValuesCache.getUpdatedFieldValues(FieldValuesCache.java:438) ~[classes/:?]
	at org.epics.archiverappliance.engine.pv.EPICS_V4_PV.fromStructure(EPICS_V4_PV.java:283) ~[classes/:?]
	at org.epics.archiverappliance.engine.pv.EPICS_V4_PV.subscribe(EPICS_V4_PV.java:438) ~[classes/:?]
	at org.epics.archiverappliance.engine.pv.EPICS_V4_PV.handleConnected(EPICS_V4_PV.java:388) ~[classes/:?]
	at org.epics.archiverappliance.engine.pv.JCACommandThread.run(JCACommandThread.java:194) [classes/:?]`