### PR TITLE
fix sampleStartup.sh multipleBuildAndDeploy.sh 

### DIFF
--- a/docs/docs/source/samples/multipleBuildAndDeploy.sh
+++ b/docs/docs/source/samples/multipleBuildAndDeploy.sh
@@ -126,7 +126,7 @@ echo "We are building for site ${ARCHAPPL_SITEID}"
 # Enable core dumps in case the JVM fails
 ulimit -c unlimited
 export LD_LIBRARY_PATH=/scratch/Work/tomcat/latest/bin/tomcat-native-1.1.20-src/jni/native/.libs:${LD_LIBRARY_PATH}
-export JAVA_OPTS="-XX:MaxPermSize=128M -Xmx1G -Dorg.apache.catalina.level=FINEST -ea"
+export JAVA_OPTS="-Xmx1G -Dorg.apache.catalina.level=FINEST -ea"
 
 stopTomcatAtLocation ${DEPLOY_DIR}/engine
 stopTomcatAtLocation ${DEPLOY_DIR}/retrieval

--- a/docs/docs/source/samples/sampleStartup.sh
+++ b/docs/docs/source/samples/sampleStartup.sh
@@ -11,7 +11,7 @@ source /opt/local/setEPICSEnv.sh
 export JAVA_HOME=/opt/local/java/latest
 export PATH=${JAVA_HOME}/bin:${PATH}
 # We use a lot of memory; so be generous with the heap. 
-export JAVA_OPTS="-XX:MaxPermSize=128M -XX:+UseG1GC -Xmx4G -Xms4G -ea"
+export JAVA_OPTS="-XX:+UseG1GC -Xmx4G -Xms4G -ea"
 
 # Set up Tomcat home
 export TOMCAT_HOME=/opt/local/tomcat


### PR DESCRIPTION
MaxPermSize needs to be removed because it is deprecated and does not work with more modern Java versions (17+).