### PR TITLE
fix: add hadoop runtime dependency - parquet archive issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -162,7 +162,8 @@ dependencies {
 	implementation(libs.parquet.common)
 	implementation(libs.parquet.hadoop)
 	implementation(libs.hadoop.common)
-	runtimeOnly(libs.hadoop.client)
+	runtimeOnly(libs.hadoop.client.api)
+	runtimeOnly(libs.hadoop.client.runtime)
 
 	// Testing
 	testImplementation(libs.junit.jupiter.api)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,7 +73,8 @@ parquet-column           = { module = "org.apache.parquet:parquet-column", versi
 parquet-common           = { module = "org.apache.parquet:parquet-common", version.ref = "parquet" }
 parquet-hadoop           = { module = "org.apache.parquet:parquet-hadoop", version.ref = "parquet" }
 hadoop-common            = { module = "org.apache.hadoop:hadoop-common", version.ref = "hadoop" }
-hadoop-client            = { module = "org.apache.hadoop:hadoop-client-api", version.ref = "hadoop" }
+hadoop-client-api        = { module = "org.apache.hadoop:hadoop-client-api", version.ref = "hadoop" }
+hadoop-client-runtime    = { module = "org.apache.hadoop:hadoop-client-runtime", version.ref = "hadoop" }
 tomcat-servlet-api       = { module = "org.apache.tomcat:tomcat-servlet-api", version.ref = "tomcat" }
 junit-jupiter-api        = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
 junit-jupiter-params     = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }


### PR DESCRIPTION
When Archiving a PV using Parquet, a NoClassDefFoundError is received: java.lang.NoClassDefFoundError: org/apache/hadoop/shaded/com/ctc/wstx/io/InputBootstrapper

This class is provided by hadoop-client-runtime dependency.
```bash
# List the contents of Hadoop runtime jar and filter for InputBootstrapper
jar tf ~/.gradle/caches/modules-2/files-2.1/org.apache.hadoop/hadoop-client-runtime/3.3.6/81065531e63fccbe85fb04a3274709593fb00d3c/hadoop-client-runtime-3.3.6.jar | grep InputBootstrapper
org/apache/hadoop/shaded/com/ctc/wstx/io/InputBootstrapper.class
```

```java
[INFO ] 2026-02-25 15:24:26.289 [MgmtArchivePVWorkflow1] ArchivePVState - Policy for pv parquet:heartbeat is {"controlPV":null,"dataStores":["parquet:\/\/localhost?name=STS&rootFolder=${ARCHAPPL_SHORT_TERM_FOLDER}&partitionGranularity=PARTITION_HOUR&consolidateOnShutdown=true","parquet:\/\/localhost?name=MTS&rootFolder=${ARCHAPPL_MEDIUM_TERM_FOLDER}&partitionGranularity=PARTITION_DAY&hold=2&gather=1","parquet:\/\/localhost?name=MLTS&rootFolder=${ARCHAPPL_MEDIUM_LONG_TERM_FOLDER}&partitionGranularity=PARTITION_MONTH&hold=4&gather=1","parquet:\/\/localhost?name=LTS&rootFolder=${ARCHAPPL_LONG_TERM_FOLDER}&partitionGranularity=PARTITION_YEAR&reducedata=firstSample_60"],"policyName":"parquet_3moDecimate60","samplingPeriod":"1.0","samplingMethod":"MONITOR"}
[ERROR] 2026-02-25 15:24:26.309 [MgmtArchivePVWorkflow1] MgmtRuntimeState - Exception processing next step in archive PV workflow
java.lang.NoClassDefFoundError: org/apache/hadoop/shaded/com/ctc/wstx/io/InputBootstrapper
	at org.apache.parquet.conf.HadoopParquetConfiguration.<init>(HadoopParquetConfiguration.java:39) ~[parquet-hadoop-1.17.0.jar:1.17.0]
	at org.apache.parquet.conf.HadoopParquetConfiguration.<init>(HadoopParquetConfiguration.java:35) ~[parquet-hadoop-1.17.0.jar:1.17.0]
	at org.apache.parquet.ParquetReadOptions$Builder.<init>(ParquetReadOptions.java:273) ~[parquet-hadoop-1.17.0.jar:1.17.0]
	at edu.stanford.slac.archiverappliance.plain.parquet.ParquetInfo.<clinit>(ParquetInfo.java:53) ~[classes/:?]
	at edu.stanford.slac.archiverappliance.plain.parquet.ParquetPlainFileHandler.<init>(ParquetPlainFileHandler.java:60) ~[classes/:?]
	at edu.stanford.slac.archiverappliance.plain.PlainStorageType.plainFileHandler(PlainStorageType.java:16) ~[classes/:?]
	at edu.stanford.slac.archiverappliance.plain.PlainStoragePlugin.<init>(PlainStoragePlugin.java:187) ~[classes/:?]
	at org.epics.archiverappliance.config.StoragePluginURLParser.parsePlainStoragePlugin(StoragePluginURLParser.java:149) ~[classes/:?]
	at org.epics.archiverappliance.config.StoragePluginURLParser.parseETLSource(StoragePluginURLParser.java:98) ~[classes/:?]
	at org.epics.archiverappliance.mgmt.archivepv.CapacityPlanningBPL.pickApplianceForPV(CapacityPlanningBPL.java:64) ~[classes/:?]
	at org.epics.archiverappliance.mgmt.archivepv.ArchivePVState.nextStep(ArchivePVState.java:238) ~[classes/:?]
	at org.epics.archiverappliance.mgmt.MgmtRuntimeState$3.run(MgmtRuntimeState.java:192) ~[classes/:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[?:?]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.shaded.com.ctc.wstx.io.InputBootstrapper
	at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1225) ~[tomcat11-catalina-11.0.15.jar:11.0.15]
	at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1056) ~[tomcat11-catalina-11.0.15.jar:11.0.15]
	... 18 more