### PR TITLE
Fix the tests not running on the extended tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -534,6 +534,9 @@ tasks.register<Tar>("buildRelease") {
 // =================================================================
 
 tasks.withType<Test>().configureEach {
+	testClassesDirs = sourceSets.test.get().output.classesDirs
+	classpath = sourceSets.test.get().runtimeClasspath
+
 	maxParallelForks = if (runTestsSequentially) {
 		1
 	} else {


### PR DESCRIPTION
This is a fix for after the upgrade to gradle 9, which no longer has the testClassPath implicitly set when extending the Test task type. Adding the the test classpath explicitly fixes the problem