### PR TITLE
Dependancy checks

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -27,8 +27,8 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  formatcheck:
-    name: Check the formatting
+  check:
+    name: Check formatting and dependencies
     runs-on: ubuntu-latest
 
     steps:
@@ -43,13 +43,15 @@ jobs:
           distribution: "temurin"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: Build with Gradle
+      - name: Check Formatting
         run: ./gradlew spotlessCheck
+      - name: Analyze Dependencies
+        run: ./gradlew analyzeDependencies
       - name: Upload build reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: formatcheck-build-reports
+          name: check-build-reports
           path: build/reports/
 
   unittests:

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -117,7 +117,7 @@ jobs:
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v5
         if: success() || failure() # always run even if the previous step fails
         with:
           report_paths: "**/build/test-results/epicsTests/TEST-*.xml"
@@ -155,7 +155,7 @@ jobs:
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v5
         if: success() || failure() # always run even if the previous step fails
         with:
           report_paths: "**/build/test-results/integrationTests/TEST-*.xml"

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -84,12 +84,6 @@ jobs:
         with:
           name: unitests-build-reports
           path: build/reports/
-      - name: Upload package
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-package
-          path: build/distributions/*.tar.gz
 
   epicstests:
     name: Run all unit tests reliant on EPICS install

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -25,6 +25,9 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  DOCKER_DEFAULT_PLATFORM: linux/amd64
+  COMPOSE_DOCKER_CLI_BUILD: 1
+  DOCKER_BUILDKIT: 1
 
 jobs:
   check:
@@ -106,10 +109,6 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
       - name: Run tests with docker compose
         run: docker compose -f docker/docker-compose.epicsTests.yml run epicsarchiver-test
-        env:
-          DOCKER_DEFAULT_PLATFORM: linux/amd64
-          COMPOSE_DOCKER_CLI_BUILD: 1
-          DOCKER_BUILDKIT: 1
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5
         if: success() || failure() # always run even if the previous step fails
@@ -144,10 +143,6 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
       - name: Run tests with docker compose
         run: docker compose -f docker/docker-compose.integrationTests.yml run epicsarchiver-test
-        env:
-          DOCKER_DEFAULT_PLATFORM: linux/amd64
-          COMPOSE_DOCKER_CLI_BUILD: 1
-          DOCKER_BUILDKIT: 1
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5
         if: success() || failure() # always run even if the previous step fails

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,6 +153,7 @@ dependencies {
 	"permitUnusedDeclared"(libs.log4j.slf4j2)
 	implementation(libs.log4j.jul)
 	"permitUnusedDeclared"(libs.log4j.jul)
+	"permitUsedUndeclared"(libs.stax.api)
 	runtimeOnly(libs.log4j.core)
 	runtimeOnly(libs.disruptor) // Needed for async logging
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ spotless-plugin = "8.1.0"
 git-version-plugin = "3.0.0"
 analyze-plugin  = "1.9.2"
 protobuf-plugin = "0.9.5"
+stax-api       = "1.0-2"
 
 [libraries]
 guava                    = { module = "com.google.guava:guava", version.ref = "guava" }
@@ -85,6 +86,7 @@ commons-compress         = { module = "org.apache.commons:commons-compress", ver
 commons-cli              = { module = "commons-cli:commons-cli", version.ref = "commons-cli" }
 jinjava                  = { module = "com.hubspot.jinjava:jinjava", version.ref = "jinjava" }
 mockito                  = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+stax-api                 = { module = "javax.xml.stream:stax-api", version.ref = "stax-api"}
 
 [bundles]
 parquet      = ["parquet-protobuf", "parquet-column", "parquet-common", "parquet-hadoop"]

--- a/src/test/org/epics/archiverappliance/retrieval/EventStreamWrapTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/EventStreamWrapTest.java
@@ -25,6 +25,7 @@ import org.epics.archiverappliance.utils.simulation.SimulationEventStream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -164,6 +165,7 @@ public class EventStreamWrapTest {
      * We wrap a thread around each source event stream. Since the source data is generated using month partitions, we
      * should get about 12 source event streams.
      */
+    @Tag("flaky")
     @ParameterizedTest
     @EnumSource(PlainStorageType.class)
     void testMultiThreadWrapper(PlainStorageType plainStorageType) throws Exception {


### PR DESCRIPTION
Add check in ci that the dependencies don't have any problems by using a gradle plugin.

Also includes:
 - Refactor the ci script to be a bit cleaner, by not repeating itself so much.
 - Update the junit report github action
 - Mark the flaky test as flaky :( 
 - Remove an unnecessary artifact upload (thats part of the build and push workflow)

This should hopefully block the issue causing #497 by making sure all the dependencies are declared.

