### PR TITLE
Fix nth post processor to correctly handle switch in year

### DIFF
--- a/src/main/org/epics/archiverappliance/retrieval/postprocessors/Nth.java
+++ b/src/main/org/epics/archiverappliance/retrieval/postprocessors/Nth.java
@@ -154,7 +154,7 @@ public class Nth implements PostProcessor, PostProcessorWithConsolidatedEventStr
 
     @Override
     public EventStream getConsolidatedEventStream() {
-        return data;
+        return new ArrayListCollectorEventStream(data);
     }
 
     @Override


### PR DESCRIPTION
For a search spanning over shift in year, the nth post processor would return wrong date for events after the switch from year n to n+1.