### PR TITLE
fix: throw ChangeInYearsException for streams spanning multiple years

### DIFF
--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/ArrayListCollectorEventStream.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/ArrayListCollectorEventStream.java
@@ -8,6 +8,7 @@ import org.epics.archiverappliance.common.TimeUtils;
 import org.epics.archiverappliance.common.remotable.ArrayListEventStream;
 import org.epics.archiverappliance.common.remotable.RemotableEventStreamDesc;
 import org.epics.archiverappliance.common.remotable.RemotableOverRaw;
+import org.epics.archiverappliance.retrieval.ChangeInYearsException;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -64,10 +65,18 @@ public class ArrayListCollectorEventStream implements EventStream, RemotableOver
         public Event next() {
             Event next = sourceStream.get(currentIndex);
             short eventYear = TimeUtils.computeYearForEpochSeconds(next.getEpochSeconds());
+
+            if (currentYear == -1) {
+                currentYear = eventYear;
+                desc.setYear(eventYear);
+            }
+
             if (eventYear != currentYear) {
                 logger.info("Detected a change in years eventYear " + eventYear + " and currentYear is " + currentYear);
                 ArrayListCollectorEventStream.this.desc.setYear(eventYear);
+                short tempCurrentYear = currentYear;
                 currentYear = eventYear;
+                throw new ChangeInYearsException(tempCurrentYear, eventYear);
             }
             currentIndex++;
             return next;

--- a/src/test/org/epics/archiverappliance/retrieval/postprocessor/OptimizedPostProcessorTest.java
+++ b/src/test/org/epics/archiverappliance/retrieval/postprocessor/OptimizedPostProcessorTest.java
@@ -12,6 +12,7 @@ import org.epics.archiverappliance.config.PVTypeInfo;
 import org.epics.archiverappliance.data.ScalarValue;
 import org.epics.archiverappliance.data.VectorValue;
 import org.epics.archiverappliance.retrieval.CallableEventStream;
+import org.epics.archiverappliance.retrieval.ChangeInYearsException;
 import org.epics.archiverappliance.retrieval.postprocessors.Optimized;
 import org.epics.archiverappliance.utils.simulation.SimulationEvent;
 import org.junit.jupiter.api.Assertions;
@@ -321,5 +322,69 @@ public class OptimizedPostProcessorTest {
                 Arguments.of(49999, 51000, Arrays.asList(40.0, 50.0)),
                 Arguments.of(50000, 51000, Arrays.asList(50.0)),
                 Arguments.of(51000, 52000, Arrays.asList(50.0)));
+    }
+
+    @Test
+    public void testOptimizedCrossYearDetection() {
+        String optimizedTestPVName = "Test_OptimizedCrossYearDetection";
+
+        YearSecondTimestamp start2024 =
+                TimeUtils.convertToYearSecondTimestamp(TimeUtils.convertFromISO8601String("2024-12-31T23:59:50.000Z"));
+        YearSecondTimestamp start2025 =
+                TimeUtils.convertToYearSecondTimestamp(TimeUtils.convertFromISO8601String("2025-01-01T00:00:00.000Z"));
+
+        double valueIn2024 = 1.0;
+        double valueIn2025 = 2.0;
+
+        ArrayListEventStream testData = new ArrayListEventStream(
+                2,
+                new RemotableEventStreamDesc(ArchDBRTypes.DBR_SCALAR_DOUBLE, optimizedTestPVName, start2024.getYear()));
+
+        // Add 1 first-year event
+        testData.add(new SimulationEvent(
+                start2024.getSecondsintoyear(),
+                start2024.getYear(),
+                ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                new ScalarValue<>(valueIn2024)));
+
+        // Add 1 second-year event
+        testData.add(new SimulationEvent(
+                start2025.getSecondsintoyear(),
+                start2025.getYear(),
+                ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                new ScalarValue<>(valueIn2025)));
+
+        Optimized optimizedPostProcessor = new Optimized();
+        try {
+            optimizedPostProcessor.initialize("optimized_5760", optimizedTestPVName);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        var callableEventStream = CallableEventStream.makeOneStreamCallable(testData, null, false);
+
+        var callable = optimizedPostProcessor.wrap(callableEventStream);
+
+        try {
+            callable.call();
+        } catch (Exception e) {
+            Assertions.fail(
+                    "An exception occurred when calling optimizedPostProcessor.wrap(callableEventStream).call()");
+        }
+
+        EventStream eventStream = optimizedPostProcessor.getConsolidatedEventStream();
+
+        // First event is in 2024 - do not trigger the ChangeInYearsException
+        Event first = eventStream.iterator().next();
+        Assertions.assertEquals(valueIn2024, first.getSampleValue().getValue());
+
+        // Second event is in 2025 - trigger the ChangeInYearsException
+        ChangeInYearsException ex = Assertions.assertThrows(
+                ChangeInYearsException.class,
+                eventStream.iterator()::next,
+                "Expected ChangeInYearsException when year changes");
+
+        Assertions.assertEquals(start2024.getYear(), ex.getPreviousYear());
+        Assertions.assertEquals(start2025.getYear(), ex.getCurrentYear());
     }
 }


### PR DESCRIPTION
This change should fix the bug mentioned by @mdavidsaver in this comment https://github.com/archiver-appliance/epicsarchiverap/issues/324#issuecomment-3151323018

In Databrowser, some data points are incorrect when the requested period crosses 2 years AND the number of archiver data points is less than the optimized number of points (5760 when calling from Phoebus).
Archiver is sending data from 2026 for timestamps in 2025. 

<img width="1548" height="648" alt="image" src="https://github.com/user-attachments/assets/730a4068-1655-46a3-b1d5-66a2f398d4bf" />

<img width="493" height="468" alt="image" src="https://github.com/user-attachments/assets/1f4c4893-9ace-4602-ac71-e6d2f69489e0" />



After the fix:

<img width="1541" height="651" alt="image" src="https://github.com/user-attachments/assets/6be37c07-fde6-4f40-9c33-83db5cf371f3" />


