### PR TITLE
Refactor ArchPaths to better support NIO2 syntax.

### DIFF
--- a/src/main/edu/stanford/slac/archiverappliance/plain/AppendDataStateData.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/AppendDataStateData.java
@@ -294,10 +294,8 @@ public abstract class AppendDataStateData {
                 // This is an attempt to not lose data during ETL appends.
                 // We make a copy of the original file if it exists, append to the copy and then do an atomic move.
                 // Should we should use path's resolve here?
-                Path pathToCopyFrom = preparePath.resolveSibling(preparePath
-                        .getFileName()
-                        .toString()
-                        .replace(extension, extensionToCopyFrom));
+                Path pathToCopyFrom = preparePath.resolveSibling(
+                        preparePath.getFileName().toString().replace(extension, extensionToCopyFrom));
                 if (Files.exists(pathToCopyFrom)) {
                     logger.debug("Making a backup from " + pathToCopyFrom.toAbsolutePath()
                             + " to file "

--- a/src/main/edu/stanford/slac/archiverappliance/plain/AppendDataStateData.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/AppendDataStateData.java
@@ -294,8 +294,10 @@ public abstract class AppendDataStateData {
                 // This is an attempt to not lose data during ETL appends.
                 // We make a copy of the original file if it exists, append to the copy and then do an atomic move.
                 // Should we should use path's resolve here?
-                Path pathToCopyFrom = context.getPaths()
-                        .get(preparePath.toAbsolutePath().toString().replace(extension, extensionToCopyFrom));
+                Path pathToCopyFrom = preparePath.resolveSibling(preparePath
+                        .getName(preparePath.getNameCount() - 1)
+                        .toString()
+                        .replace(extension, extensionToCopyFrom));
                 if (Files.exists(pathToCopyFrom)) {
                     logger.debug("Making a backup from " + pathToCopyFrom.toAbsolutePath()
                             + " to file "

--- a/src/main/edu/stanford/slac/archiverappliance/plain/AppendDataStateData.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/AppendDataStateData.java
@@ -295,7 +295,7 @@ public abstract class AppendDataStateData {
                 // We make a copy of the original file if it exists, append to the copy and then do an atomic move.
                 // Should we should use path's resolve here?
                 Path pathToCopyFrom = preparePath.resolveSibling(preparePath
-                        .getName(preparePath.getNameCount() - 1)
+                        .getFileName()
                         .toString()
                         .replace(extension, extensionToCopyFrom));
                 if (Files.exists(pathToCopyFrom)) {

--- a/src/main/edu/stanford/slac/archiverappliance/plain/PathNameUtility.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/PathNameUtility.java
@@ -13,6 +13,7 @@ import org.epics.archiverappliance.common.PartitionGranularity;
 import org.epics.archiverappliance.common.TimeUtils;
 import org.epics.archiverappliance.config.PVNameToKeyMapping;
 import org.epics.archiverappliance.utils.nio.ArchPaths;
+import org.epics.archiverappliance.utils.nio.PVPath;
 
 import java.io.IOException;
 import java.nio.file.*;
@@ -343,8 +344,8 @@ public class PathNameUtility {
             throws IOException {
         String partitionNameComponent = TimeUtils.getPartitionName(ts, partitionGranularity);
         String pvKey = pv2key.convertPVNameToKey(pvName);
-        String pvPathComponent = pvKey + partitionNameComponent + extension;
-        return pathResolver.get(paths, createParentFolder, rootFolder, pvPathComponent, pvKey);
+        return pathResolver.get(
+                paths, createParentFolder, new PVPath(rootFolder, pvKey, partitionNameComponent, extension));
     }
 
     /**
@@ -357,32 +358,6 @@ public class PathNameUtility {
     private static String getFinalNameComponent(String pvName, PVNameToKeyMapping pv2key) {
         Path pvPathAlone = Paths.get(pv2key.convertPVNameToKey(pvName));
         return pvPathAlone.getFileName().toString();
-    }
-
-    /**
-     * A pv is mapped to a path that can span folders. This method returns the parent path of the pv; we search for pv
-     * data in this folder.
-     *
-     * @param paths           ArchPaths - The replacement for NIO Paths
-     * @param rootFolder      The root folder for the plugin
-     * @param pvName          Name of the PV.
-     * @param pathResolver    PathResolver
-     * @param pv2key          PVNameToKeyMapping
-     * @return Path A list of all the paths
-     * @throws IOException &emsp;
-     */
-    private static Path getParentPath(
-            ArchPaths paths,
-            String rootFolder,
-            final String pvName,
-            PathResolver pathResolver,
-            PVNameToKeyMapping pv2key)
-            throws IOException {
-        String pvKey = pv2key.convertPVNameToKey(pvName);
-        boolean createParentFolder = false; // should we create parent folder if it does not exist
-        return pathResolver
-                .get(paths, createParentFolder, rootFolder, pvKey, pvKey)
-                .getParent();
     }
 
     /**
@@ -430,12 +405,11 @@ public class PathNameUtility {
             PVNameToKeyMapping pv2key)
             throws IOException {
         try {
-            Path parentFolder = getParentPath(paths, rootFolder, pvName, pathResolver, pv2key);
-            String pvFinalNameComponent = getFinalNameComponent(pvName, pv2key);
-            String matchGlob = pvFinalNameComponent + "*" + extension;
-            logger.debug(pvName + ": Looking for " + matchGlob + " in parentFolder " + parentFolder.toString());
-
-            return Files.newDirectoryStream(parentFolder, matchGlob);
+            PVPath pvPath = new PVPath(rootFolder, pv2key.convertPVNameToKey(pvName), null, null);
+            ArchPaths.GlobSearchParams gs = paths.getGlobSearchParams(pvPath, extension);
+            logger.debug(pvName + ": Looking for " + gs.globPattern() + " in parentFolder "
+                    + gs.searchFolder().toString());
+            return Files.newDirectoryStream(gs.searchFolder(), gs.globPattern());
         } catch (NotDirectoryException nex) {
             logger.debug("Possibly empty zip file when looking for data for pv " + pvName, nex);
             // Return an empty directory stream in this case.
@@ -471,7 +445,8 @@ public class PathNameUtility {
                 String pvName, String pathName, String pvFinalNameComponent, PartitionGranularity granularity)
                 throws IOException {
             String afterpvname = pathName.substring(pvFinalNameComponent.length());
-            logger.debug("After pvName, name of the file is " + afterpvname);
+            logger.debug("After pvName, name of the file is " + afterpvname + " with final name component "
+                    + pvFinalNameComponent);
             String justtheTimeComponent = afterpvname.split("\\.")[0];
             logger.debug("Just the time component is " + justtheTimeComponent);
             String[] timecomponents = justtheTimeComponent.split("_");

--- a/src/main/edu/stanford/slac/archiverappliance/plain/PathNameUtility.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/PathNameUtility.java
@@ -93,14 +93,13 @@ public class PathNameUtility {
             final Instant endts,
             final String extension,
             final PartitionGranularity granularity,
-            final PathResolver pathResolver,
             PVNameToKeyMapping pv2key)
             throws IOException {
         String pvFinalNameComponent = getFinalNameComponent(pvName, pv2key);
 
         ArrayList<Path> retVal = new ArrayList<>();
         try (DirectoryStream<Path> paths =
-                getDirectoryStreamsForPV(archPaths, rootFolder, pvName, extension, pathResolver, pv2key)) {
+                getDirectoryStreamsForPV(archPaths, rootFolder, pvName, extension, pv2key)) {
             for (Path path : paths) {
                 String name = path.getFileName().toString();
                 try {
@@ -168,7 +167,6 @@ public class PathNameUtility {
                 reqEndTime,
                 extension,
                 granularity,
-                pathResolver,
                 pv2key);
     }
 
@@ -194,7 +192,7 @@ public class PathNameUtility {
             throws IOException {
         ArrayList<Path> retval = new ArrayList<>();
         try (DirectoryStream<Path> paths =
-                getDirectoryStreamsForPV(archPaths, rootFolder, pvName, extension, pathResolver, pv2key)) {
+                getDirectoryStreamsForPV(archPaths, rootFolder, pvName, extension, pv2key)) {
             for (Path path : paths) {
                 retval.add(path);
             }
@@ -391,7 +389,6 @@ public class PathNameUtility {
      * @param rootFolder      The root folder for the plugin
      * @param pvName          Name of the PV.
      * @param extension       The file extension.
-     * @param pathResolver    Path Resolver
      * @param pv2key          PVNameToKeyMapping
      * @return DirectoryStream  NIO2 directory stream;
      * @throws IOException &emsp;
@@ -401,7 +398,6 @@ public class PathNameUtility {
             String rootFolder,
             final String pvName,
             final String extension,
-            PathResolver pathResolver,
             PVNameToKeyMapping pv2key)
             throws IOException {
         try {

--- a/src/main/edu/stanford/slac/archiverappliance/plain/PathNameUtility.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/PathNameUtility.java
@@ -98,8 +98,7 @@ public class PathNameUtility {
         String pvFinalNameComponent = getFinalNameComponent(pvName, pv2key);
 
         ArrayList<Path> retVal = new ArrayList<>();
-        try (DirectoryStream<Path> paths =
-                getDirectoryStreamsForPV(archPaths, rootFolder, pvName, extension, pv2key)) {
+        try (DirectoryStream<Path> paths = getDirectoryStreamsForPV(archPaths, rootFolder, pvName, extension, pv2key)) {
             for (Path path : paths) {
                 String name = path.getFileName().toString();
                 try {
@@ -191,8 +190,7 @@ public class PathNameUtility {
             PVNameToKeyMapping pv2key)
             throws IOException {
         ArrayList<Path> retval = new ArrayList<>();
-        try (DirectoryStream<Path> paths =
-                getDirectoryStreamsForPV(archPaths, rootFolder, pvName, extension, pv2key)) {
+        try (DirectoryStream<Path> paths = getDirectoryStreamsForPV(archPaths, rootFolder, pvName, extension, pv2key)) {
             for (Path path : paths) {
                 retval.add(path);
             }
@@ -394,11 +392,7 @@ public class PathNameUtility {
      * @throws IOException &emsp;
      */
     private static DirectoryStream<Path> getDirectoryStreamsForPV(
-            ArchPaths paths,
-            String rootFolder,
-            final String pvName,
-            final String extension,
-            PVNameToKeyMapping pv2key)
+            ArchPaths paths, String rootFolder, final String pvName, final String extension, PVNameToKeyMapping pv2key)
             throws IOException {
         try {
             PVPath pvPath = new PVPath(rootFolder, pv2key.convertPVNameToKey(pvName), null, null);

--- a/src/main/edu/stanford/slac/archiverappliance/plain/PathResolver.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/PathResolver.java
@@ -1,14 +1,13 @@
 package edu.stanford.slac.archiverappliance.plain;
 
 import org.epics.archiverappliance.utils.nio.ArchPaths;
+import org.epics.archiverappliance.utils.nio.PVPath;
 
 import java.io.IOException;
 import java.nio.file.Path;
 
 public interface PathResolver {
-    PathResolver BASE_PATH_RESOLVER = (paths, createParentFolder, rootFolder, pvComponent, pvKey) ->
-            paths.get(createParentFolder, rootFolder, pvComponent);
+    PathResolver BASE_PATH_RESOLVER = (paths, createParentFolder, pvPath) -> paths.get(pvPath, createParentFolder);
 
-    Path get(ArchPaths paths, boolean createParentFolder, String rootFolder, String pvPathComponent, String pvKey)
-            throws IOException;
+    Path get(ArchPaths paths, boolean createParentFolder, PVPath pvPath) throws IOException;
 }

--- a/src/main/edu/stanford/slac/archiverappliance/plain/PlainFileHandler.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/PlainFileHandler.java
@@ -65,7 +65,7 @@ public interface PlainFileHandler extends PlainStreams {
                 PathNameUtility.getAllPathsForPV(context.getPaths(), rootFolder, pvName, suffix, pathResolver, pv2key);
         for (Path path : paths) {
             Path destPath = path.resolveSibling(
-                    path.getName(path.getNameCount() - 1).toString().replace(randSuffix, ""));
+                    path.getFileName().toString().replace(randSuffix, ""));
             logger.debug("Moving path " + path + " to " + destPath);
             Files.move(path, destPath, StandardCopyOption.ATOMIC_MOVE);
         }

--- a/src/main/edu/stanford/slac/archiverappliance/plain/PlainFileHandler.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/PlainFileHandler.java
@@ -64,8 +64,7 @@ public interface PlainFileHandler extends PlainStreams {
         Path[] paths =
                 PathNameUtility.getAllPathsForPV(context.getPaths(), rootFolder, pvName, suffix, pathResolver, pv2key);
         for (Path path : paths) {
-            Path destPath = path.resolveSibling(
-                    path.getFileName().toString().replace(randSuffix, ""));
+            Path destPath = path.resolveSibling(path.getFileName().toString().replace(randSuffix, ""));
             logger.debug("Moving path " + path + " to " + destPath);
             Files.move(path, destPath, StandardCopyOption.ATOMIC_MOVE);
         }

--- a/src/main/edu/stanford/slac/archiverappliance/plain/PlainFileHandler.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/PlainFileHandler.java
@@ -64,7 +64,8 @@ public interface PlainFileHandler extends PlainStreams {
         Path[] paths =
                 PathNameUtility.getAllPathsForPV(context.getPaths(), rootFolder, pvName, suffix, pathResolver, pv2key);
         for (Path path : paths) {
-            Path destPath = context.getPaths().get(path.toString().replace(randSuffix, ""));
+            Path destPath = path.resolveSibling(
+                    path.getName(path.getNameCount() - 1).toString().replace(randSuffix, ""));
             logger.debug("Moving path " + path + " to " + destPath);
             Files.move(path, destPath, StandardCopyOption.ATOMIC_MOVE);
         }

--- a/src/main/edu/stanford/slac/archiverappliance/plain/PlainStoragePlugin.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/PlainStoragePlugin.java
@@ -1041,7 +1041,7 @@ public class PlainStoragePlugin implements StoragePlugin, ETLSource, ETLDest, St
                 logger.debug(desc + " Found " + appendDataPaths.length + " matching files for pv " + pvName);
 
             for (Path srcPath : appendDataPaths) {
-                Path destPath = srcPath.resolveSibling(srcPath.getName(srcPath.getNameCount() - 1)
+                Path destPath = srcPath.resolveSibling(srcPath.getFileName()
                         .toString()
                         .replace(appendExtension, plainFileHandler.getExtensionString()));
                 Files.move(srcPath, destPath, REPLACE_EXISTING, ATOMIC_MOVE);
@@ -1193,7 +1193,7 @@ public class PlainStoragePlugin implements StoragePlugin, ETLSource, ETLDest, St
 
         LinkedList<PPMissingPaths> ret = new LinkedList<PPMissingPaths>();
         for (Path rawPath : rawPaths) {
-            Path expectedPPPath = rawPath.resolveSibling(rawPath.getName(rawPath.getNameCount() - 1)
+            Path expectedPPPath = rawPath.resolveSibling(rawPath.getFileName()
                     .toString()
                     .replace(plainFileHandler.getExtensionString(), ppExt));
             if (!ppPathsMap.containsKey(expectedPPPath)) {

--- a/src/main/edu/stanford/slac/archiverappliance/plain/PlainStoragePlugin.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/PlainStoragePlugin.java
@@ -281,7 +281,6 @@ public class PlainStoragePlugin implements StoragePlugin, ETLSource, ETLDest, St
                         endTime,
                         this.plainFileHandler.getExtensionString(),
                         partitionGranularity,
-                        this.getPathResolver(),
                         this.pv2key);
             } else {
                 paths = PathNameUtility.getPathsWithData(
@@ -292,7 +291,6 @@ public class PlainStoragePlugin implements StoragePlugin, ETLSource, ETLDest, St
                         endTime,
                         extension,
                         partitionGranularity,
-                        this.getPathResolver(),
                         this.pv2key);
                 if (paths.length == 0) {
                     logger.info("Did not find any cached entries for " + pvName + " for post processor " + extension
@@ -306,7 +304,6 @@ public class PlainStoragePlugin implements StoragePlugin, ETLSource, ETLDest, St
                             endTime,
                             plainFileHandler.getExtensionString(),
                             partitionGranularity,
-                            this.getPathResolver(),
                             this.pv2key);
                 } else {
                     logger.info("Found " + paths.length + " cached entries for " + pvName + " for post processor "
@@ -434,7 +431,6 @@ public class PlainStoragePlugin implements StoragePlugin, ETLSource, ETLDest, St
                 eTime,
                 getExtensionString(),
                 partitionGranularity,
-                this.getPathResolver(),
                 pv2key);
         if (paths == null) return null;
         List<Path> pathList = Arrays.asList(paths);

--- a/src/main/edu/stanford/slac/archiverappliance/plain/PlainStoragePlugin.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/PlainStoragePlugin.java
@@ -1193,9 +1193,8 @@ public class PlainStoragePlugin implements StoragePlugin, ETLSource, ETLDest, St
 
         LinkedList<PPMissingPaths> ret = new LinkedList<PPMissingPaths>();
         for (Path rawPath : rawPaths) {
-            Path expectedPPPath = rawPath.resolveSibling(rawPath.getFileName()
-                    .toString()
-                    .replace(plainFileHandler.getExtensionString(), ppExt));
+            Path expectedPPPath = rawPath.resolveSibling(
+                    rawPath.getFileName().toString().replace(plainFileHandler.getExtensionString(), ppExt));
             if (!ppPathsMap.containsKey(expectedPPPath)) {
                 if (logger.isDebugEnabled()) logger.debug("Missing pp path " + expectedPPPath);
                 ret.add(new PPMissingPaths(rawPath, expectedPPPath));

--- a/src/main/edu/stanford/slac/archiverappliance/plain/PlainStoragePlugin.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/PlainStoragePlugin.java
@@ -44,6 +44,7 @@ import org.epics.archiverappliance.retrieval.postprocessors.PostProcessor;
 import org.epics.archiverappliance.retrieval.postprocessors.PostProcessorWithConsolidatedEventStream;
 import org.epics.archiverappliance.retrieval.postprocessors.PostProcessors;
 import org.epics.archiverappliance.utils.nio.ArchPaths;
+import org.epics.archiverappliance.utils.nio.PVPath;
 import org.epics.archiverappliance.utils.ui.URIUtils;
 
 import java.io.IOException;
@@ -703,14 +704,9 @@ public class PlainStoragePlugin implements StoragePlugin, ETLSource, ETLDest, St
         logger.debug("Setting root folder to " + rootFolder);
         try (ArchPaths paths = new ArchPaths()) {
             String rootFolderPath = plainFileHandler.rootFolderPath(this.rootFolder);
-            Path path = paths.get(rootFolderPath);
-            if (!Files.exists(path)) {
-                logger.warn(desc + ": The root folder specified does not exist - " + rootFolder + ". Creating it");
-                Files.createDirectories(path);
-                return;
-            }
-
-            if (!Files.isDirectory(path)) {
+            PVPath pvPath = PVPath.fromRootFolder(rootFolderPath);
+            Path parentPath = paths.get(pvPath, true);
+            if (!Files.isDirectory(parentPath)) {
                 logger.error(desc + ": The root folder specified is not a directory - " + rootFolder);
                 return;
             }
@@ -813,11 +809,10 @@ public class PlainStoragePlugin implements StoragePlugin, ETLSource, ETLDest, St
 
                 FileInfo fileinfo = fileInfo(path);
                 // To make sure deletion later knows the files are in the zip file system
-                String pathKey = this.plainFileHandler.getPathKey(path);
                 ETLInfo etlInfo = new ETLInfo(
                         pvName,
                         fileinfo.getType(),
-                        pathKey,
+                        path,
                         partitionGranularity,
                         new PlainETLStreamCreator(pvName, path, fileinfo, plainFileHandler),
                         fileinfo.getFirstEvent(),
@@ -910,11 +905,10 @@ public class PlainStoragePlugin implements StoragePlugin, ETLSource, ETLDest, St
 
                 FileInfo fileinfo = plainFileHandler.fileInfo(path);
                 // To make sure deletion later knows the files are in the zip file system
-                String pathKey = this.plainFileHandler.getPathKey(path);
                 ETLInfo etlInfo = new ETLInfo(
                         pvName,
                         fileinfo.getType(),
-                        pathKey,
+                        path,
                         partitionGranularity,
                         new PlainETLStreamCreator(pvName, path, fileinfo, plainFileHandler),
                         fileinfo.getFirstEvent(),
@@ -934,7 +928,7 @@ public class PlainStoragePlugin implements StoragePlugin, ETLSource, ETLDest, St
     @Override
     public void markForDeletion(ETLInfo info, ETLContext context) {
         try {
-            Path path = context.getPaths().get(info.getKey());
+            Path path = info.getKey();
             this.plainFileHandler.markForDeletion(path);
             long size = Files.size(path);
             long sizeFromInfo = info.getSize();
@@ -1051,10 +1045,9 @@ public class PlainStoragePlugin implements StoragePlugin, ETLSource, ETLDest, St
                 logger.debug(desc + " Found " + appendDataPaths.length + " matching files for pv " + pvName);
 
             for (Path srcPath : appendDataPaths) {
-                Path destPath = context.getPaths()
-                        .get(srcPath.toUri()
-                                .toString()
-                                .replace(appendExtension, plainFileHandler.getExtensionString()));
+                Path destPath = srcPath.resolveSibling(srcPath.getName(srcPath.getNameCount() - 1)
+                        .toString()
+                        .replace(appendExtension, plainFileHandler.getExtensionString()));
                 Files.move(srcPath, destPath, REPLACE_EXISTING, ATOMIC_MOVE);
             }
         }
@@ -1204,10 +1197,12 @@ public class PlainStoragePlugin implements StoragePlugin, ETLSource, ETLDest, St
 
         LinkedList<PPMissingPaths> ret = new LinkedList<PPMissingPaths>();
         for (Path rawPath : rawPaths) {
-            String expectedPPPath = rawPath.toUri().toString().replace(plainFileHandler.getExtensionString(), ppExt);
+            Path expectedPPPath = rawPath.resolveSibling(rawPath.getName(rawPath.getNameCount() - 1)
+                    .toString()
+                    .replace(plainFileHandler.getExtensionString(), ppExt));
             if (!ppPathsMap.containsKey(expectedPPPath)) {
                 if (logger.isDebugEnabled()) logger.debug("Missing pp path " + expectedPPPath);
-                ret.add(new PPMissingPaths(rawPath, context.getPaths().get(expectedPPPath)));
+                ret.add(new PPMissingPaths(rawPath, expectedPPPath));
             } else {
                 if (logger.isDebugEnabled()) logger.debug("pp path " + expectedPPPath + " already present");
                 Path actualPPPath = ppPathsMap.get(expectedPPPath);
@@ -1217,7 +1212,7 @@ public class PlainStoragePlugin implements StoragePlugin, ETLSource, ETLDest, St
                     logger.debug("Modification time of src " + rawPathTime + " and of pp file " + ppPathTime);
                 if (rawPathTime.compareTo(ppPathTime) > 0) {
                     logger.debug("Raw file is newer than PP file for " + expectedPPPath);
-                    ret.add(new PPMissingPaths(rawPath, context.getPaths().get(expectedPPPath)));
+                    ret.add(new PPMissingPaths(rawPath, expectedPPPath));
                 }
             }
         }

--- a/src/main/org/epics/archiverappliance/etl/ETLInfo.java
+++ b/src/main/org/epics/archiverappliance/etl/ETLInfo.java
@@ -7,13 +7,14 @@
  *******************************************************************************/
 package org.epics.archiverappliance.etl;
 
-import java.io.IOException;
-import java.util.HashMap;
-
 import org.epics.archiverappliance.Event;
 import org.epics.archiverappliance.EventStream;
 import org.epics.archiverappliance.common.PartitionGranularity;
 import org.epics.archiverappliance.config.ArchDBRTypes;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
 
 /**
  * A POJO that encapsulates all the information needed about a stream from an ETL source
@@ -21,59 +22,73 @@ import org.epics.archiverappliance.config.ArchDBRTypes;
  *
  */
 public class ETLInfo {
-	private String pvName;
-	private String key;
-	private Event firstEvent;
-	private PartitionGranularity granularity;
-	private ETLStreamCreator strmCreator;
-	private ArchDBRTypes type;
-	private long size = -1;
-	private HashMap<String, String> otherInfo = new HashMap<String, String>();
-	
-	public ETLInfo(String pvName, ArchDBRTypes type, String key, PartitionGranularity granularity, ETLStreamCreator strmCreator, Event firstEvent, long size) {
-		this.pvName = pvName;
-		this.type = type;
-		this.key = key;
-		this.granularity = granularity;
-		this.strmCreator = strmCreator;
-		this.firstEvent = firstEvent;
-		this.size = size;
-	}
-	public ArchDBRTypes getType() {
-		return type;
-	}
-	public String getPvName() {
-		return pvName;
-	}
-	public String getKey() {
-		return key;
-	}
-	public PartitionGranularity getGranularity() {
-		return granularity;
-	}
-	public EventStream getEv() throws IOException {
-		return strmCreator.getStream();
-	}
-	public Event getFirstEvent() {
-		return firstEvent;
-	}
-	
-	
-	public void addOtherInfo(String name, String value) { 
-		otherInfo.put(name, value);
-	}
-	
-	public String getOtherInfo(String name){ 
-		return otherInfo.get(name);
-	}
-	public long getSize() {
-		return size;
-	}
-	
-	public ETLStreamCreator getStrmCreator() {
-		return strmCreator;
-	}
-	public void setStrmCreator(ETLStreamCreator strmCreator) {
-		this.strmCreator = strmCreator;
-	}
+    private String pvName;
+    private Path key;
+    private Event firstEvent;
+    private PartitionGranularity granularity;
+    private ETLStreamCreator strmCreator;
+    private ArchDBRTypes type;
+    private long size = -1;
+    private HashMap<String, String> otherInfo = new HashMap<String, String>();
+
+    public ETLInfo(
+            String pvName,
+            ArchDBRTypes type,
+            Path key,
+            PartitionGranularity granularity,
+            ETLStreamCreator strmCreator,
+            Event firstEvent,
+            long size) {
+        this.pvName = pvName;
+        this.type = type;
+        this.key = key;
+        this.granularity = granularity;
+        this.strmCreator = strmCreator;
+        this.firstEvent = firstEvent;
+        this.size = size;
+    }
+
+    public ArchDBRTypes getType() {
+        return type;
+    }
+
+    public String getPvName() {
+        return pvName;
+    }
+
+    public Path getKey() {
+        return key;
+    }
+
+    public PartitionGranularity getGranularity() {
+        return granularity;
+    }
+
+    public EventStream getEv() throws IOException {
+        return strmCreator.getStream();
+    }
+
+    public Event getFirstEvent() {
+        return firstEvent;
+    }
+
+    public void addOtherInfo(String name, String value) {
+        otherInfo.put(name, value);
+    }
+
+    public String getOtherInfo(String name) {
+        return otherInfo.get(name);
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public ETLStreamCreator getStrmCreator() {
+        return strmCreator;
+    }
+
+    public void setStrmCreator(ETLStreamCreator strmCreator) {
+        this.strmCreator = strmCreator;
+    }
 }

--- a/src/main/org/epics/archiverappliance/etl/common/DefaultETLInfoListProcessor.java
+++ b/src/main/org/epics/archiverappliance/etl/common/DefaultETLInfoListProcessor.java
@@ -37,7 +37,8 @@ public class DefaultETLInfoListProcessor extends ETLInfoListProcessor {
             long checkSzStart = System.currentTimeMillis();
             long sizeOfSrcStream = infoItem.getSize();
             totalSrcBytes += sizeOfSrcStream;
-            if (notEnoughFreeSpace(sizeOfSrcStream, curETLDest, etlStage, infoItem.getKey(), pvName)) {
+            if (notEnoughFreeSpace(
+                    sizeOfSrcStream, curETLDest, etlStage, infoItem.getKey().toString(), pvName)) {
                 if (deleteSrcStreamWhenOutOfSpace(
                         List.of(infoItem), etlStage.getOutOfSpaceHandling(), movedList, etlStage, pvName)) {
                     continue;
@@ -55,7 +56,7 @@ public class DefaultETLInfoListProcessor extends ETLInfoListProcessor {
                 boolean status = this.curETLDest.appendToETLAppendData(pvName, stream, etlContext);
                 movedList.add(infoItem);
                 time4appendToETLAppendData = time4appendToETLAppendData + System.currentTimeMillis() - time3;
-                checkAppendStatus(pvName, status, infoItem.getKey(), infoItem.getGranularity());
+                checkAppendStatus(pvName, status, infoItem.getKey().toString(), infoItem.getGranularity());
             } catch (IOException ex) {
                 // TODO What do we do in the case of exceptions? Do we remove the source still? Do we stop the
                 // engine from recording this PV?

--- a/src/main/org/epics/archiverappliance/etl/common/ETLMetricsIntoStore.java
+++ b/src/main/org/epics/archiverappliance/etl/common/ETLMetricsIntoStore.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.Logger;
 import org.epics.archiverappliance.common.TimeUtils;
 import org.epics.archiverappliance.etl.StorageMetricsContext;
 import org.epics.archiverappliance.utils.nio.ArchPaths;
+import org.epics.archiverappliance.utils.nio.PVPath;
 
 import java.io.IOException;
 import java.nio.file.FileStore;
@@ -58,7 +59,7 @@ public class ETLMetricsIntoStore implements StorageMetricsContext {
                 .build(new CacheLoader<String, FileStoreSpace>() {
                     public FileStoreSpace load(@NotNull String rootFolder) throws IOException {
                         try (ArchPaths paths = new ArchPaths()) {
-                            Path rootF = paths.get(rootFolder);
+                            Path rootF = paths.get(PVPath.fromRootFolder(rootFolder));
                             logger.info("Loading available space from file store for root folder {}", rootFolder);
                             FileStore fileStore = Files.getFileStore(rootF);
                             return new FileStoreSpace(fileStore.getUsableSpace(), fileStore.getTotalSpace());
@@ -196,7 +197,8 @@ public class ETLMetricsIntoStore implements StorageMetricsContext {
     @Override
     public long getUsableSpaceFromCache(String rootFolder) throws IOException {
         try {
-            FileStoreSpace space = this.fileStoreCache.get(rootFolder);
+            PVPath pvPath = PVPath.fromRootFolder(rootFolder);
+            FileStoreSpace space = this.fileStoreCache.get(pvPath.getParentPathForCreation());
             return space.usableSpace;
         } catch (Exception ex) {
             throw new IOException(ex);
@@ -206,7 +208,8 @@ public class ETLMetricsIntoStore implements StorageMetricsContext {
     @Override
     public long getTotalSpaceFromCache(String rootFolder) throws IOException {
         try {
-            FileStoreSpace space = this.fileStoreCache.get(rootFolder);
+            PVPath pvPath = PVPath.fromRootFolder(rootFolder);
+            FileStoreSpace space = this.fileStoreCache.get(pvPath.getParentPathForCreation());
             return space.totalSpace;
         } catch (Exception ex) {
             throw new IOException(ex);

--- a/src/main/org/epics/archiverappliance/utils/nio/ArchPaths.java
+++ b/src/main/org/epics/archiverappliance/utils/nio/ArchPaths.java
@@ -6,11 +6,8 @@ import org.apache.logging.log4j.Logger;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.*;
-import java.nio.file.spi.FileSystemProvider;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -27,8 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ArchPaths implements Closeable {
     public static final String ZIP_PREFIX = "jar:file://";
     private static final Logger logger = LogManager.getLogger(ArchPaths.class.getName());
-    private static final FileSystemProvider zipFSProvider = getZipFSProvider();
-    private final ConcurrentHashMap<String, FileSystem> fileSystemList = new ConcurrentHashMap<String, FileSystem>();
+    private final ConcurrentHashMap<URI, FileSystem> fileSystemList = new ConcurrentHashMap<URI, FileSystem>();
 
     /**
      * Returns a seekable byte channel.
@@ -41,190 +37,78 @@ public class ArchPaths implements Closeable {
      * @throws IOException &emsp;
      */
     public static SeekableByteChannel newByteChannel(Path path, OpenOption... options) throws IOException {
-        String pathURI = path.toUri().toString();
-        if (pathURI.startsWith(ZIP_PREFIX)) {
+        String scheme = path.toUri().getScheme();
+        if (scheme != null && PVPath.SCHEME_TO_PACKFILE_EXTENSION.containsKey(scheme)) {
             return new WrappedSeekableByteChannel(path);
         } else {
             return Files.newByteChannel(path, options);
         }
     }
 
-    private static FileSystemProvider getZipFSProvider() {
-        for (FileSystemProvider provider : FileSystemProvider.installedProviders()) {
-            if ("jar".equals(provider.getScheme())) return provider;
+    public Path get(PVPath pvPath) throws IOException {
+        return this.get(pvPath, false);
+    }
+
+    public Path get(PVPath pvPath, boolean createParentFolder) throws IOException {
+        if (pvPath.shouldWeCreateParentFolder() && createParentFolder) {
+            Path parentPath = Paths.get(pvPath.getParentPathForCreation());
+            if (logger.isDebugEnabled()) logger.debug("Creating parent folder " + parentPath);
+            if (Files.notExists(parentPath)) {
+                Files.createDirectories(parentPath);
+            }
         }
-        logger.fatal("For some reason we do not have the zip file system provider on this JVM.");
-        return null;
-    }
 
-    /**
-     * Return a path based on a varargs list of path components.
-     * Each path component is separated by the file separator.
-     *
-     * @param first &emsp;
-     * @param more  &emsp;
-     * @return Path  &emsp;
-     * @throws IOException &emsp;
-     */
-    public Path get(String first, String... more) throws IOException {
-        return get(false, first, more);
-    }
+        if (pvPath.isPlainFile()) {
+            logger.debug("Returning plain file path " + pvPath.getFullPath());
+            return Paths.get(pvPath.getFullPath());
+        }
 
-    /**
-     * Return a path based on a varargs list of path components.
-     * Each path component is separated by the file separator.
-     *
-     * @param createParent If this is true, we create the parent automatically when requesting the path
-     * @param first        &emsp;
-     * @param more         &emsp;
-     * @return Path  &emsp;
-     * @throws IOException &emsp;
-     */
-    public Path get(boolean createParent, String first, String... more) throws IOException {
-        String path;
-        if (more.length == 0) {
-            path = first;
+        if (pvPath.isRootFolderOnly()) {
+            return Paths.get(pvPath.getFullPath());
+        }
+
+        FileSystem fs = null;
+        URI rootURI = pvPath.toRootURI();
+        if (this.fileSystemList.containsKey(rootURI)) {
+            fs = this.fileSystemList.get(rootURI);
         } else {
-            StringBuilder sb = new StringBuilder();
-            sb.append(first);
-            for (String segment : more) {
-                if (!segment.isEmpty()) {
-                    if (!sb.isEmpty() && sb.charAt(sb.length() - 1) != '/') {
-                        sb.append('/');
-                    }
-                    sb.append(segment);
-                }
-            }
-            path = sb.toString();
+            // Should we do a getFileSystem here and it that thread safe?
+            fs = FileSystems.newFileSystem(rootURI, Map.of("create", createParentFolder ? "true" : "false"));
+            this.fileSystemList.put(rootURI, fs);
         }
 
-        return this.get(path, createParent);
+        return fs.getPath(pvPath.getContainedPath());
     }
 
-    /**
-     * @param uriPathOrDefautFilePath &emsp;
-     * @return Path  &emsp;
-     * @throws IOException &emsp;
+    public record GlobSearchParams(Path searchFolder, String globPattern) {}
+
+    /*
+     * For listing the files in a folder, we do a GLOB search in a folder.
+     * The search folder depends on whether this represents a pack file.
      */
-    public Path get(String uriPathOrDefautFilePath) throws IOException {
-        return get(uriPathOrDefautFilePath, false);
-    }
-
-    /**
-     * Return a path based on the full URI representation of the path.
-     *
-     * @param uriPathOrDefautFilePath &emsp;
-     * @param createParent            If this is true, we create the parent automatically when requesting the path
-     * @return Path  &emsp;
-     * @throws IOException &emsp;
-     */
-    public Path get(String uriPathOrDefautFilePath, boolean createParent) throws IOException {
-        if (uriPathOrDefautFilePath.startsWith(ZIP_PREFIX)) {
-            // We are dealing with zip files here.
-            int sep = uriPathOrDefautFilePath.indexOf("!/");
-            if (sep == -1) {
-                int sep2 = uriPathOrDefautFilePath.indexOf(ZIP_PREFIX);
-                if (sep2 != -1) {
-                    String defaultFile = uriPathOrDefautFilePath.substring(sep2 + 11);
-                    return FileSystems.getDefault().getPath(defaultFile);
-                } else {
-
-                    IOException e = new IOException(
-                            "the uri path doesn't include the file path in zip fie. the url path should be like these:"
-                                    + " jar:file:///D:/ziptest/alltext.zip!/SomeTextFile.txt or jar:file:///ziptest/alltext.zip!/SomeTextFile.txt,or jar:file:///ziptest/, but your path is "
-                                    + uriPathOrDefautFilePath);
-                    logger.error(
-                            "the uri path doesn't include the file path in zip fie. the url path should be like these:"
-                                    + " jar:file:///D:/ziptest/alltext.zip!/SomeTextFile.txt or jar:file:///ziptest/alltext.zip!/SomeTextFile.txt,or jar:file:///ziptest/, but your path is "
-                                    + uriPathOrDefautFilePath,
-                            e);
-                    throw e;
-                }
-            }
-            if (logger.isDebugEnabled())
-                logger.debug("Asking for " + uriPathOrDefautFilePath
-                        + (createParent
-                                ? " with and option to create parent folder"
-                                : " without the option to create the parent folder"));
-            String zipPathStr = uriPathOrDefautFilePath.substring(ZIP_PREFIX.length(), sep);
-            if (logger.isDebugEnabled()) logger.debug("The path to the zip file is " + zipPathStr);
-            String innerFilePath = uriPathOrDefautFilePath.substring(sep + 1);
-            if (logger.isDebugEnabled()) logger.debug("The path to the file within the zip file is " + innerFilePath);
-
-            FileSystem zipfs = null;
-            if (fileSystemList.get(zipPathStr) != null) {
-                logger.debug("We already have the zip file open in this context " + zipPathStr);
-                zipfs = fileSystemList.get(zipPathStr);
-            } else {
-                Path zipPath = FileSystems.getDefault().getPath(zipPathStr);
-                if (!Files.exists(zipPath)) {
-                    if (createParent) {
-                        Files.createDirectories(zipPath.getParent());
-                        logger.debug("Creating the zip file.");
-                        Map<String, String> env = new HashMap<>();
-                        env.put("create", "true");
-                        zipfs = zipFSProvider.newFileSystem(zipPath, env);
-                        if (zipfs == null) throw new IOException("Unable to get a new file system from the provider.");
-                        fileSystemList.put(zipPathStr, zipfs);
-                    } else {
-                        throw new NoSuchFileException("The zip file " + zipPathStr
-                                + " does not exist and we do not have the createParent set to true");
-                    }
-                } else {
-                    Map<String, String> env = new HashMap<>();
-                    env.put("create", "false");
-                    zipfs = zipFSProvider.newFileSystem(zipPath, env);
-                    if (zipfs == null) throw new IOException("Unable to get a new file system from the provider.");
-                    fileSystemList.put(zipPathStr, zipfs);
-                }
-            }
-
-            Path pathWithinZipFile = zipfs.getPath(innerFilePath);
-            Path parent = pathWithinZipFile.getParent();
-            if (createParent && parent != null && Files.notExists(parent)) {
-                if (logger.isDebugEnabled()) logger.debug("Creating parent folder " + parent);
-                Files.createDirectories(parent);
-            }
-            return pathWithinZipFile;
-        } else {
-            if (uriPathOrDefautFilePath.contains(":")
-                    && uriPathOrDefautFilePath.indexOf(':') < uriPathOrDefautFilePath.indexOf('/')
-                    && !uriPathOrDefautFilePath.startsWith("file:///")) {
-                try {
-                    URI uri = new URI(uriPathOrDefautFilePath);
-                    FileSystem fs = FileSystems.newFileSystem(
-                            uri, System.getenv(), Thread.currentThread().getContextClassLoader());
-                    Path normalFilePath = fs.getPath(uri.getPath());
-                    Path parent = normalFilePath.getParent();
-                    if (createParent && parent != null && Files.notExists(parent)) {
-                        if (logger.isDebugEnabled()) logger.debug("Creating parent folder " + parent);
-                        Files.createDirectories(parent);
-                    }
-
-                    return normalFilePath;
-                } catch (URISyntaxException ex) {
-                    throw new IOException(ex);
-                }
-
-            } else {
-                // We are dealing with normal file system paths.
-                Path normalFilePath = FileSystems.getDefault().getPath(uriPathOrDefautFilePath);
-                Path parent = normalFilePath.getParent();
-                if (createParent && parent != null && Files.notExists(parent)) {
-                    if (logger.isDebugEnabled()) logger.debug("Creating parent folder " + parent);
-                    Files.createDirectories(parent);
-                }
-
-                return normalFilePath;
-            }
+    public GlobSearchParams getGlobSearchParams(PVPath pvPath, String extension) throws IOException {
+        if (pvPath.getChunkKey() == null) {
+            throw new IllegalStateException("chunkKey is required to determine glob search params");
         }
+        String noterm = pvPath.getChunkKey().substring(0, pvPath.getChunkKey().length() - 1);
+        String terminator = pvPath.getChunkKey().substring(pvPath.getChunkKey().length() - 1);
+        Path notermPath = Path.of(noterm);
+        if (!pvPath.isPackFile()) {
+            Path par = notermPath.getParent();
+            return new GlobSearchParams(
+                    Path.of(pvPath.getRootFolder(), par != null ? par.toString() : ""),
+                    notermPath.getFileName().toString() + terminator + "*" + extension);
+        }
+        Path cPath = this.get(new PVPath(pvPath.getRootFolder(), pvPath.getChunkKey(), null, null));
+        return new GlobSearchParams(cPath, notermPath.getFileName().toString() + terminator + "*" + extension);
     }
 
     @Override
     public void close() throws IOException {
-        for (String key : fileSystemList.keySet()) {
-            if (logger.isDebugEnabled()) logger.debug("Closing file system for " + key);
-            fileSystemList.get(key).close();
+        for (Map.Entry<URI, FileSystem> entry : fileSystemList.entrySet()) {
+            if (logger.isDebugEnabled())
+                logger.debug("Closing file system for " + entry.getKey().toString());
+            entry.getValue().close();
         }
     }
 }

--- a/src/main/org/epics/archiverappliance/utils/nio/PVPath.java
+++ b/src/main/org/epics/archiverappliance/utils/nio/PVPath.java
@@ -1,0 +1,287 @@
+package org.epics.archiverappliance.utils.nio;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Map;
+
+/*
+ * Encapsulates the various distinct components of a Parquet/PB file in EAA.
+ */
+
+public class PVPath {
+    private final String rootFolder;
+    /* Per convertPVNameToKey, the chunkKey here includes the terminator character */
+    private final String chunkKey;
+    private final char terminator;
+    /* The portion of the path that corresponds to the partition granularity */
+    private final String partitionName;
+    /* The file extension, including the dot (e.g., ".parquet") */
+    private final String extension;
+    /* Derived attributes */
+    /* Does this start with a *scheme*://. Note paths that start with file:// are also considered NIO2 paths */
+    private final boolean isPackFile;
+    /* The NIO2 scheme for this path */
+    private final String scheme;
+    /* This path specifies the root folder only. Primarily used to indicate that we do not expect a chunk key etc for this path */
+    private final boolean rootFolderOnly;
+
+    public static final Map<String, String> SCHEME_TO_PACKFILE_EXTENSION = Map.of(
+            "zip", ".zip",
+            "jar", ".zip",
+            "tar", ".tar",
+            "gztar", ".tar");
+
+    public PVPath(String rootFolder, String chunkKey, String partitionName, String extension, boolean rootFolderOnly) {
+        this.rootFolder = rootFolder;
+        this.chunkKey = chunkKey;
+        this.terminator = chunkKey != null && !chunkKey.isEmpty() ? chunkKey.charAt(chunkKey.length() - 1) : 0;
+        this.partitionName = partitionName;
+        this.extension = extension;
+        this.rootFolderOnly = rootFolderOnly;
+        if (rootFolder.contains(":/")) {
+            this.scheme = rootFolder.substring(0, rootFolder.indexOf(":/")).substring(0, rootFolder.indexOf(":"));
+            this.isPackFile = SCHEME_TO_PACKFILE_EXTENSION.containsKey(this.scheme);
+        } else {
+            this.scheme = null; // Should this be "file"?
+            this.isPackFile = false;
+        }
+    }
+
+    public static PVPath fromRootFolder(String rootFolder) {
+        return new PVPath(rootFolder, null, null, null, true);
+    }
+
+    public PVPath(String rootFolder, String chunkKey) {
+        this(rootFolder, chunkKey, null, null, false);
+    }
+
+    public PVPath(String rootFolder, String chunkKey, String partitionName, String extension) {
+        this(rootFolder, chunkKey, partitionName, extension, false);
+    }
+
+    public String getRootFolder() {
+        return rootFolder;
+    }
+
+    public String getChunkKey() {
+        return chunkKey;
+    }
+
+    public String getPartitionName() {
+        return partitionName;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public boolean isPackFile() {
+        return isPackFile;
+    }
+
+    public boolean isNIO2Path() {
+        return this.scheme != null;
+    }
+
+    public boolean isPlainFile() {
+        return !this.isPackFile && (this.scheme == null || this.scheme.equals("file"));
+    }
+
+    public boolean shouldWeCreateParentFolder() {
+        return (this.scheme == null
+                || this.scheme.equals("file")
+                || (this.scheme != null && SCHEME_TO_PACKFILE_EXTENSION.containsKey(this.scheme)));
+    }
+
+    public boolean isRootFolderOnly() {
+        return rootFolderOnly;
+    }
+
+    public String getFullPath() {
+        StringBuilder fullPath = new StringBuilder(rootFolder);
+        if (chunkKey != null) {
+            if (!rootFolder.endsWith("/")) {
+                fullPath.append("/");
+            }
+            if (this.isPackFile) {
+                fullPath.append(chunkKey.substring(0, chunkKey.length() - 1));
+                fullPath.append(SCHEME_TO_PACKFILE_EXTENSION.get(this.scheme));
+            } else {
+                fullPath.append(chunkKey);
+            }
+        }
+        if (partitionName != null) {
+            if (this.isPackFile) {
+                fullPath.append("!/");
+                if (chunkKey != null) {
+                    Path ckPath = Path.of(chunkKey);
+                    Path finalComponent = ckPath.getFileName();
+                    fullPath.append(finalComponent);
+                }
+            }
+            fullPath.append(partitionName);
+        }
+        if (extension != null) {
+            fullPath.append(extension);
+        }
+        return fullPath.toString();
+    }
+
+    public URI toURI() {
+        return URI.create(this.getFullPath());
+    }
+
+    /*
+     * This can be used as the key in any cache of FileSystem objects.
+     */
+    public URI toRootURI() {
+        if (this.isPlainFile()) {
+            return URI.create(this.rootFolder);
+        }
+        if (this.isNIO2Path() && !this.isPackFile) {
+            return URI.create(this.rootFolder);
+        }
+
+        StringBuilder rootURI = new StringBuilder();
+        rootURI.append(rootFolder.substring(0, rootFolder.indexOf("://") + 3));
+        rootURI.append(this.getContainerPath());
+        return URI.create(rootURI.toString());
+    }
+
+    public String getParentPathForCreation() {
+        StringBuilder parentPath = new StringBuilder();
+        if (this.isPackFile) {
+            parentPath.append(rootFolder.substring(rootFolder.indexOf("://") + 3));
+        } else {
+            parentPath.append(rootFolder);
+        }
+        if (chunkKey != null) {
+            if (chunkKey.contains("/")) {
+                if (!rootFolder.endsWith("/")) {
+                    parentPath.append("/");
+                }
+                parentPath.append(chunkKey, 0, chunkKey.lastIndexOf("/"));
+            }
+        }
+        return parentPath.toString();
+    }
+
+    /*
+     * Return the name of a NIO2 container file.
+     * For example, for jar:file:/scratch/zipfiles/flot-0.7.zip!/FAQ.txt, we'd return /scratch/zipfiles/flot-0.7.zip
+     */
+    public String getContainerPath() {
+        if (!this.isPackFile) {
+            throw new UnsupportedOperationException("getContainerPath is only supported for NIO2 paths");
+        }
+        if (chunkKey == null) {
+            throw new IllegalStateException("chunkKey is required to determine container path");
+        }
+        StringBuilder containerPath = new StringBuilder(rootFolder.substring(rootFolder.indexOf("://") + 3));
+        if (!rootFolder.endsWith("/")) {
+            containerPath.append("/");
+        }
+        containerPath.append(chunkKey.substring(0, chunkKey.length() - 1));
+        containerPath.append(SCHEME_TO_PACKFILE_EXTENSION.get(this.scheme));
+        return containerPath.toString();
+    }
+
+    /*
+     * Return the name of a the file within the NIO2 container.
+     * For example, for jar:file:/scratch/zipfiles/flot-0.7.zip!/FAQ.txt, we'd return /FAQ.txt
+     * For non-packed files, this is the part of the path after the root folder
+     */
+    public String getContainedPath() {
+        if (this.isRootFolderOnly()) {
+            return "/";
+        }
+
+        if (!this.isPackFile()) {
+            StringBuilder containedPath = new StringBuilder();
+            if (chunkKey != null) {
+                if (!chunkKey.startsWith("/")) {
+                    containedPath.append("/");
+                }
+                containedPath.append(chunkKey);
+            }
+            if (partitionName != null) {
+                containedPath.append(partitionName);
+            }
+            if (extension != null) {
+                containedPath.append(extension);
+            }
+            return containedPath.toString();
+        }
+
+        if (this.partitionName == null) {
+            return "/";
+        }
+
+        StringBuilder containedPath = new StringBuilder();
+        if (!partitionName.startsWith("/")) {
+            containedPath.append("/");
+        }
+        if (chunkKey != null) {
+            Path ckPath = Path.of(chunkKey);
+            Path finalComponent = ckPath.getFileName();
+            containedPath.append(finalComponent);
+        }
+        containedPath.append(partitionName);
+        if (extension != null) {
+            containedPath.append(extension);
+        }
+        return containedPath.toString();
+    }
+
+    public static PVPath fromPath(String pathStr, String chunkKey) {
+        boolean isNIO2Path = pathStr.contains(":/");
+        String chunkKeyWithoutTerminator = isNIO2Path ? chunkKey.substring(0, chunkKey.length() - 1) : chunkKey;
+        String rootFolder = pathStr.substring(0, pathStr.indexOf(chunkKeyWithoutTerminator));
+        String extension = null;
+        String partitionName = null;
+        if (isNIO2Path) {
+            if (pathStr.contains("!/")) {
+                String restOfPath = isNIO2Path
+                        ? pathStr.substring(pathStr.lastIndexOf("!/") + 2)
+                        : pathStr.substring(pathStr.indexOf(chunkKey) + chunkKey.length());
+                extension = restOfPath.contains(".") ? restOfPath.substring(restOfPath.lastIndexOf(".")) : null;
+                partitionName = extension != null ? restOfPath.substring(0, restOfPath.indexOf(extension)) : restOfPath;
+            }
+        } else {
+            String restOfPath = pathStr.substring(pathStr.indexOf(chunkKey) + chunkKey.length());
+            extension = restOfPath.contains(".") ? restOfPath.substring(restOfPath.lastIndexOf(".")) : null;
+            partitionName = extension != null ? restOfPath.substring(0, restOfPath.indexOf(extension)) : restOfPath;
+        }
+
+        if (rootFolder.endsWith("/")) {
+            rootFolder = rootFolder.substring(0, rootFolder.length() - 1);
+        }
+        if (partitionName != null && partitionName.isBlank()) {
+            partitionName = null;
+        }
+        return new PVPath(rootFolder, chunkKey, partitionName, extension);
+    }
+
+    public PVPath withNewExtension(String newExtension) {
+        return new PVPath(this.rootFolder, this.chunkKey, this.partitionName, newExtension);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        PVPath other = (PVPath) obj;
+        return rootFolder.equals(other.rootFolder)
+                && ((chunkKey == null && other.chunkKey == null)
+                        || (chunkKey != null && chunkKey.equals(other.chunkKey)))
+                && ((partitionName == null && other.partitionName == null)
+                        || (partitionName != null && partitionName.equals(other.partitionName)))
+                && ((extension == null && other.extension == null)
+                        || (extension != null && extension.equals(other.extension)));
+    }
+
+    @Override
+    public String toString() {
+        return this.getFullPath();
+    }
+}

--- a/src/main/org/epics/archiverappliance/utils/nio/PVPath.java
+++ b/src/main/org/epics/archiverappliance/utils/nio/PVPath.java
@@ -83,6 +83,15 @@ public class PVPath {
         return this.scheme != null;
     }
 
+    public String getScheme() {
+        return scheme;
+    }
+
+    /*
+     * Used by ArchPaths to determine if we need to look up a FileSystem using NIO2
+     * or if this is a plain file on the local filesystem and can be accessed directly without
+     * NIO2 lookup.
+     */
     public boolean isPlainFile() {
         return !this.isPackFile && (this.scheme == null || this.scheme.equals("file"));
     }

--- a/src/test/edu/stanford/slac/archiverappliance/PB/compression/zipfs/ArchPathsTest.java
+++ b/src/test/edu/stanford/slac/archiverappliance/PB/compression/zipfs/ArchPathsTest.java
@@ -1,10 +1,15 @@
 package edu.stanford.slac.archiverappliance.PB.compression.zipfs;
 
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.epics.archiverappliance.common.PartitionGranularity;
+import org.epics.archiverappliance.common.TimeUtils;
 import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.epics.archiverappliance.utils.nio.ArchPaths;
+import org.epics.archiverappliance.utils.nio.PVPath;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,15 +21,16 @@ import java.io.FileOutputStream;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import java.nio.file.Paths;
+import java.time.Instant;
 
 public class ArchPathsTest {
-    private final String rootFolderStr = ConfigServiceForTests.getDefaultPBTestFolder() + "/ArchPathsTest";
+    private static final String zipFolderStr = ConfigServiceForTests.getDefaultPBTestFolder() + "/ArchPathsTest";
     private static final Logger logger = LogManager.getLogger(ArchPathsTest.class.getName());
+    private static final Instant startOfLastYear = TimeUtils.getStartOfYear(TimeUtils.getCurrentYear() - 1);
+    private static final String chunkKey = "ArchUnitTest/sine:";
 
     private static Thread getReaderThread(String zipFileName, Thread writerThread) {
-
         Runnable reader = () -> {
             int exceptionCount = 0;
             boolean checkedAtLeastOnce = false;
@@ -32,11 +38,14 @@ public class ArchPathsTest {
                 if (new File(zipFileName).exists()) {
                     logger.info("Checking concurrent access");
                     try {
-                        for (int filenum = 1; filenum < 100; filenum++) {
-                            try (ArchPaths paths = new ArchPaths()) {
+                        for (int daynum = 1; daynum < 300; daynum++) {
+                            String timeComponent = TimeUtils.getPartitionName(
+                                    startOfLastYear.plusSeconds(daynum * 24 * 60 * 60),
+                                    PartitionGranularity.PARTITION_DAY);
+                            try (ArchPaths arch = new ArchPaths()) {
                                 checkedAtLeastOnce = true;
-                                Path destPath = paths.get(
-                                        "jar:file://" + zipFileName + "!/result/SomeTextFile" + filenum + ".txt");
+                                Path destPath = arch.get(
+                                        new PVPath("jar:file:" + zipFolderStr, chunkKey, timeComponent, ".txt"));
                                 Files.exists(destPath);
                             } catch (Exception ex) {
                                 exceptionCount++;
@@ -54,7 +63,6 @@ public class ArchPathsTest {
             Assertions.assertTrue(checkedAtLeastOnce, "We have not check the reader part even once ");
             Assertions.assertEquals(0, exceptionCount, "The read thread had " + exceptionCount + " exceptions");
         };
-
         Thread readerthread = new Thread(reader);
         readerthread.setName("Reader");
         return readerthread;
@@ -62,13 +70,15 @@ public class ArchPathsTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        File rootFolder = new File(rootFolderStr);
+        File rootFolder = new File(zipFolderStr);
         FileUtils.deleteDirectory(rootFolder);
         assert rootFolder.mkdirs();
         // We create some sample files for testing.
-        for (int filenum = 1; filenum < 100; filenum++) {
-            try (PrintWriter out =
-                    new PrintWriter(new FileOutputStream(rootFolderStr + File.separator + "text" + filenum + ".txt"))) {
+        for (int daynum = 1; daynum < 365; daynum++) {
+            String timeComponent = TimeUtils.getPartitionName(
+                    startOfLastYear.plusSeconds(daynum * 24 * 60 * 60), PartitionGranularity.PARTITION_DAY);
+            Path destPath = Paths.get(rootFolder.getAbsolutePath(), timeComponent + ".txt");
+            try (PrintWriter out = new PrintWriter(new FileOutputStream(destPath.toFile()))) {
                 for (int i = 0; i < 1000; i++) {
                     out.println("Line " + i);
                 }
@@ -78,46 +88,60 @@ public class ArchPathsTest {
 
     @Test
     public void testPack() throws Exception {
-        String zipFileName = rootFolderStr + "/pack.zip";
-        String zipFilePath = "jar:file://" + zipFileName + "!/result/SomeTextFile.txt";
+        File rootFolder = new File(zipFolderStr);
         try (ArchPaths arch = new ArchPaths()) {
-            Path sourcePath = arch.get(rootFolderStr + "/text1.txt");
-            Path destPath = arch.get(zipFilePath, true);
-            Files.copy(sourcePath, destPath, REPLACE_EXISTING);
-        }
+            for (int daynum = 1; daynum < 200; daynum++) {
+                String timeComponent = TimeUtils.getPartitionName(
+                        startOfLastYear.plusSeconds(daynum * 24 * 60 * 60), PartitionGranularity.PARTITION_DAY);
 
-        Assertions.assertTrue(new File(zipFileName).exists(), "Zip file does not exist " + zipFileName);
-
-        try (ArchPaths validateArchPaths = new ArchPaths()) {
-            Assertions.assertTrue(
-                    Files.exists(validateArchPaths.get(zipFilePath)),
-                    "Path does not exist after packing " + zipFilePath);
-        }
-
-        // Now we test adding more files.
-        try (ArchPaths arch = new ArchPaths()) {
-            for (int filenum = 2; filenum < 10; filenum++) {
-                Path sourcePath = arch.get(rootFolderStr + "/text" + filenum + ".txt");
-                Path destPath = arch.get("jar:file://" + zipFileName + "!/result/SomeTextFile" + filenum + ".txt");
-                logger.debug("Packing " + sourcePath.toString() + " into " + destPath.toString());
+                Path sourcePath = Paths.get(rootFolder.getAbsolutePath(), timeComponent + ".txt");
+                Path destPath =
+                        arch.get(new PVPath("jar:file://" + zipFolderStr, chunkKey, timeComponent, ".txt"), true);
                 Files.copy(sourcePath, destPath, REPLACE_EXISTING);
             }
         }
 
+        PVPath zipFilePath = new PVPath("jar:file://" + zipFolderStr, chunkKey);
+        Assertions.assertTrue(
+                new File(zipFilePath.getContainerPath()).exists(),
+                "Zip file does not exist " + zipFilePath.getContainerPath());
+
         try (ArchPaths validateArchPaths = new ArchPaths()) {
-            for (int filenum = 2; filenum < 10; filenum++) {
+            Assertions.assertTrue(
+                    Files.exists(validateArchPaths.get(zipFilePath)),
+                    "Path does not exist after packing " + zipFilePath.getFullPath());
+        }
+
+        // Now we test adding more files.
+        try (ArchPaths arch = new ArchPaths()) {
+            for (int daynum = 200; daynum < 300; daynum++) {
+                String timeComponent = TimeUtils.getPartitionName(
+                        startOfLastYear.plusSeconds(daynum * 24 * 60 * 60), PartitionGranularity.PARTITION_DAY);
+
+                Path sourcePath = Paths.get(rootFolder.getAbsolutePath(), timeComponent + ".txt");
+                Path destPath =
+                        arch.get(new PVPath("jar:file://" + zipFolderStr, chunkKey, timeComponent, ".txt"), true);
+                Files.copy(sourcePath, destPath, REPLACE_EXISTING);
+            }
+        }
+
+        try (ArchPaths arch = new ArchPaths()) {
+            for (int daynum = 1; daynum < 300; daynum++) {
+                String timeComponent = TimeUtils.getPartitionName(
+                        startOfLastYear.plusSeconds(daynum * 24 * 60 * 60), PartitionGranularity.PARTITION_DAY);
+
+                Path destPath = arch.get(new PVPath("jar:file://" + zipFolderStr, chunkKey, timeComponent, ".txt"));
                 Assertions.assertTrue(
-                        Files.exists(validateArchPaths.get(
-                                "jar:file:///" + zipFileName + "!/result/SomeTextFile" + filenum + ".txt")),
-                        "Path does not exist after packing " + zipFilePath);
+                        Files.exists(destPath),
+                        "Path does not exist after packing " + destPath.toString() + " for daynum " + daynum);
             }
         }
     }
 
     @AfterEach
     public void tearDown() throws Exception {
-        FileUtils.cleanDirectory(new File(rootFolderStr));
-        FileUtils.deleteDirectory(new File(rootFolderStr));
+        FileUtils.cleanDirectory(new File(zipFolderStr));
+        FileUtils.deleteDirectory(new File(zipFolderStr));
     }
 
     @Test
@@ -126,16 +150,19 @@ public class ArchPathsTest {
         // Test to see if we can access the zip file concurrently.
         // We launch two threads and see if one can add while the other can read
 
-        final String zipFileName = rootFolderStr + "/concurrpack.zip";
+        final String zipFileName = zipFolderStr + "/concurrpack.zip";
         Runnable writer = () -> {
             int exceptionCount = 0;
+            File rootFolder = new File(zipFolderStr);
             try {
-                for (int filenum = 1; filenum < 100; filenum++) {
-                    try (ArchPaths paths = new ArchPaths()) {
-                        Path sourcePath = paths.get(rootFolderStr + "/text" + filenum + ".txt");
-                        Path destPath = paths.get(
-                                "jar:file://" + zipFileName + "!/result/SomeTextFile" + filenum + ".txt", true);
-                        logger.info("Packing " + sourcePath.toString() + " into " + destPath.toString());
+                for (int daynum = 1; daynum < 200; daynum++) {
+                    try (ArchPaths arch = new ArchPaths()) {
+                        String timeComponent = TimeUtils.getPartitionName(
+                                startOfLastYear.plusSeconds(daynum * 24 * 60 * 60), PartitionGranularity.PARTITION_DAY);
+
+                        Path sourcePath = Paths.get(rootFolder.getAbsolutePath(), timeComponent + ".txt");
+                        Path destPath =
+                                arch.get(new PVPath("jar:file:" + zipFolderStr, chunkKey, timeComponent, ".txt"), true);
                         Files.copy(sourcePath, destPath, REPLACE_EXISTING);
                     } catch (Exception ex) {
                         exceptionCount++;

--- a/src/test/edu/stanford/slac/archiverappliance/plain/PlainPBFileNameUtilityTest.java
+++ b/src/test/edu/stanford/slac/archiverappliance/plain/PlainPBFileNameUtilityTest.java
@@ -138,7 +138,6 @@ public class PlainPBFileNameUtilityTest {
                 startOfYear.plusSeconds(nIntervals * granularity.getApproxSecondsPerChunk() - 1),
                 extension,
                 granularity,
-                PathResolver.BASE_PATH_RESOLVER,
                 configService.getPVNameToKeyConverter());
         Assertions.assertEquals(nIntervals, matchingPaths.length, "File count " + matchingPaths.length);
 
@@ -209,7 +208,6 @@ public class PlainPBFileNameUtilityTest {
                 endYear.minusSeconds(1).toInstant(),
                 extension,
                 partition,
-                PathResolver.BASE_PATH_RESOLVER,
                 configService.getPVNameToKeyConverter());
         Assertions.assertEquals(8, matchingPaths.length, "File count " + matchingPaths.length);
 

--- a/src/test/edu/stanford/slac/archiverappliance/plain/PlainPBFileNameUtilityTest.java
+++ b/src/test/edu/stanford/slac/archiverappliance/plain/PlainPBFileNameUtilityTest.java
@@ -111,6 +111,25 @@ public class PlainPBFileNameUtilityTest {
                     extension));
         }
 
+        {
+            // This really tests that we do not pick files from PV's that could glob match this PV's files.
+            // If we have incorrect GLOB's, we'll see NumberFormatException's as we try to parse the time component of
+            // the file name.
+            String pvNameWithSuffix = pvName + "suffix";
+            for (long nGranularity = 0; nGranularity < nIntervals; nGranularity++) {
+                fileTime = startOfYear.plusSeconds(nGranularity * granularity.getApproxSecondsPerChunk());
+                mkPath(PathNameUtility.getPathNameForTime(
+                        rootFolderStr,
+                        pvNameWithSuffix,
+                        fileTime,
+                        granularity,
+                        new ArchPaths(),
+                        PathResolver.BASE_PATH_RESOLVER,
+                        configService.getPVNameToKeyConverter(),
+                        extension));
+            }
+        }
+
         Path[] matchingPaths = PathNameUtility.getPathsWithData(
                 new ArchPaths(),
                 rootFolderStr,

--- a/src/test/org/epics/archiverappliance/utils/nio/PVPathTest.java
+++ b/src/test/org/epics/archiverappliance/utils/nio/PVPathTest.java
@@ -434,4 +434,31 @@ public class PVPathTest {
                 URI.create("s3:///arch/lts"),
                 new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", null, null).toRootURI());
     }
+
+
+    @Test
+    public void testScheme() {
+        Assertions.assertNull(new PVPath("/arch/lts", "ArchUnitTest/sine:", null, null).getScheme());
+        Assertions.assertEquals("jar", new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", null, null).getScheme());
+        Assertions.assertEquals("jar", new PVPath("jar://arch/lts", "ArchUnitTest/sine:", null, null).getScheme());
+        Assertions.assertEquals("tar", new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", null, null).getScheme());
+        Assertions.assertEquals("tar", new PVPath("tar:s3:///arch/lts", "ArchUnitTest/sine:", null, null).getScheme());
+        Assertions.assertEquals("s3", new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", null, null).getScheme());
+    }
+    
+    @Test
+    public void testIsPlainFile() {
+        Assertions.assertTrue(new PVPath("/arch/lts", "ArchUnitTest/sine:", null, null).isPlainFile());
+        Assertions.assertFalse(new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", null, null).isPlainFile());
+        Assertions.assertFalse(new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", null, null).isPlainFile());
+        Assertions.assertFalse(new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", null, null).isPlainFile());
+    }
+
+    @Test
+    public void testIsPackFile() {
+        Assertions.assertFalse(new PVPath("/arch/lts", "ArchUnitTest/sine:", null, null).isPackFile());
+        Assertions.assertTrue(new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", null, null).isPackFile());
+        Assertions.assertTrue(new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", null, null).isPackFile());
+        Assertions.assertFalse(new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", null, null).isPackFile());
+    }
 }

--- a/src/test/org/epics/archiverappliance/utils/nio/PVPathTest.java
+++ b/src/test/org/epics/archiverappliance/utils/nio/PVPathTest.java
@@ -1,0 +1,437 @@
+package org.epics.archiverappliance.utils.nio;
+
+import org.apache.commons.io.FileUtils;
+import org.epics.archiverappliance.config.ConfigServiceForTests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+
+public class PVPathTest {
+    private final File testFolder =
+            new File(ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "PVPathTest");
+    private final String tPath = testFolder.getAbsolutePath();
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        if (testFolder.exists()) {
+            FileUtils.deleteDirectory(testFolder);
+        }
+        testFolder.mkdirs();
+        new File(tPath + File.separator + "ArchUnitTest").mkdirs();
+
+        {
+            URI uri = URI.create("jar:file://" + tPath + "/ArchUnitTest/sine.zip");
+            try (FileSystem fs = FileSystems.newFileSystem(uri, Map.of("create", "true"))) {
+                for (int i = 0; i < 10; i++) {
+                    Path nf = fs.getPath(i + ".txt");
+                    try (BufferedWriter writer =
+                            Files.newBufferedWriter(nf, StandardCharsets.UTF_8, StandardOpenOption.CREATE)) {
+                        writer.write("This is a test");
+                    }
+                }
+            }
+        }
+        {
+            URI uri = URI.create("jar:file://" + tPath + "/sine.zip");
+            try (FileSystem fs = FileSystems.newFileSystem(uri, Map.of("create", "true"))) {
+                for (int i = 0; i < 10; i++) {
+                    Path nf = fs.getPath(i + ".txt");
+                    try (BufferedWriter writer =
+                            Files.newBufferedWriter(nf, StandardCharsets.UTF_8, StandardOpenOption.CREATE)) {
+                        writer.write("This is a test");
+                    }
+                }
+            }
+        }
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        FileUtils.deleteDirectory(testFolder);
+    }
+
+    @Test
+    public void testFullPath() {
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest/sine:", null, null).getFullPath(),
+                "/arch/lts/ArchUnitTest/sine:");
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest/sine:", "2026_01_01", null).getFullPath(),
+                "/arch/lts/ArchUnitTest/sine:2026_01_01");
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".parquet").getFullPath(),
+                "/arch/lts/ArchUnitTest/sine:2026_01_01.parquet");
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest:", null, null).getFullPath(), "/arch/lts/ArchUnitTest:");
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest:", "2026_01_01", null).getFullPath(),
+                "/arch/lts/ArchUnitTest:2026_01_01");
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest:", "2026_01_01", ".parquet").getFullPath(),
+                "/arch/lts/ArchUnitTest:2026_01_01.parquet");
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb").getFullPath(),
+                "/arch/lts/ArchUnitTest/sine:2026_01_01.pb");
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb.tmpabc").getFullPath(),
+                "/arch/lts/ArchUnitTest/sine:2026_01_01.pb.tmpabc");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", null, null).getFullPath(),
+                "jar:file:///arch/lts/ArchUnitTest/sine.zip");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", null).getFullPath(),
+                "jar:file:///arch/lts/ArchUnitTest/sine.zip!/sine:2026_01_01");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb").getFullPath(),
+                "jar:file:///arch/lts/ArchUnitTest/sine.zip!/sine:2026_01_01.pb");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb.tmpabc").getFullPath(),
+                "jar:file:///arch/lts/ArchUnitTest/sine.zip!/sine:2026_01_01.pb.tmpabc");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest:", null, null).getFullPath(),
+                "jar:file:///arch/lts/ArchUnitTest.zip");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest:", "2026_01_01", null).getFullPath(),
+                "jar:file:///arch/lts/ArchUnitTest.zip!/ArchUnitTest:2026_01_01");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest:", "2026_01_01", ".pb").getFullPath(),
+                "jar:file:///arch/lts/ArchUnitTest.zip!/ArchUnitTest:2026_01_01.pb");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", null, null).getFullPath(),
+                "tar:///arch/lts/ArchUnitTest/sine.tar");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", null).getFullPath(),
+                "tar:///arch/lts/ArchUnitTest/sine.tar!/sine:2026_01_01");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb").getFullPath(),
+                "tar:///arch/lts/ArchUnitTest/sine.tar!/sine:2026_01_01.pb");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb.tmpabc").getFullPath(),
+                "tar:///arch/lts/ArchUnitTest/sine.tar!/sine:2026_01_01.pb.tmpabc");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest:", null, null).getFullPath(),
+                "tar:///arch/lts/ArchUnitTest.tar");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest:", "2026_01_01", null).getFullPath(),
+                "tar:///arch/lts/ArchUnitTest.tar!/ArchUnitTest:2026_01_01");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest:", "2026_01_01", ".pb").getFullPath(),
+                "tar:///arch/lts/ArchUnitTest.tar!/ArchUnitTest:2026_01_01.pb");
+        Assertions.assertEquals(
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", null, null).getFullPath(),
+                "s3:///arch/lts/ArchUnitTest/sine:");
+        Assertions.assertEquals(
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", null).getFullPath(),
+                "s3:///arch/lts/ArchUnitTest/sine:2026_01_01");
+        Assertions.assertEquals(
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb").getFullPath(),
+                "s3:///arch/lts/ArchUnitTest/sine:2026_01_01.pb");
+        Assertions.assertEquals(
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb.tmpabc").getFullPath(),
+                "s3:///arch/lts/ArchUnitTest/sine:2026_01_01.pb.tmpabc");
+        Assertions.assertEquals(
+                new PVPath("s3:///arch/lts", "ArchUnitTest:", null, null).getFullPath(),
+                "s3:///arch/lts/ArchUnitTest:");
+        Assertions.assertEquals(
+                new PVPath("s3:///arch/lts", "ArchUnitTest:", "2026_01_01", null).getFullPath(),
+                "s3:///arch/lts/ArchUnitTest:2026_01_01");
+        Assertions.assertEquals(
+                new PVPath("s3:///arch/lts", "ArchUnitTest:", "2026_01_01", ".pb").getFullPath(),
+                "s3:///arch/lts/ArchUnitTest:2026_01_01.pb");
+    }
+
+    @Test
+    public void testGetParentPathForCreation() {
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest/sine:", null, null).getParentPathForCreation(),
+                "/arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest/sine:", "2026_01_01", null).getParentPathForCreation(),
+                "/arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb").getParentPathForCreation(),
+                "/arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb.tmpabc").getParentPathForCreation(),
+                "/arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest:", null, null).getParentPathForCreation(), "/arch/lts");
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest:", "2026_01_01", null).getParentPathForCreation(), "/arch/lts");
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest:", "2026_01_01", ".pb").getParentPathForCreation(), "/arch/lts");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", null, null).getParentPathForCreation(),
+                "/arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", null).getParentPathForCreation(),
+                "/arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb")
+                        .getParentPathForCreation(),
+                "/arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb.tmpabc")
+                        .getParentPathForCreation(),
+                "/arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest:", null, null).getParentPathForCreation(),
+                "/arch/lts");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest:", "2026_01_01", null).getParentPathForCreation(),
+                "/arch/lts");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest:", "2026_01_01", ".pb").getParentPathForCreation(),
+                "/arch/lts");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", null, null).getParentPathForCreation(),
+                "/arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", null).getParentPathForCreation(),
+                "/arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb").getParentPathForCreation(),
+                "/arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb.tmpabc")
+                        .getParentPathForCreation(),
+                "/arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest:", null, null).getParentPathForCreation(), "/arch/lts");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest:", "2026_01_01", null).getParentPathForCreation(),
+                "/arch/lts");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest:", "2026_01_01", ".pb").getParentPathForCreation(),
+                "/arch/lts");
+        Assertions.assertEquals(
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", null, null).getParentPathForCreation(),
+                "s3:///arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", null).getParentPathForCreation(),
+                "s3:///arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb").getParentPathForCreation(),
+                "s3:///arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb.tmpabc")
+                        .getParentPathForCreation(),
+                "s3:///arch/lts/ArchUnitTest");
+        Assertions.assertEquals(
+                new PVPath("s3:///arch/lts", "ArchUnitTest:", null, null).getParentPathForCreation(), "s3:///arch/lts");
+        Assertions.assertEquals(
+                new PVPath("s3:///arch/lts", "ArchUnitTest:", "2026_01_01", null).getParentPathForCreation(),
+                "s3:///arch/lts");
+        Assertions.assertEquals(
+                new PVPath("s3:///arch/lts", "ArchUnitTest:", "2026_01_01", ".pb").getParentPathForCreation(),
+                "s3:///arch/lts");
+    }
+
+    @Test
+    public void testFromPath() {
+        Assertions.assertEquals(
+                PVPath.fromPath("/arch/lts/ArchUnitTest/sine:2026_01_01.pb", "ArchUnitTest/sine:"),
+                new PVPath("/arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb"));
+        Assertions.assertEquals(
+                PVPath.fromPath("/arch/lts/ArchUnitTest/sine:2026_01_01", "ArchUnitTest/sine:"),
+                new PVPath("/arch/lts", "ArchUnitTest/sine:", "2026_01_01", null));
+        Assertions.assertEquals(
+                PVPath.fromPath("/arch/lts/ArchUnitTest/sine:", "ArchUnitTest/sine:"),
+                new PVPath("/arch/lts", "ArchUnitTest/sine:", null, null));
+        Assertions.assertEquals(
+                PVPath.fromPath("jar:file:///arch/lts/ArchUnitTest/sine.zip!/2026_01_01.pb", "ArchUnitTest/sine:"),
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb"));
+        Assertions.assertEquals(
+                PVPath.fromPath("jar:file:///arch/lts/ArchUnitTest/sine.zip!/2026_01_01", "ArchUnitTest/sine:"),
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", null));
+        Assertions.assertEquals(
+                PVPath.fromPath("jar:file:///arch/lts/ArchUnitTest/sine.zip", "ArchUnitTest/sine:"),
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", null, null));
+        Assertions.assertEquals(
+                PVPath.fromPath("jar:file:///arch/lts/ArchUnitTest/sine.zip!/2026_01_01.pb", "ArchUnitTest/sine:"),
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb"));
+        Assertions.assertEquals(
+                PVPath.fromPath("jar:file:///arch/lts/ArchUnitTest/sine.zip!/2026_01_01", "ArchUnitTest/sine:"),
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", null));
+        Assertions.assertEquals(
+                PVPath.fromPath("jar:file:///arch/lts/ArchUnitTest/sine.zip", "ArchUnitTest/sine:"),
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", null, null));
+        Assertions.assertEquals(
+                PVPath.fromPath("s3:///arch/lts/ArchUnitTest/sine.zip!/2026_01_01.pb", "ArchUnitTest/sine:"),
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb"));
+        Assertions.assertEquals(
+                PVPath.fromPath("s3:///arch/lts/ArchUnitTest/sine.zip!/2026_01_01", "ArchUnitTest/sine:"),
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", null));
+        Assertions.assertEquals(
+                PVPath.fromPath("s3:///arch/lts/ArchUnitTest/sine.zip", "ArchUnitTest/sine:"),
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", null, null));
+        Assertions.assertEquals(
+                PVPath.fromPath("s3:///arch/lts/ArchUnitTest/sine.zip!/2026_01_01.pb", "ArchUnitTest/sine:"),
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb"));
+        Assertions.assertEquals(
+                PVPath.fromPath("s3:///arch/lts/ArchUnitTest/sine.zip!/2026_01_01", "ArchUnitTest/sine:"),
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", null));
+        Assertions.assertEquals(
+                PVPath.fromPath("s3:///arch/lts/ArchUnitTest/sine.zip", "ArchUnitTest/sine:"),
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", null, null));
+    }
+
+    @Test
+    public void testWithNewExtension() {
+        PVPath original = new PVPath("/arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb");
+        PVPath modified = original.withNewExtension(".pb.tmpabc");
+        Assertions.assertEquals("/arch/lts/ArchUnitTest/sine:2026_01_01.pb.tmpabc", modified.getFullPath());
+
+        Assertions.assertEquals(
+                PVPath.fromPath("jar:file:///arch/lts/ArchUnitTest/sine.zip!/2026_01_01.pb", "ArchUnitTest/sine:")
+                        .withNewExtension(".pb.tmp"),
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb.tmp"));
+        Assertions.assertEquals(
+                PVPath.fromPath("tar:///arch/lts/ArchUnitTest/sine.zip!/2026_01_01.pb", "ArchUnitTest/sine:")
+                        .withNewExtension(".pb.tmp"),
+                new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb.tmp"));
+        Assertions.assertEquals(
+                PVPath.fromPath("s3:///arch/lts/ArchUnitTest/sine.zip!/2026_01_01.pb", "ArchUnitTest/sine:")
+                        .withNewExtension(".pb.tmp"),
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb.tmp"));
+    }
+
+    @Test
+    public void testContainerPath() {
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb").getContainerPath(),
+                "/arch/lts/ArchUnitTest/sine.zip");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".parquet").getContainerPath(),
+                "/arch/lts/ArchUnitTest/sine.zip");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", null, ".parquet").getContainerPath(),
+                "/arch/lts/ArchUnitTest/sine.zip");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb").getContainerPath(),
+                "/arch/lts/ArchUnitTest/sine.tar");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".parquet").getContainerPath(),
+                "/arch/lts/ArchUnitTest/sine.tar");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", null, ".parquet").getContainerPath(),
+                "/arch/lts/ArchUnitTest/sine.tar");
+        Assertions.assertThrows(
+                UnsupportedOperationException.class,
+                () -> new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb").getContainerPath());
+    }
+
+    @Test
+    public void testContainedPath() {
+        Assertions.assertEquals(
+                new PVPath("/arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb").getContainedPath(),
+                "/ArchUnitTest/sine:2026_01_01.pb");
+        Assertions.assertEquals(
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb").getContainedPath(),
+                "/sine:2026_01_01.pb");
+        Assertions.assertEquals(
+                new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb").getContainedPath(),
+                "/sine:2026_01_01.pb");
+        Assertions.assertEquals(
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", "2026_01_01", ".pb").getContainedPath(),
+                "/ArchUnitTest/sine:2026_01_01.pb");
+    }
+
+    @Test
+    public void testGlobSearchParams() throws IOException {
+        try (ArchPaths paths = new ArchPaths()) {
+            Assertions.assertThrows(
+                    IllegalStateException.class,
+                    () -> paths.getGlobSearchParams(new PVPath("/arch/lts", null, "2026_01_01", ".pb"), ".parquet"));
+            Assertions.assertEquals(
+                    new ArchPaths.GlobSearchParams(Path.of("/arch/lts/ArchUnitTest"), "sine:*.parquet"),
+                    paths.getGlobSearchParams(new PVPath("/arch/lts", "ArchUnitTest/sine:", null, null), ".parquet"));
+            Assertions.assertEquals(
+                    new ArchPaths.GlobSearchParams(Path.of("/arch/lts"), "sine:*.parquet"),
+                    paths.getGlobSearchParams(new PVPath("/arch/lts", "sine:", null, null), ".parquet"));
+            {
+                ArchPaths.GlobSearchParams sparams = paths.getGlobSearchParams(
+                        new PVPath("jar:file://" + tPath, "ArchUnitTest/sine:", null, null), ".parquet");
+                Assertions.assertEquals("sine:*.parquet", sparams.globPattern());
+                Assertions.assertTrue(
+                        sparams.searchFolder()
+                                .getFileSystem()
+                                .getClass()
+                                .getName()
+                                .contains("Zip"),
+                        "Expected a Zip file system for the jar file");
+                Assertions.assertEquals(
+                        "jar:file://" + tPath + "/ArchUnitTest/sine.zip!/",
+                        sparams.searchFolder().toUri().toString());
+                Assertions.assertEquals(
+                        "/", sparams.searchFolder().toAbsolutePath().toString());
+            }
+            {
+                ArchPaths.GlobSearchParams sparams =
+                        paths.getGlobSearchParams(new PVPath("jar:file://" + tPath, "sine:", null, null), ".parquet");
+                Assertions.assertEquals("sine:*.parquet", sparams.globPattern());
+                Assertions.assertTrue(
+                        sparams.searchFolder()
+                                .getFileSystem()
+                                .getClass()
+                                .getName()
+                                .contains("Zip"),
+                        "Expected a Zip file system for the jar file");
+                Assertions.assertEquals(
+                        "jar:file://" + tPath + "/sine.zip!/",
+                        sparams.searchFolder().toUri().toString());
+                Assertions.assertEquals(
+                        "/", sparams.searchFolder().toAbsolutePath().toString());
+            }
+            // Turn these on once we have tar and s3 plugins in the build.
+            // Assertions.assertEquals(
+            //         new ArchPaths.GlobSearchParams(Path.of("tar:///arch/lts/ArchUnitTest/sine.tar"), "*.parquet"),
+            //         paths.getGlobSearchParams(new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", null, null),
+            // ".parquet")
+            // );
+            // Assertions.assertEquals(
+            //         new ArchPaths.GlobSearchParams(Path.of("tar:///arch/lts/sine.tar"), "*.parquet"),
+            //         paths.getGlobSearchParams(new PVPath("tar:///arch/lts", "sine:", null, null), ".parquet")
+            // );
+            // Assertions.assertEquals(
+            //         new ArchPaths.GlobSearchParams(Path.of("s3:///arch/lts/ArchUnitTest"), "sine:*.parquet"),
+            //         paths.getGlobSearchParams(new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", null, null),
+            // ".parquet")
+            // );
+            // Assertions.assertEquals(
+            //         new ArchPaths.GlobSearchParams(Path.of("s3:///arch/lts"), "sine:*.parquet"),
+            //         paths.getGlobSearchParams(new PVPath("s3:///arch/lts", "sine:", null, null), ".parquet")
+            // );
+        }
+    }
+
+    @Test
+    public void testRootURI() {
+        Assertions.assertEquals(
+                URI.create("/arch/lts"), new PVPath("/arch/lts", "ArchUnitTest/sine:", null, null).toRootURI());
+        Assertions.assertEquals(
+                URI.create("jar:file:///arch/lts/ArchUnitTest/sine.zip"),
+                new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", null, null).toRootURI());
+        Assertions.assertEquals(
+                URI.create("tar:///arch/lts/ArchUnitTest/sine.tar"),
+                new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", null, null).toRootURI());
+        Assertions.assertEquals(
+                URI.create("tar:///arch/lts/sine.tar"), new PVPath("tar:///arch/lts", "sine:", null, null).toRootURI());
+        Assertions.assertEquals(
+                URI.create("s3:///arch/lts"),
+                new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", null, null).toRootURI());
+    }
+}

--- a/src/test/org/epics/archiverappliance/utils/nio/PVPathTest.java
+++ b/src/test/org/epics/archiverappliance/utils/nio/PVPathTest.java
@@ -435,17 +435,17 @@ public class PVPathTest {
                 new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", null, null).toRootURI());
     }
 
-
     @Test
     public void testScheme() {
         Assertions.assertNull(new PVPath("/arch/lts", "ArchUnitTest/sine:", null, null).getScheme());
-        Assertions.assertEquals("jar", new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", null, null).getScheme());
+        Assertions.assertEquals(
+                "jar", new PVPath("jar:file:///arch/lts", "ArchUnitTest/sine:", null, null).getScheme());
         Assertions.assertEquals("jar", new PVPath("jar://arch/lts", "ArchUnitTest/sine:", null, null).getScheme());
         Assertions.assertEquals("tar", new PVPath("tar:///arch/lts", "ArchUnitTest/sine:", null, null).getScheme());
         Assertions.assertEquals("tar", new PVPath("tar:s3:///arch/lts", "ArchUnitTest/sine:", null, null).getScheme());
         Assertions.assertEquals("s3", new PVPath("s3:///arch/lts", "ArchUnitTest/sine:", null, null).getScheme());
     }
-    
+
     @Test
     public void testIsPlainFile() {
         Assertions.assertTrue(new PVPath("/arch/lts", "ArchUnitTest/sine:", null, null).isPlainFile());

--- a/src/test/org/epics/archiverappliance/zipfs/ZipCachedFetchTest.java
+++ b/src/test/org/epics/archiverappliance/zipfs/ZipCachedFetchTest.java
@@ -146,7 +146,6 @@ public class ZipCachedFetchTest {
                     endTime,
                     pbplugin.getExtensionString(),
                     pbplugin.getPartitionGranularity(),
-                    pbplugin.getPathResolver(),
                     configService.getPVNameToKeyConverter());
             long previousEpochSeconds = 0L;
             long eventCount = 0;
@@ -179,7 +178,6 @@ public class ZipCachedFetchTest {
                     endTime,
                     pbplugin.getExtensionString(),
                     pbplugin.getPartitionGranularity(),
-                    pbplugin.getPathResolver(),
                     configService.getPVNameToKeyConverter());
 
             List<Future<EventStream>> futures = new LinkedList<Future<EventStream>>();

--- a/src/test/org/epics/archiverappliance/zipfs/ZipCachedFetchTest.java
+++ b/src/test/org/epics/archiverappliance/zipfs/ZipCachedFetchTest.java
@@ -25,7 +25,6 @@ import org.epics.archiverappliance.data.ScalarValue;
 import org.epics.archiverappliance.utils.simulation.SimulationEvent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -47,7 +46,6 @@ import java.util.concurrent.Future;
  * @author mshankar
  *
  */
-@Disabled("Disabled until we add back support for zip compression thru NIO2")
 public class ZipCachedFetchTest {
     private static final Logger logger = LogManager.getLogger(ZipCachedFetchTest.class.getName());
     String rootFolderName = ConfigServiceForTests.getDefaultPBTestFolder() + "/" + "ZipCachedFetchTest/";
@@ -93,8 +91,7 @@ public class ZipCachedFetchTest {
                 pluginString(
                         PB_PLUGIN_IDENTIFIER,
                         "localhost",
-                        "name=STS&rootFolder=" + rootFolderName
-                                + "&partitionGranularity=PARTITION_DAY&compress=ZIP_PER_PV"),
+                        "name=STS&rootFolder=jar:file://" + rootFolderName + "&partitionGranularity=PARTITION_DAY"),
                 configService);
         if (new File(rootFolderName).exists()) {
             FileUtils.deleteDirectory(new File(rootFolderName));

--- a/src/test/org/epics/archiverappliance/zipfs/ZipETLTest.java
+++ b/src/test/org/epics/archiverappliance/zipfs/ZipETLTest.java
@@ -23,7 +23,6 @@ import org.epics.archiverappliance.utils.simulation.SineGenerator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -34,11 +33,13 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
-@Disabled("Disabled until we add back support for zip compression thru NIO2")
 @Tag("slow")
 public class ZipETLTest {
     private static Logger logger = LogManager.getLogger(ZipETLTest.class.getName());
     File testFolder = new File(ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "ZipETLTest");
+    private final String srcRootFolder = testFolder.getAbsolutePath() + File.separator + "srcFiles";
+    private final String destRootFolder = testFolder.getAbsolutePath() + File.separator + "destFiles";
+
     private ConfigService configService;
 
     @BeforeEach
@@ -48,6 +49,8 @@ public class ZipETLTest {
             FileUtils.deleteDirectory(testFolder);
         }
         testFolder.mkdirs();
+        new File(srcRootFolder).mkdirs();
+        new File(destRootFolder).mkdirs();
     }
 
     @AfterEach
@@ -58,7 +61,6 @@ public class ZipETLTest {
     @Test
     public void testETLIntoZipPerPV() throws Exception {
         String pvName = ConfigServiceForTests.ARCH_UNIT_TEST_PVNAME_PREFIX + ":ETLZipTest";
-        String srcRootFolder = testFolder.getAbsolutePath() + File.separator + "srcFiles";
         PlainStoragePlugin etlSrc = (PlainStoragePlugin) StoragePluginURLParser.parseStoragePlugin(
                 pluginString(
                         PB_PLUGIN_IDENTIFIER,
@@ -79,13 +81,11 @@ public class ZipETLTest {
             etlSrc.appendData(context, pvName, simstream);
         }
 
-        String destRootFolder = testFolder.getAbsolutePath() + File.separator + "destFiles";
         PlainStoragePlugin etlDest = (PlainStoragePlugin) StoragePluginURLParser.parseStoragePlugin(
                 pluginString(
                         PB_PLUGIN_IDENTIFIER,
                         "localhost",
-                        "name=ZipETL&rootFolder=" + destRootFolder
-                                + "&partitionGranularity=PARTITION_DAY&compress=ZIP_PER_PV"),
+                        "name=ZipETL&rootFolder=jar:file://" + destRootFolder + "&partitionGranularity=PARTITION_DAY"),
                 configService);
         logger.info(etlDest.getURLRepresentation());
 
@@ -105,8 +105,9 @@ public class ZipETLTest {
         ETLExecutor.runETLs(configService, timeETLruns);
         logger.info("Done performing ETL");
 
-        File expectedZipFile = new File(destRootFolder + File.separator
-                + configService.getPVNameToKeyConverter().convertPVNameToKey(pvName) + "_pb.zip");
+        String zipFileName = configService.getPVNameToKeyConverter().convertPVNameToKey(pvName);
+        zipFileName = zipFileName.substring(0, zipFileName.length() - 1) + ".zip";
+        File expectedZipFile = new File(destRootFolder + File.separator + zipFileName);
         Assertions.assertTrue(expectedZipFile.exists(), "Zip file does not seem to exist " + expectedZipFile);
 
         logger.info("Testing retrieval for zip per pv");

--- a/src/test/org/epics/archiverappliance/zipfs/ZipRetrievalTest.java
+++ b/src/test/org/epics/archiverappliance/zipfs/ZipRetrievalTest.java
@@ -18,12 +18,12 @@ import org.epics.archiverappliance.config.ConfigServiceForTests;
 import org.epics.archiverappliance.config.StoragePluginURLParser;
 import org.epics.archiverappliance.retrieval.workers.CurrentThreadWorkerEventStream;
 import org.epics.archiverappliance.utils.nio.ArchPaths;
+import org.epics.archiverappliance.utils.nio.PVPath;
 import org.epics.archiverappliance.utils.simulation.SimulationEventStream;
 import org.epics.archiverappliance.utils.simulation.SineGenerator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -41,7 +41,6 @@ import java.time.Instant;
  * @author mshankar
  *
  */
-@Disabled("Disabled until we add back support for zip compression thru NIO2")
 public class ZipRetrievalTest {
     private static Logger logger = LogManager.getLogger(ZipRetrievalTest.class.getName());
     File testFolder = new File(ConfigServiceForTests.getDefaultPBTestFolder() + File.separator + "ZipRetrievalTest");
@@ -74,7 +73,8 @@ public class ZipRetrievalTest {
         }
 
         try (ArchPaths paths = new ArchPaths()) {
-            Path zipPath = paths.get(true, "jar:file://" + testFolder.getAbsolutePath(), "sk.zip!/sk.txt");
+            // Path zipPath = paths.get(true, "jar:file://" + testFolder.getAbsolutePath(), "sk.zip!/sk.txt");
+            Path zipPath = paths.get(new PVPath("jar:file:" + testFolder.getAbsolutePath(), "sk:", "sk", ".txt"), true);
             Files.copy(skFile.toPath(), zipPath, StandardCopyOption.REPLACE_EXISTING);
         }
 
@@ -82,7 +82,7 @@ public class ZipRetrievalTest {
         Assertions.assertTrue(new File(zipFileStr).exists(), "Zip file does not exist " + zipFileStr);
         logger.info("Checking seeks etc");
         try (ArchPaths paths = new ArchPaths()) {
-            Path zipPath = paths.get("jar:file://" + testFolder.getAbsolutePath(), "sk.zip!/sk.txt");
+            Path zipPath = paths.get(new PVPath("jar:file:" + testFolder.getAbsolutePath(), "sk:", "sk", ".txt"));
             logger.debug(zipPath.toUri().toString());
             // Each line has 6 bytes...
             DecimalFormat format = new DecimalFormat("00000");
@@ -107,8 +107,7 @@ public class ZipRetrievalTest {
                 pluginString(
                         PB_PLUGIN_IDENTIFIER,
                         "localhost",
-                        "name=ZipTest&rootFolder=" + rootFolder
-                                + "&partitionGranularity=PARTITION_HOUR&compress=ZIP_PER_PV"),
+                        "name=ZipTest&rootFolder=jar:file://" + rootFolder + "&partitionGranularity=PARTITION_HOUR"),
                 configService);
         logger.info(storagePlugin.getURLRepresentation());
         String pvName = ConfigServiceForTests.ARCH_UNIT_TEST_PVNAME_PREFIX + ":SimpleZipTest";
@@ -124,9 +123,11 @@ public class ZipRetrievalTest {
         try (BasicContext context = new BasicContext()) {
             storagePlugin.appendData(context, pvName, simstream);
         }
-        File expectedZipFile = new File(testFolder + File.separator
-                + configService.getPVNameToKeyConverter().convertPVNameToKey(pvName) + "_pb.zip");
+        String zipFileName = configService.getPVNameToKeyConverter().convertPVNameToKey(pvName);
+        zipFileName = zipFileName.substring(0, zipFileName.length() - 1) + ".zip";
+        File expectedZipFile = new File(testFolder + File.separator + zipFileName);
         Assertions.assertTrue(expectedZipFile.exists(), "Zip file does not seem to exist " + expectedZipFile);
+        logger.info("Zip file " + expectedZipFile + " exists");
 
         logger.info("Testing retrieval for zip per pv");
         try (BasicContext context = new BasicContext();
@@ -179,8 +180,7 @@ public class ZipRetrievalTest {
                     pluginString(
                             PB_PLUGIN_IDENTIFIER,
                             "localhost",
-                            "name=ZipTest&rootFolder=" + rootFolder
-                                    + "&partitionGranularity=PARTITION_DAY&compress=ZIP_PER_PV"),
+                            "name=ZipTest&rootFolder=" + rootFolder + "&partitionGranularity=PARTITION_DAY"),
                     configService);
             logger.info(storagePlugin.getURLRepresentation());
             int phasediffindegrees = 10;
@@ -240,8 +240,7 @@ public class ZipRetrievalTest {
                     pluginString(
                             PB_PLUGIN_IDENTIFIER,
                             "localhost",
-                            "name=ZipTest&rootFolder=" + rootFolder
-                                    + "&partitionGranularity=PARTITION_DAY&compress=ZIP_PER_PV"),
+                            "name=ZipTest&rootFolder=" + rootFolder + "&partitionGranularity=PARTITION_DAY"),
                     configService);
             DecimalFormat format = new DecimalFormat("00");
             long totalTimeConsumed = 0;

--- a/src/test/org/epics/archiverappliance/zipfs/ZipSingleDayRawFetchTest.java
+++ b/src/test/org/epics/archiverappliance/zipfs/ZipSingleDayRawFetchTest.java
@@ -26,7 +26,6 @@ import org.epics.archiverappliance.utils.simulation.SimulationEvent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -41,7 +40,6 @@ import java.util.concurrent.Callable;
  * @author mshankar
  *
  */
-@Disabled("Disabled until we add back support for zip compression thru NIO2")
 public class ZipSingleDayRawFetchTest {
     private static final Logger logger = LogManager.getLogger(ZipSingleDayRawFetchTest.class.getName());
     String rootFolderName = ConfigServiceForTests.getDefaultPBTestFolder() + "/" + "ZipSingleDayRawFetch/";
@@ -57,8 +55,7 @@ public class ZipSingleDayRawFetchTest {
                 pluginString(
                         PB_PLUGIN_IDENTIFIER,
                         "localhost",
-                        "name=STS&rootFolder=" + rootFolderName
-                                + "&partitionGranularity=PARTITION_DAY&compress=ZIP_PER_PV"),
+                        "name=STS&rootFolder=jar:file://" + rootFolderName + "&partitionGranularity=PARTITION_DAY"),
                 configService);
         if (new File(rootFolderName).exists()) {
             FileUtils.deleteDirectory(new File(rootFolderName));


### PR DESCRIPTION
This is the start of refactoring the EAA codebase to strictly use  NIO2 compatible API calls for the PlainFileHandler's

There is some value in keeping track of the rootfolder, chunkkey, timecomponent and extension for paths used by the PlainStoragePlugins. The new PVPath class encodes this and we use this new way of specifying paths as much as possible. So now, we should be able to specify the root folder as a URI and pull in the appropriate NIO2 plugin.

With this change, we should be able to support zip files for both .pb and .parquet files by simply using the jar URI as the rootURL for the plugins. I will update the doc once I test the release a bit more.