### PR TITLE
Improve performance of the writer

### DIFF
--- a/docker/archappl/conf/archappl.properties
+++ b/docker/archappl/conf/archappl.properties
@@ -8,8 +8,10 @@ org.epics.archiverappliance.config.ConvertPVNameToKey.siteNameSpaceSeparators=[\
 org.epics.archiverappliance.config.ConvertPVNameToKey.siteNameSpaceTerminator=:
 # We enforce a site specific minimum sampling period (read maximum rate) using this value
 org.epics.archiverappliance.mgmt.bpl.ArchivePVAction.minimumSamplingPeriod=0.1
-# We have a system wide buffer size (specified in seconds) for buffering the data in engine memory
-# This is a compromise between various factors including garbage collection, IOPS of the short term store and memory availability.
+# How often (in seconds) the engine saves buffered PV data to the short-term store.
+# Shorter values reduce memory use and data latency but increase storage I/O.
+# Reduce cautiously on NFS or network-attached storage; use the
+# "Equivalent sequential I/O load (%)" on the engine metrics page to check headroom.
 org.epics.archiverappliance.config.PVTypeInfo.secondsToBuffer=2
 # Per FRIB/PSI, we have a configuration knob to increase/decrease the sample buffer size used by the engine for all PV's.
 # This is a double - by default 1.0 which means we leave the buffer size computation as is.
@@ -47,8 +49,11 @@ org.epics.archiverappliance.engine.epics.commandThreadCount=10
 org.epics.archiverappliance.engine.epics.scanJitterFactor=0.95
 # We use a ScheduledThreadPoolExecutor for implementing SCAN PV's.
 # If you have a lot of PV's under SCAN and some of these take time; it is possible to miss some SCAN samples because we just don't get to the PV in time.
-# In this case, you can increase the number of SCAN threads used; the need for this is probably pretty rare 
+# In this case, you can increase the number of SCAN threads used; the need for this is probably pretty rare
 org.epics.archiverappliance.engine.epics.scanThreadCount=1
+# Maximum number of channels written concurrently per write cycle (0 = unlimited).
+# Set to 4-8 for NFS or shared SAN; leave at 0 for local SSD/NVMe.
+org.epics.archiverappliance.engine.epics.writeThreadCount=0
 # How should ETL handle out of space situations.
 # See the javadoc of org.epics.archiverappliance.etl.common.OutOfSpaceHandling for some options
 org.epics.archiverappliance.etl.common.OutOfSpaceHandling=DELETE_SRC_STREAMS_IF_FIRST_DEST_WHEN_OUT_OF_SPACE

--- a/docs/docs/source/faq.md
+++ b/docs/docs/source/faq.md
@@ -73,6 +73,22 @@
       - sampleBufferCapacityAdjustment is a system-wide adjustment
         for the buffer side and is set in archappl.properties.
 
+      The engine flushes all channel buffers in parallel using Java 21
+      virtual threads, so `write_period` no longer needs to be sized
+      around how long sequential writes take. The tradeoffs are now:
+
+      - **Buffer memory**: shorter period = smaller per-PV buffers = less JVM heap.
+      - **File I/O frequency**: shorter period = more file open/write/close
+        operations per second across all channels. Reduce cautiously on
+        NFS or shared SAN storage.
+      - **STS data latency**: shorter period = data appears in the short-term
+        store sooner.
+
+      The engine metrics page exposes an "Equivalent sequential I/O load (%)"
+      value that shows how loaded storage would be under the old sequential
+      model. If that figure is well below 100%, the write period can safely
+      be reduced.
+
       For example, if the `write_period` is 10 seconds, and the
       `pvSamplingPeriod` is 1 second, we would allocate
       `10/1 + 1 = 11` samples for the default

--- a/src/main/org/epics/archiverappliance/engine/epics/EngineMetrics.java
+++ b/src/main/org/epics/archiverappliance/engine/epics/EngineMetrics.java
@@ -14,7 +14,6 @@ import org.epics.archiverappliance.config.ConfigService;
 import org.epics.archiverappliance.engine.metadata.MetaGet;
 import org.epics.archiverappliance.engine.model.ArchiveChannel;
 import org.epics.archiverappliance.engine.pv.EngineContext;
-import org.epics.archiverappliance.engine.pv.PVContext;
 import org.epics.archiverappliance.engine.pv.PVMetrics;
 
 import java.text.DecimalFormat;
@@ -23,7 +22,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 
 /**
  * POJO with some basic metrics.
@@ -40,6 +38,9 @@ public class EngineMetrics implements Details {
     private double eventRate;
     private double dataRate;
     private double secondsConsumedByWriter = 0.00;
+    private double totalChannelIOSeconds = 0.00;
+    private double avgChannelsWrittenPerCycle = 0.00;
+    private long skippedWriteCycles = 0;
     // private static Logger logger=Logger.getLogger(EngineMetrics.class.getName());
 
     public double getSecondsConsumedByWriter() {
@@ -48,6 +49,30 @@ public class EngineMetrics implements Details {
 
     public void setSecondsConsumedByWriter(double secondsConsumedByWriter) {
         this.secondsConsumedByWriter = secondsConsumedByWriter;
+    }
+
+    public double getTotalChannelIOSeconds() {
+        return totalChannelIOSeconds;
+    }
+
+    public void setTotalChannelIOSeconds(double totalChannelIOSeconds) {
+        this.totalChannelIOSeconds = totalChannelIOSeconds;
+    }
+
+    public double getAvgChannelsWrittenPerCycle() {
+        return avgChannelsWrittenPerCycle;
+    }
+
+    public void setAvgChannelsWrittenPerCycle(double avgChannelsWrittenPerCycle) {
+        this.avgChannelsWrittenPerCycle = avgChannelsWrittenPerCycle;
+    }
+
+    public long getSkippedWriteCycles() {
+        return skippedWriteCycles;
+    }
+
+    public void setSkippedWriteCycles(long skippedWriteCycles) {
+        this.skippedWriteCycles = skippedWriteCycles;
     }
 
     public double getEventRate() {
@@ -97,6 +122,9 @@ public class EngineMetrics implements Details {
         engineMetrics.put("disconnectedPVCount", Integer.toString(disconnectedPVCount));
         engineMetrics.put("formattedWriteThreadSeconds", twoSignificantDigits.format(secondsConsumedByWriter));
         engineMetrics.put("secondsConsumedByWriter", Double.toString(secondsConsumedByWriter));
+        engineMetrics.put("totalChannelIOSeconds", Double.toString(totalChannelIOSeconds));
+        engineMetrics.put("avgChannelsWrittenPerCycle", twoSignificantDigits.format(avgChannelsWrittenPerCycle));
+        engineMetrics.put("skippedWriteCycles", Long.toString(skippedWriteCycles));
 
         return engineMetrics;
     }
@@ -122,11 +150,24 @@ public class EngineMetrics implements Details {
                 "Data Rate in (GB/year)",
                 twoSignificantDigits.format((dataRate * 60 * 60 * 24 * 365) / (1024 * 1024 * 1024))));
         details.add(this.metricDetail(
-                "Time consumed for writing samplebuffers to STS (in secs)",
-                twoSignificantDigits.format(secondsConsumedByWriter)));
-        if (secondsConsumedByWriter != 0) {
-            double writesPerSec = eventRate * context.getWritePeriod() / secondsConsumedByWriter;
-            double writeBytesPerSec = (dataRate * context.getWritePeriod() / secondsConsumedByWriter) / (1024 * 1024);
+                "Write cycle elapsed time (secs)", twoSignificantDigits.format(secondsConsumedByWriter)));
+        details.add(this.metricDetail(
+                "Equivalent sequential I/O time per cycle (secs)", twoSignificantDigits.format(totalChannelIOSeconds)));
+        details.add(this.metricDetail(
+                "Avg channels written per cycle", twoSignificantDigits.format(avgChannelsWrittenPerCycle)));
+        details.add(this.metricDetail("Skipped write cycles (backpressure)", Long.toString(skippedWriteCycles)));
+        double writePeriod = context.getWritePeriod();
+        if (writePeriod > 0) {
+            details.add(this.metricDetail(
+                    "Write cycle scheduling load (%)",
+                    twoSignificantDigits.format(secondsConsumedByWriter * 100.0 / writePeriod)));
+            details.add(this.metricDetail(
+                    "Equivalent sequential I/O load (%)",
+                    twoSignificantDigits.format(totalChannelIOSeconds * 100.0 / writePeriod)));
+        }
+        if (totalChannelIOSeconds > 0) {
+            double writesPerSec = eventRate * writePeriod / totalChannelIOSeconds;
+            double writeBytesPerSec = (dataRate * writePeriod / totalChannelIOSeconds) / (1024 * 1024);
             details.add(this.metricDetail(
                     "Benchmark - writing at (events/sec)", twoSignificantDigits.format(writesPerSec)));
             details.add(this.metricDetail(
@@ -199,6 +240,9 @@ public class EngineMetrics implements Details {
         }
         engineMetrics.setTotalEPICSChannels(totalchannelCount);
         engineMetrics.setSecondsConsumedByWriter(engineContext.getAverageSecondsConsumedByWriter());
+        engineMetrics.setTotalChannelIOSeconds(engineContext.getAverageTotalChannelIOSeconds());
+        engineMetrics.setAvgChannelsWrittenPerCycle(engineContext.getAverageChannelsWrittenPerCycle());
+        engineMetrics.setSkippedWriteCycles(engineContext.getSkippedWriteCycles());
 
         return engineMetrics;
     }

--- a/src/main/org/epics/archiverappliance/engine/model/SampleBuffer.java
+++ b/src/main/org/epics/archiverappliance/engine/model/SampleBuffer.java
@@ -152,6 +152,11 @@ public class SampleBuffer {
         return currentSamples.size();
     }
 
+    /** @return true if there are samples currently waiting in the active buffer. */
+    public boolean hasCurrentSamples() {
+        return !currentSamples.isEmpty();
+    }
+
     /** @return <code>true</code> if currently experiencing write errors */
     public static boolean isInErrorState() {
         return error;

--- a/src/main/org/epics/archiverappliance/engine/pv/EngineContext.java
+++ b/src/main/org/epics/archiverappliance/engine/pv/EngineContext.java
@@ -114,6 +114,8 @@ public class EngineContext {
 
     private double sampleBufferCapacityAdjustment = 1.0;
 
+    private int writeThreadCount = 0;
+
     /***
      *
      * @return the list of pvs controlling other pvs
@@ -137,6 +139,11 @@ public class EngineContext {
     public double getAverageSecondsConsumedByWriter() {
         if (countOfWrittingByWriter == 0) return 0;
         return totalTimeConsumedByWriter / countOfWrittingByWriter;
+    }
+
+    /** @return Maximum concurrent channel writes per cycle; 0 means unlimited. */
+    public int getWriteThreadCount() {
+        return writeThreadCount;
     }
 
     /**
@@ -171,6 +178,12 @@ public class EngineContext {
                 + (100.0 - MAXIMUM_DISCONNECTED_CHANNEL_PERCENTAGE_BEFORE_STARTING_METACHANNELS)
                 + "% of channels have connected. We'll start metachannels " + METACHANNELS_TO_START_AT_A_TIME
                 + " at a time");
+
+        String writeThreadCountName = "org.epics.archiverappliance.engine.epics.writeThreadCount";
+        String writeThreadCountStr = configService.getInstallationProperties().getProperty(writeThreadCountName, "0");
+        this.writeThreadCount = Integer.parseInt(writeThreadCountStr);
+        configlogger.info("Write concurrency limit: " + writeThreadCountStr + " (0=unlimited) as specified by "
+                + writeThreadCountName + " in archappl.properties");
 
         writer = new WriterRunnable(configService);
         channelList = new ConcurrentHashMap<String, ArchiveChannel>();

--- a/src/main/org/epics/archiverappliance/engine/pv/EngineContext.java
+++ b/src/main/org/epics/archiverappliance/engine/pv/EngineContext.java
@@ -219,6 +219,7 @@ public class EngineContext {
                 }
 
                 writer.flushBuffer();
+                writer.shutdown();
                 channelList.clear();
 
                 // stop the controlling pv

--- a/src/main/org/epics/archiverappliance/engine/pv/EngineContext.java
+++ b/src/main/org/epics/archiverappliance/engine/pv/EngineContext.java
@@ -81,10 +81,16 @@ public class EngineContext {
 
     private PVAClient pvaClient;
 
-    /**the total time consumed by the writer*/
+    /** total wall-clock seconds consumed by write cycles */
     private double totalTimeConsumedByWriter;
-    /**the total times of writer executed*/
+    /** total sum of per-channel I/O seconds across all write cycles */
+    private double totalChannelIOTimeConsumedByWriter;
+    /** total channels written summed across all write cycles */
+    private long totalChannelsWritten = 0;
+    /** number of completed write cycles */
     private long countOfWrittingByWriter = 0;
+    /** number of write cycles skipped due to backpressure (prior cycle still running) */
+    private long skippedWriteCycles = 0;
     /**the list of pvs controlling other pvs*/
     private final ConcurrentHashMap<String, ControllingPV> controlingPVList =
             new ConcurrentHashMap<String, ControllingPV>();
@@ -124,21 +130,44 @@ public class EngineContext {
         return controlingPVList;
     }
     /**
-     * set the time consumed by writer to write the sample buffer once
-     * @param secondsConsumedByWriter  the time in second consumed by writer to write the sample buffer once
-     *
+     * Record the outcome of a completed write cycle.
+     * @param wallClockSeconds  elapsed wall-clock seconds for the full cycle
+     * @param totalChannelIOSeconds  sum of per-channel I/O seconds across all channels written
+     * @param channelsWritten  number of channels that had data to write this cycle
      */
-    public void setSecondsConsumedByWriter(double secondsConsumedByWriter) {
+    public void recordWriteCycle(double wallClockSeconds, double totalChannelIOSeconds, int channelsWritten) {
         countOfWrittingByWriter++;
-        totalTimeConsumedByWriter = totalTimeConsumedByWriter + secondsConsumedByWriter;
+        totalTimeConsumedByWriter += wallClockSeconds;
+        totalChannelIOTimeConsumedByWriter += totalChannelIOSeconds;
+        totalChannelsWritten += channelsWritten;
     }
-    /**
-     *
-     * @return the average time in second consumed by writer
-     */
+
+    /** Record a write cycle that was skipped because the prior cycle was still running. */
+    public void recordSkippedWriteCycle() {
+        skippedWriteCycles++;
+    }
+
+    /** @return average write-cycle wall-clock time in seconds */
     public double getAverageSecondsConsumedByWriter() {
         if (countOfWrittingByWriter == 0) return 0;
         return totalTimeConsumedByWriter / countOfWrittingByWriter;
+    }
+
+    /** @return average sum of per-channel I/O seconds per write cycle (equivalent sequential load) */
+    public double getAverageTotalChannelIOSeconds() {
+        if (countOfWrittingByWriter == 0) return 0;
+        return totalChannelIOTimeConsumedByWriter / countOfWrittingByWriter;
+    }
+
+    /** @return average number of channels written per write cycle */
+    public double getAverageChannelsWrittenPerCycle() {
+        if (countOfWrittingByWriter == 0) return 0;
+        return (double) totalChannelsWritten / countOfWrittingByWriter;
+    }
+
+    /** @return total number of write cycles skipped due to backpressure */
+    public long getSkippedWriteCycles() {
+        return skippedWriteCycles;
     }
 
     /** @return Maximum concurrent channel writes per cycle; 0 means unlimited. */

--- a/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
+++ b/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
@@ -60,10 +60,20 @@ public class WriterRunnable implements Runnable {
     public void removeChannel(final String channelName) {
         SampleBuffer buffer = buffers.get(channelName);
         if (buffer != null) {
-            try {
-                write(buffer);
-            } catch (Throwable e) {
-                logger.error("Exception flushing data for " + channelName, e);
+            ConcurrentHashMap<String, ArchiveChannel> channelList =
+                    configservice.getEngineContext().getChannelList();
+            buffer.resetSamples();
+            ArrayListEventStream previousSamples = buffer.getPreviousSamples();
+            if (!previousSamples.isEmpty()) {
+                ArchiveChannel channel = channelList.get(channelName);
+                if (channel != null) {
+                    try (BasicContext ctx = new BasicContext()) {
+                        channel.setlastRotateLogsEpochSeconds(System.currentTimeMillis() / 1000);
+                        channel.getWriter().appendData(ctx, channelName, previousSamples);
+                    } catch (IOException e) {
+                        logger.error("Exception flushing buffer on channel removal for " + channelName, e);
+                    }
+                }
             }
         }
         buffers.remove(channelName);
@@ -75,19 +85,8 @@ public class WriterRunnable implements Runnable {
      * @param buffer the sample buffer for this channel
      */
     void addSampleBuffer(final String name, final SampleBuffer buffer) {
-        // buffers.add(buffer);
         buffers.put(name, buffer);
-        buffer.addYearListener(sampleBuffer -> {
-            //
-            configservice.getEngineContext().getScheduler().execute(() -> {
-                try {
-                    write(sampleBuffer);
-                    logger.info(sampleBuffer.getChannelName() + ":year change");
-                } catch (IOException e) {
-                    logger.error("Exception", e);
-                }
-            });
-        });
+        buffer.addYearListener(this::writeYearChange);
     }
 
     /**
@@ -117,31 +116,36 @@ public class WriterRunnable implements Runnable {
             logger.error("Exception", e);
         }
     }
+
     /**
-     * write the sample buffer to the short term storage
+     * Flush a single channel's sample buffer on a year boundary.
+     * The isRunning guard is intentionally absent: year-change callbacks are already
+     * serialised on the scheduler thread, so there is no re-entrancy risk. The old guard
+     * was silently dropping year-change flushes whenever a bulk write cycle was running.
      * @param buffer the sample buffer to be written
-     * @throws IOException  error occurs during writing the sample buffer to the short term storage
      */
-    private void write(SampleBuffer buffer) throws IOException {
-        if (!isRunning.compareAndSet(false, true)) return;
+    private void writeYearChange(SampleBuffer buffer) {
+        String channelName = buffer.getChannelName();
         ConcurrentHashMap<String, ArchiveChannel> channelList =
                 configservice.getEngineContext().getChannelList();
-        String channelNname = buffer.getChannelName();
+
         buffer.resetSamples();
         ArrayListEventStream previousSamples = buffer.getPreviousSamples();
+        if (previousSamples.isEmpty()) return;
+
+        ArchiveChannel channel = channelList.get(channelName);
+        if (channel == null) return;
 
         try (BasicContext basicContext = new BasicContext()) {
-            if (!previousSamples.isEmpty()) {
-                ArchiveChannel tempChannel = channelList.get(channelNname);
-                tempChannel.setlastRotateLogsEpochSeconds(System.currentTimeMillis() / 1000);
-                tempChannel.getWriter().appendData(basicContext, channelNname, previousSamples);
-            }
+            channel.aboutToWriteBuffer((DBRTimeEvent) previousSamples.getLast());
+            channel.setlastRotateLogsEpochSeconds(System.currentTimeMillis() / 1000);
+            channel.getWriter().appendData(basicContext, channelName, previousSamples);
+            logger.info(channelName + ": year change");
         } catch (IOException e) {
-            throw (e);
-        } finally {
-            isRunning.set(false);
+            logger.error("Exception writing year-change buffer for " + channelName, e);
         }
     }
+
     /**
      * write all sample buffers into short term storage
      * @throws Exception error occurs during writing the sample buffer to the short term storage

--- a/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
+++ b/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -243,5 +244,21 @@ public class WriterRunnable implements Runnable {
      */
     public void flushBuffer() throws Exception {
         write();
+    }
+
+    /**
+     * Shut down the virtual thread executor, waiting up to 30 seconds for in-flight writes to complete.
+     */
+    public void shutdown() {
+        writeExecutor.shutdown();
+        try {
+            if (!writeExecutor.awaitTermination(30, TimeUnit.SECONDS)) {
+                logger.warn("Write executor did not terminate within 30 seconds; forcing shutdown.");
+                writeExecutor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            writeExecutor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
+++ b/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
@@ -177,6 +177,9 @@ public class WriterRunnable implements Runnable {
         yearChangeFutures.put(channelName, future);
     }
 
+    /** Carries the data needed to write one channel's buffer in a single write cycle. */
+    private record WriteTask(ArchiveChannel channel, String name, ArrayListEventStream samples) {}
+
     /**
      * Write all sample buffers into short term storage in parallel using Java 21 virtual threads.
      * All buffer swaps happen on the scheduler thread before fan-out so that every channel shares
@@ -185,56 +188,75 @@ public class WriterRunnable implements Runnable {
      */
     private void write() throws Exception {
         if (!isRunning.compareAndSet(false, true)) return;
-
-        final long writeTimestamp = System.currentTimeMillis() / 1000;
-        ConcurrentHashMap<String, ArchiveChannel> channelList =
-                configservice.getEngineContext().getChannelList();
-
         try {
-            // Phase 1 (scheduler thread): swap all active buffers and prepare write tasks.
-            // Doing all swaps before submitting any I/O ensures a consistent epoch snapshot —
-            // no channel accumulates new data in its "previous" buffer while another is still writing.
-            record WriteTask(ArchiveChannel channel, String name, ArrayListEventStream samples) {}
-            List<WriteTask> tasks = new ArrayList<>(buffers.size());
+            final long writeTimestamp = System.currentTimeMillis() / 1000;
+            ConcurrentHashMap<String, ArchiveChannel> channelList =
+                    configservice.getEngineContext().getChannelList();
 
-            for (Entry<String, SampleBuffer> entry : buffers.entrySet()) {
-                SampleBuffer buffer = entry.getValue();
-                if (!buffer.hasCurrentSamples()) continue;
-
-                String channelName = buffer.getChannelName();
-                buffer.resetSamples();
-                ArrayListEventStream previousSamples = buffer.getPreviousSamples();
-                if (previousSamples.isEmpty()) continue;
-
-                ArchiveChannel channel = channelList.get(channelName);
-                if (channel == null) continue;
-
-                channel.aboutToWriteBuffer((DBRTimeEvent) previousSamples.getLast());
-                channel.setlastRotateLogsEpochSeconds(writeTimestamp);
-                tasks.add(new WriteTask(channel, channelName, previousSamples));
-            }
-
-            // Phase 2: fan out blocking I/O to virtual threads
-            List<Future<?>> futures = new ArrayList<>(tasks.size());
-            for (WriteTask task : tasks) {
-                futures.add(writeExecutor.submit(() -> {
-                    if (writeSemaphore != null) writeSemaphore.acquireUninterruptibly();
-                    try (BasicContext ctx = new BasicContext()) {
-                        task.channel().getWriter().appendData(ctx, task.name(), task.samples());
-                    } catch (IOException e) {
-                        logger.error("Exception writing channel " + task.name(), e);
-                    } finally {
-                        if (writeSemaphore != null) writeSemaphore.release();
-                    }
-                }));
-            }
-
-            // Phase 3: join — preserves backpressure on the scheduler
-            for (Future<?> future : futures) {
-                future.get();
-            }
+            List<WriteTask> tasks = collectWriteTasks(channelList, writeTimestamp);
+            List<Future<?>> futures = submitWriteTasks(tasks);
+            awaitWriteCompletion(futures);
         } finally {
             isRunning.set(false);
+        }
+    }
+
+    /**
+     * Swaps the double-buffer for every active channel on the scheduler thread, preparing a
+     * snapshot of each channel's pending samples. All swaps happen before any I/O is submitted
+     * so no channel accumulates new data into its previous buffer while another is still writing.
+     */
+    private List<WriteTask> collectWriteTasks(
+            ConcurrentHashMap<String, ArchiveChannel> channelList, long writeTimestamp) {
+        List<WriteTask> tasks = new ArrayList<>(buffers.size());
+        for (Entry<String, SampleBuffer> entry : buffers.entrySet()) {
+            SampleBuffer buffer = entry.getValue();
+            if (!buffer.hasCurrentSamples()) continue;
+
+            String channelName = buffer.getChannelName();
+            buffer.resetSamples();
+            ArrayListEventStream previousSamples = buffer.getPreviousSamples();
+            if (previousSamples.isEmpty()) continue;
+
+            ArchiveChannel channel = channelList.get(channelName);
+            if (channel == null) continue;
+
+            channel.aboutToWriteBuffer((DBRTimeEvent) previousSamples.getLast());
+            channel.setlastRotateLogsEpochSeconds(writeTimestamp);
+            tasks.add(new WriteTask(channel, channelName, previousSamples));
+        }
+        return tasks;
+    }
+
+    /**
+     * Submits each channel's appendData() call to the virtual thread executor,
+     * optionally throttled by the write semaphore.
+     */
+    private List<Future<?>> submitWriteTasks(List<WriteTask> tasks) {
+        List<Future<?>> futures = new ArrayList<>(tasks.size());
+        for (WriteTask task : tasks) {
+            futures.add(writeExecutor.submit(() -> {
+                if (writeSemaphore != null) writeSemaphore.acquireUninterruptibly();
+                try (BasicContext ctx = new BasicContext()) {
+                    task.channel().getWriter().appendData(ctx, task.name(), task.samples());
+                } catch (IOException e) {
+                    logger.error("Exception writing channel " + task.name(), e);
+                } finally {
+                    if (writeSemaphore != null) writeSemaphore.release();
+                }
+            }));
+        }
+        return futures;
+    }
+
+    /**
+     * Waits for all submitted write futures to complete. Joining here preserves backpressure
+     * on the scheduler: if I/O is slow the next scheduled tick will observe isRunning=true
+     * and skip, rather than queuing up unbounded work.
+     */
+    private void awaitWriteCompletion(List<Future<?>> futures) throws Exception {
+        for (Future<?> future : futures) {
+            future.get();
         }
     }
 

--- a/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
+++ b/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
@@ -108,10 +108,13 @@ public class WriterRunnable implements Runnable {
     }
 
     /**
-     * set the writing period. when the writing period is at least 10 seconds.
-     * When write_period &lt; 10 , the writing period is 10 seconds actually.
-     * @param write_period  the writing period in second
-     * @return the actual writing period in second
+     * Validates and returns the effective write period, enforcing the minimum.
+     * The minimum of {@value MIN_WRITE_PERIOD} second guards against excessive file
+     * open/write/close frequency across all channels. With parallel virtual-thread
+     * writes the write cycle itself completes quickly, so this floor is about
+     * storage I/O frequency rather than write-cycle duration.
+     * @param write_period  the requested writing period in seconds
+     * @return the actual writing period in seconds (at least {@value MIN_WRITE_PERIOD})
      */
     public double setWritingPeriod(double write_period) {
         double tempwrite_period = write_period;

--- a/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
+++ b/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
@@ -19,6 +19,7 @@ import org.epics.archiverappliance.engine.model.SampleBuffer;
 import java.io.IOException;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * WriterRunnable is scheduled by the executor in the engine context every writing period.
@@ -34,8 +35,8 @@ public class WriterRunnable implements Runnable {
 
     /**the configservice used by this WriterRunnable*/
     private ConfigService configservice = null;
-    /**is running?*/
-    private boolean isRunning = false;
+    /**guards against concurrent write() invocations*/
+    private final AtomicBoolean isRunning = new AtomicBoolean(false);
     /**
      * the constructor
      * @param configservice the configservice used by this WriterRunnable
@@ -122,8 +123,7 @@ public class WriterRunnable implements Runnable {
      * @throws IOException  error occurs during writing the sample buffer to the short term storage
      */
     private void write(SampleBuffer buffer) throws IOException {
-        if (isRunning) return;
-        isRunning = true;
+        if (!isRunning.compareAndSet(false, true)) return;
         ConcurrentHashMap<String, ArchiveChannel> channelList =
                 configservice.getEngineContext().getChannelList();
         String channelNname = buffer.getChannelName();
@@ -131,7 +131,6 @@ public class WriterRunnable implements Runnable {
         ArrayListEventStream previousSamples = buffer.getPreviousSamples();
 
         try (BasicContext basicContext = new BasicContext()) {
-
             if (!previousSamples.isEmpty()) {
                 ArchiveChannel tempChannel = channelList.get(channelNname);
                 tempChannel.setlastRotateLogsEpochSeconds(System.currentTimeMillis() / 1000);
@@ -140,43 +139,39 @@ public class WriterRunnable implements Runnable {
         } catch (IOException e) {
             throw (e);
         } finally {
-            isRunning = false;
+            isRunning.set(false);
         }
-        isRunning = false;
     }
     /**
      * write all sample buffers into short term storage
      * @throws Exception error occurs during writing the sample buffer to the short term storage
      */
     private void write() throws Exception {
-        if (isRunning) return;
-        isRunning = true;
+        if (!isRunning.compareAndSet(false, true)) return;
         ConcurrentHashMap<String, ArchiveChannel> channelList =
                 configservice.getEngineContext().getChannelList();
 
-        for (Entry<String, SampleBuffer> entry : buffers.entrySet()) {
+        try {
+            for (Entry<String, SampleBuffer> entry : buffers.entrySet()) {
+                SampleBuffer buffer = entry.getValue();
+                String channelNname = buffer.getChannelName();
 
-            SampleBuffer buffer = entry.getValue();
-
-            String channelNname = buffer.getChannelName();
-
-            buffer.resetSamples();
-            ArrayListEventStream previousSamples = buffer.getPreviousSamples();
-            try (BasicContext basicContext = new BasicContext()) {
-                if (!previousSamples.isEmpty()) {
-                    ArchiveChannel tempChannel = channelList.get(channelNname);
-                    tempChannel.aboutToWriteBuffer((DBRTimeEvent) previousSamples.getLast());
-                    tempChannel.setlastRotateLogsEpochSeconds(System.currentTimeMillis() / 1000);
-                    tempChannel.getWriter().appendData(basicContext, channelNname, previousSamples);
+                buffer.resetSamples();
+                ArrayListEventStream previousSamples = buffer.getPreviousSamples();
+                try (BasicContext basicContext = new BasicContext()) {
+                    if (!previousSamples.isEmpty()) {
+                        ArchiveChannel tempChannel = channelList.get(channelNname);
+                        tempChannel.aboutToWriteBuffer((DBRTimeEvent) previousSamples.getLast());
+                        tempChannel.setlastRotateLogsEpochSeconds(System.currentTimeMillis() / 1000);
+                        tempChannel.getWriter().appendData(basicContext, channelNname, previousSamples);
+                    }
+                } catch (IOException e) {
+                    throw (e);
                 }
-            } catch (IOException e) {
-                throw (e);
-            } finally {
-                isRunning = false;
             }
+        } finally {
+            isRunning.set(false);
         }
-
-        isRunning = false;
     }
     /**
      * flush out the sample buffer to the short term storage before shutting down the engine

--- a/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
+++ b/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
@@ -124,10 +124,19 @@ public class WriterRunnable implements Runnable {
     @Override
     public void run() {
         try {
-            long startTime = System.currentTimeMillis();
-            write();
-            long endTime = System.currentTimeMillis();
-            configservice.getEngineContext().setSecondsConsumedByWriter((double) (endTime - startTime) / 1000);
+            long startMillis = System.currentTimeMillis();
+            WriteCycleMetrics metrics = write();
+            long wallClockMillis = System.currentTimeMillis() - startMillis;
+            if (metrics == null) {
+                configservice.getEngineContext().recordSkippedWriteCycle();
+            } else {
+                configservice
+                        .getEngineContext()
+                        .recordWriteCycle(
+                                wallClockMillis / 1000.0,
+                                metrics.totalChannelIOMillis() / 1000.0,
+                                metrics.channelsWritten());
+            }
         } catch (Exception e) {
             logger.error("Exception", e);
         }
@@ -180,22 +189,27 @@ public class WriterRunnable implements Runnable {
     /** Carries the data needed to write one channel's buffer in a single write cycle. */
     private record WriteTask(ArchiveChannel channel, String name, ArrayListEventStream samples) {}
 
+    /** Summary of a completed write cycle returned to run() for metrics reporting. */
+    private record WriteCycleMetrics(int channelsWritten, long totalChannelIOMillis) {}
+
     /**
      * Write all sample buffers into short term storage in parallel using Java 21 virtual threads.
      * All buffer swaps happen on the scheduler thread before fan-out so that every channel shares
      * a consistent epoch snapshot for the write cycle.
+     * @return metrics for the completed cycle, or null if the cycle was skipped due to a prior cycle still running
      * @throws Exception error occurs during writing the sample buffer to the short term storage
      */
-    private void write() throws Exception {
-        if (!isRunning.compareAndSet(false, true)) return;
+    private WriteCycleMetrics write() throws Exception {
+        if (!isRunning.compareAndSet(false, true)) return null;
         try {
             final long writeTimestamp = System.currentTimeMillis() / 1000;
             ConcurrentHashMap<String, ArchiveChannel> channelList =
                     configservice.getEngineContext().getChannelList();
 
             List<WriteTask> tasks = collectWriteTasks(channelList, writeTimestamp);
-            List<Future<?>> futures = submitWriteTasks(tasks);
-            awaitWriteCompletion(futures);
+            List<Future<Long>> futures = submitWriteTasks(tasks);
+            long totalChannelIOMillis = awaitWriteCompletion(futures);
+            return new WriteCycleMetrics(tasks.size(), totalChannelIOMillis);
         } finally {
             isRunning.set(false);
         }
@@ -231,12 +245,14 @@ public class WriterRunnable implements Runnable {
     /**
      * Submits each channel's appendData() call to the virtual thread executor,
      * optionally throttled by the write semaphore.
+     * Each future returns the elapsed wall-clock milliseconds for that channel's write.
      */
-    private List<Future<?>> submitWriteTasks(List<WriteTask> tasks) {
-        List<Future<?>> futures = new ArrayList<>(tasks.size());
+    private List<Future<Long>> submitWriteTasks(List<WriteTask> tasks) {
+        List<Future<Long>> futures = new ArrayList<>(tasks.size());
         for (WriteTask task : tasks) {
             futures.add(writeExecutor.submit(() -> {
                 if (writeSemaphore != null) writeSemaphore.acquireUninterruptibly();
+                long t0 = System.currentTimeMillis();
                 try (BasicContext ctx = new BasicContext()) {
                     task.channel().getWriter().appendData(ctx, task.name(), task.samples());
                 } catch (IOException e) {
@@ -244,20 +260,24 @@ public class WriterRunnable implements Runnable {
                 } finally {
                     if (writeSemaphore != null) writeSemaphore.release();
                 }
+                return System.currentTimeMillis() - t0;
             }));
         }
         return futures;
     }
 
     /**
-     * Waits for all submitted write futures to complete. Joining here preserves backpressure
-     * on the scheduler: if I/O is slow the next scheduled tick will observe isRunning=true
-     * and skip, rather than queuing up unbounded work.
+     * Waits for all submitted write futures to complete and returns the sum of per-channel
+     * elapsed times in milliseconds. Joining here preserves backpressure on the scheduler:
+     * if I/O is slow the next scheduled tick will observe isRunning=true and skip, rather
+     * than queuing up unbounded work.
      */
-    private void awaitWriteCompletion(List<Future<?>> futures) throws Exception {
-        for (Future<?> future : futures) {
-            future.get();
+    private long awaitWriteCompletion(List<Future<Long>> futures) throws Exception {
+        long total = 0;
+        for (Future<Long> future : futures) {
+            total += future.get();
         }
+        return total;
     }
 
     /**
@@ -265,7 +285,7 @@ public class WriterRunnable implements Runnable {
      * @throws Exception  error occurs during writing the sample buffer to the short term storage
      */
     public void flushBuffer() throws Exception {
-        write();
+        write(); // metrics from this flush cycle are intentionally discarded
     }
 
     /**

--- a/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
+++ b/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
@@ -17,8 +17,14 @@ import org.epics.archiverappliance.engine.model.ArchiveChannel;
 import org.epics.archiverappliance.engine.model.SampleBuffer;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -30,20 +36,30 @@ public class WriterRunnable implements Runnable {
     private static final Logger logger = LogManager.getLogger(WriterRunnable.class);
     /** Minimum write period [seconds] */
     private static final double MIN_WRITE_PERIOD = 1.0;
-    /**the sample buffer hash map*/
-    private final ConcurrentHashMap<String, SampleBuffer> buffers = new ConcurrentHashMap<String, SampleBuffer>();
+    /** the sample buffer hash map */
+    private final ConcurrentHashMap<String, SampleBuffer> buffers = new ConcurrentHashMap<>();
 
-    /**the configservice used by this WriterRunnable*/
-    private ConfigService configservice = null;
-    /**guards against concurrent write() invocations*/
+    /** the configservice used by this WriterRunnable */
+    private final ConfigService configservice;
+    /** guards against concurrent write() invocations */
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
+    /** virtual thread executor for parallel per-channel I/O */
+    private final ExecutorService writeExecutor = Executors.newVirtualThreadPerTaskExecutor();
+    /** tracks in-flight year-change write futures per channel to prevent duplicate submission */
+    private final ConcurrentHashMap<String, Future<?>> yearChangeFutures = new ConcurrentHashMap<>();
+    /** optional semaphore capping concurrent channel writes; null means unlimited */
+    private final Semaphore writeSemaphore;
+
     /**
      * the constructor
      * @param configservice the configservice used by this WriterRunnable
      */
     public WriterRunnable(ConfigService configservice) {
-
         this.configservice = configservice;
+        int limit = Integer.parseInt(configservice
+                .getInstallationProperties()
+                .getProperty("org.epics.archiverappliance.engine.epics.writeThreadCount", "0"));
+        this.writeSemaphore = (limit > 0) ? new Semaphore(limit) : null;
     }
 
     /** Add a channel's buffer that this thread reads
@@ -52,6 +68,7 @@ public class WriterRunnable implements Runnable {
     public void addChannel(final ArchiveChannel channel) {
         addSampleBuffer(channel.getName(), channel.getSampleBuffer());
     }
+
     /**
      * remove one sample buffer from the buffer hash map.
      * At the same time. it also removes the channel from the channel hash map in the engine context
@@ -90,7 +107,7 @@ public class WriterRunnable implements Runnable {
     }
 
     /**
-     * set the writing period. when the writing period is at least 10 seonds.
+     * set the writing period. when the writing period is at least 10 seconds.
      * When write_period &lt; 10 , the writing period is 10 seconds actually.
      * @param write_period  the writing period in second
      * @return the actual writing period in second
@@ -98,7 +115,6 @@ public class WriterRunnable implements Runnable {
     public double setWritingPeriod(double write_period) {
         double tempwrite_period = write_period;
         if (tempwrite_period < MIN_WRITE_PERIOD) {
-
             tempwrite_period = MIN_WRITE_PERIOD;
         }
         return tempwrite_period;
@@ -107,7 +123,6 @@ public class WriterRunnable implements Runnable {
     @Override
     public void run() {
         try {
-            // final long written = write();
             long startTime = System.currentTimeMillis();
             write();
             long endTime = System.currentTimeMillis();
@@ -119,12 +134,15 @@ public class WriterRunnable implements Runnable {
 
     /**
      * Flush a single channel's sample buffer on a year boundary.
-     * The isRunning guard is intentionally absent: year-change callbacks are already
-     * serialised on the scheduler thread, so there is no re-entrancy risk. The old guard
-     * was silently dropping year-change flushes whenever a bulk write cycle was running.
+     * Submits the blocking I/O to the virtual thread executor. Skips submission if a
+     * year-change write for this channel is already in-flight, preventing duplicate writes.
      * @param buffer the sample buffer to be written
      */
     private void writeYearChange(SampleBuffer buffer) {
+        if (writeExecutor.isShutdown()) {
+            logger.warn("Skipping year-change flush for {} — executor already shut down", buffer.getChannelName());
+            return;
+        }
         String channelName = buffer.getChannelName();
         ConcurrentHashMap<String, ArchiveChannel> channelList =
                 configservice.getEngineContext().getChannelList();
@@ -136,53 +154,94 @@ public class WriterRunnable implements Runnable {
         ArchiveChannel channel = channelList.get(channelName);
         if (channel == null) return;
 
-        try (BasicContext basicContext = new BasicContext()) {
-            channel.aboutToWriteBuffer((DBRTimeEvent) previousSamples.getLast());
-            channel.setlastRotateLogsEpochSeconds(System.currentTimeMillis() / 1000);
-            channel.getWriter().appendData(basicContext, channelName, previousSamples);
-            logger.info(channelName + ": year change");
-        } catch (IOException e) {
-            logger.error("Exception writing year-change buffer for " + channelName, e);
+        Future<?> existing = yearChangeFutures.get(channelName);
+        if (existing != null && !existing.isDone()) {
+            logger.debug("Year-change write already in-flight for {}; skipping duplicate", channelName);
+            return;
         }
+
+        channel.aboutToWriteBuffer((DBRTimeEvent) previousSamples.getLast());
+        channel.setlastRotateLogsEpochSeconds(System.currentTimeMillis() / 1000);
+
+        Future<?> future = writeExecutor.submit(() -> {
+            try (BasicContext ctx = new BasicContext()) {
+                channel.getWriter().appendData(ctx, channelName, previousSamples);
+                logger.info(channelName + ": year change write complete");
+            } catch (IOException e) {
+                logger.error("Exception writing year-change buffer for " + channelName, e);
+            } finally {
+                yearChangeFutures.remove(channelName);
+            }
+        });
+        yearChangeFutures.put(channelName, future);
     }
 
     /**
-     * write all sample buffers into short term storage
+     * Write all sample buffers into short term storage in parallel using Java 21 virtual threads.
+     * All buffer swaps happen on the scheduler thread before fan-out so that every channel shares
+     * a consistent epoch snapshot for the write cycle.
      * @throws Exception error occurs during writing the sample buffer to the short term storage
      */
     private void write() throws Exception {
         if (!isRunning.compareAndSet(false, true)) return;
+
+        final long writeTimestamp = System.currentTimeMillis() / 1000;
         ConcurrentHashMap<String, ArchiveChannel> channelList =
                 configservice.getEngineContext().getChannelList();
 
         try {
+            // Phase 1 (scheduler thread): swap all active buffers and prepare write tasks.
+            // Doing all swaps before submitting any I/O ensures a consistent epoch snapshot —
+            // no channel accumulates new data in its "previous" buffer while another is still writing.
+            record WriteTask(ArchiveChannel channel, String name, ArrayListEventStream samples) {}
+            List<WriteTask> tasks = new ArrayList<>(buffers.size());
+
             for (Entry<String, SampleBuffer> entry : buffers.entrySet()) {
                 SampleBuffer buffer = entry.getValue();
-                String channelNname = buffer.getChannelName();
+                if (!buffer.hasCurrentSamples()) continue;
 
+                String channelName = buffer.getChannelName();
                 buffer.resetSamples();
                 ArrayListEventStream previousSamples = buffer.getPreviousSamples();
-                try (BasicContext basicContext = new BasicContext()) {
-                    if (!previousSamples.isEmpty()) {
-                        ArchiveChannel tempChannel = channelList.get(channelNname);
-                        tempChannel.aboutToWriteBuffer((DBRTimeEvent) previousSamples.getLast());
-                        tempChannel.setlastRotateLogsEpochSeconds(System.currentTimeMillis() / 1000);
-                        tempChannel.getWriter().appendData(basicContext, channelNname, previousSamples);
+                if (previousSamples.isEmpty()) continue;
+
+                ArchiveChannel channel = channelList.get(channelName);
+                if (channel == null) continue;
+
+                channel.aboutToWriteBuffer((DBRTimeEvent) previousSamples.getLast());
+                channel.setlastRotateLogsEpochSeconds(writeTimestamp);
+                tasks.add(new WriteTask(channel, channelName, previousSamples));
+            }
+
+            // Phase 2: fan out blocking I/O to virtual threads
+            List<Future<?>> futures = new ArrayList<>(tasks.size());
+            for (WriteTask task : tasks) {
+                futures.add(writeExecutor.submit(() -> {
+                    if (writeSemaphore != null) writeSemaphore.acquireUninterruptibly();
+                    try (BasicContext ctx = new BasicContext()) {
+                        task.channel().getWriter().appendData(ctx, task.name(), task.samples());
+                    } catch (IOException e) {
+                        logger.error("Exception writing channel " + task.name(), e);
+                    } finally {
+                        if (writeSemaphore != null) writeSemaphore.release();
                     }
-                } catch (IOException e) {
-                    throw (e);
-                }
+                }));
+            }
+
+            // Phase 3: join — preserves backpressure on the scheduler
+            for (Future<?> future : futures) {
+                future.get();
             }
         } finally {
             isRunning.set(false);
         }
     }
+
     /**
      * flush out the sample buffer to the short term storage before shutting down the engine
      * @throws Exception  error occurs during writing the sample buffer to the short term storage
      */
     public void flushBuffer() throws Exception {
-
         write();
     }
 }

--- a/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
+++ b/src/main/org/epics/archiverappliance/engine/writer/WriterRunnable.java
@@ -57,9 +57,14 @@ public class WriterRunnable implements Runnable {
      */
     public WriterRunnable(ConfigService configservice) {
         this.configservice = configservice;
-        int limit = Integer.parseInt(configservice
-                .getInstallationProperties()
-                .getProperty("org.epics.archiverappliance.engine.epics.writeThreadCount", "0"));
+        int limit = 0;
+        try {
+            limit = Integer.parseInt(configservice
+                    .getInstallationProperties()
+                    .getProperty("org.epics.archiverappliance.engine.epics.writeThreadCount", "0"));
+        } catch (NumberFormatException e) {
+            logger.warn("Invalid writeThreadCount configuration, using default value: 0", e);
+        }
         this.writeSemaphore = (limit > 0) ? new Semaphore(limit) : null;
     }
 

--- a/src/main/org/epics/archiverappliance/mgmt/archivepv/CapacityPlanningData.java
+++ b/src/main/org/epics/archiverappliance/mgmt/archivepv/CapacityPlanningData.java
@@ -27,186 +27,189 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  */
 public class CapacityPlanningData {
-	private static final int MEASURED_DATA_CACHE_TIME = 60*60*1000;
-	private static Logger logger = LogManager.getLogger(CapacityPlanningData.class.getName());
-	/**
-	 * This is the percentage of time taken (averaged over the lifetime of the engine) that the engine write thread takes to flush data into short term store.
-	 */
-	private float engineWriteThreadUsage; 
-	private float secondsConsumedByWriter;
-	private float currentTotalStorageRate;
-	private float  percentageTimeForWriterAfterPVadded=0;
-	/**
-	 * ETL metrics for all the stores in this appliance that support the storage API.
-	 */
-	private ConcurrentHashMap<String, ETLMetrics> etlMetrics = new ConcurrentHashMap<String, ETLMetrics>();
-	
-	private ApplianceAggregateInfo applianceAggregateInfoAsOfLastFetch;
-	private String identity;
-	private boolean isAvailable=true;
-	private static CPStaticData cachedCPStaticData = null;
-	
-	
-	
-	class ETLMetrics {
-		String identity;
-		/**
-		 * This is percentage time taken (averaged over the lifetime of ETL) that the ETL thread takes to move data from one store to another.
-		 */
-		double etlTimeTaken;
-		/**
-		   this is the estimated storage size for pv just added.
-		   estimateStoragePVadded=sum(pvDataRate*partitionTime);
-		 */
-		long estimateStoragePVadded=0;
-		
-		double estimateETLtimePercentageAfterPVadded;
-		
-		
-		/**
-		 * This is the raw storage (in bytes, averaged over the lifetime of ETL) available before ETL runs in all the various stores.
-		 */
-		long etlStorageAvailable;
-		
-		/**
-		 * This is the total size of the store.
-		 */
-		long totalSpace;
-		
-		public ETLMetrics(JSONObject obj) {
-			this.identity = (String) obj.get("identity");
-			this.totalSpace = Long.parseLong((String) obj.get("totalSpace"));
-			this.etlStorageAvailable = Long.parseLong((String) obj.get("availableSpace"));
-			this.etlTimeTaken = Double.parseDouble((String) obj.get("avgTimeConsumedPercent"));
-			//avgTimeConsumedMs
-			
-		}
-	}
-	
-	
-	
-	public CapacityPlanningData(ConfigService configService, ApplianceInfo applianceInfo) throws IOException {
-		try{
-			identity = applianceInfo.getIdentity();
-			String engineURL = applianceInfo.getEngineURL() + "/getApplianceMetrics";
-			JSONObject engineMetrics = GetUrlContent.getURLContentAsJSONObject(engineURL);
-			DecimalFormat twoSignificantDigits = new DecimalFormat("###,###,###,###,###,###.##");
-			String secondsConsumedByWriterStr = (String) engineMetrics.get("secondsConsumedByWriter");
-			secondsConsumedByWriter=twoSignificantDigits.parse(secondsConsumedByWriterStr).floatValue();
-			String currentTotalStorageRateStr = (String) engineMetrics.get("dataRate");
-			if(currentTotalStorageRateStr != null) {
-				currentTotalStorageRate=twoSignificantDigits.parse(currentTotalStorageRateStr).floatValue();
-			}
-			String etlURL = applianceInfo.getEtlURL() + "/getStorageMetricsForAppliance";
-			JSONArray etlMetricsArray = GetUrlContent.getURLContentAsJSONArray(etlURL);
-			logger.debug(applianceInfo.getIdentity()+"'s ETLMetric:"+etlMetricsArray.toJSONString());
-			for(Object etlMetricObj : etlMetricsArray) {
-				ETLMetrics etlMetric = new ETLMetrics((JSONObject) etlMetricObj);
-				etlMetrics.put(etlMetric.identity, etlMetric);
-			}
-			
-			applianceAggregateInfoAsOfLastFetch = configService.getAggregatedApplianceInfo(applianceInfo).clone();
-		} catch(Exception e) {
-			logger.error("Exception in CapacityPlanningMetricsPerApplianceForPV", e);
-			throw new IOException(e);
-		}
-	}
-	
-	public static CPStaticData getMetricsForAppliances(ConfigService configService) throws IOException {
+    private static final int MEASURED_DATA_CACHE_TIME = 60 * 60 * 1000;
+    private static Logger logger = LogManager.getLogger(CapacityPlanningData.class.getName());
+    /**
+     * This is the percentage of time taken (averaged over the lifetime of the engine) that the engine write thread takes to flush data into short term store.
+     */
+    private float engineWriteThreadUsage;
+
+    private float secondsConsumedByWriter;
+    private float totalChannelIOSeconds;
+    private float currentTotalStorageRate;
+    private float percentageTimeForWriterAfterPVadded = 0;
+    /**
+     * ETL metrics for all the stores in this appliance that support the storage API.
+     */
+    private ConcurrentHashMap<String, ETLMetrics> etlMetrics = new ConcurrentHashMap<String, ETLMetrics>();
+
+    private ApplianceAggregateInfo applianceAggregateInfoAsOfLastFetch;
+    private String identity;
+    private boolean isAvailable = true;
+    private static CPStaticData cachedCPStaticData = null;
+
+    class ETLMetrics {
+        String identity;
+        /**
+         * This is percentage time taken (averaged over the lifetime of ETL) that the ETL thread takes to move data from one store to another.
+         */
+        double etlTimeTaken;
+        /**
+         * this is the estimated storage size for pv just added.
+         * estimateStoragePVadded=sum(pvDataRate*partitionTime);
+         */
+        long estimateStoragePVadded = 0;
+
+        double estimateETLtimePercentageAfterPVadded;
+
+        /**
+         * This is the raw storage (in bytes, averaged over the lifetime of ETL) available before ETL runs in all the various stores.
+         */
+        long etlStorageAvailable;
+
+        /**
+         * This is the total size of the store.
+         */
+        long totalSpace;
+
+        public ETLMetrics(JSONObject obj) {
+            this.identity = (String) obj.get("identity");
+            this.totalSpace = Long.parseLong((String) obj.get("totalSpace"));
+            this.etlStorageAvailable = Long.parseLong((String) obj.get("availableSpace"));
+            this.etlTimeTaken = Double.parseDouble((String) obj.get("avgTimeConsumedPercent"));
+            // avgTimeConsumedMs
+
+        }
+    }
+
+    public CapacityPlanningData(ConfigService configService, ApplianceInfo applianceInfo) throws IOException {
+        try {
+            identity = applianceInfo.getIdentity();
+            String engineURL = applianceInfo.getEngineURL() + "/getApplianceMetrics";
+            JSONObject engineMetrics = GetUrlContent.getURLContentAsJSONObject(engineURL);
+            DecimalFormat twoSignificantDigits = new DecimalFormat("###,###,###,###,###,###.##");
+            String secondsConsumedByWriterStr = (String) engineMetrics.get("secondsConsumedByWriter");
+            secondsConsumedByWriter =
+                    twoSignificantDigits.parse(secondsConsumedByWriterStr).floatValue();
+            String totalChannelIOSecondsStr = (String) engineMetrics.get("totalChannelIOSeconds");
+            if (totalChannelIOSecondsStr != null) {
+                totalChannelIOSeconds =
+                        twoSignificantDigits.parse(totalChannelIOSecondsStr).floatValue();
+            } else {
+                totalChannelIOSeconds = secondsConsumedByWriter;
+            }
+            String currentTotalStorageRateStr = (String) engineMetrics.get("dataRate");
+            if (currentTotalStorageRateStr != null) {
+                currentTotalStorageRate =
+                        twoSignificantDigits.parse(currentTotalStorageRateStr).floatValue();
+            }
+            String etlURL = applianceInfo.getEtlURL() + "/getStorageMetricsForAppliance";
+            JSONArray etlMetricsArray = GetUrlContent.getURLContentAsJSONArray(etlURL);
+            logger.debug(applianceInfo.getIdentity() + "'s ETLMetric:" + etlMetricsArray.toJSONString());
+            for (Object etlMetricObj : etlMetricsArray) {
+                ETLMetrics etlMetric = new ETLMetrics((JSONObject) etlMetricObj);
+                etlMetrics.put(etlMetric.identity, etlMetric);
+            }
+
+            applianceAggregateInfoAsOfLastFetch =
+                    configService.getAggregatedApplianceInfo(applianceInfo).clone();
+        } catch (Exception e) {
+            logger.error("Exception in CapacityPlanningMetricsPerApplianceForPV", e);
+            throw new IOException(e);
+        }
+    }
+
+    public static CPStaticData getMetricsForAppliances(ConfigService configService) throws IOException {
         Instant now = TimeUtils.now();
-		if(cachedCPStaticData != null) {
+        if (cachedCPStaticData != null) {
             if ((now.toEpochMilli() - cachedCPStaticData.timeofData.toEpochMilli()) > MEASURED_DATA_CACHE_TIME) {
-                logger.debug("Refetching static data for capacity planning as it is stale " + (now.toEpochMilli() - cachedCPStaticData.timeofData.toEpochMilli()));
-			} else {
-				logger.debug("Using cached copy of measured data");
-				return cachedCPStaticData;
-			}
-		}
+                logger.debug("Refetching static data for capacity planning as it is stale "
+                        + (now.toEpochMilli() - cachedCPStaticData.timeofData.toEpochMilli()));
+            } else {
+                logger.debug("Using cached copy of measured data");
+                return cachedCPStaticData;
+            }
+        }
 
-		logger.debug("Fetching new capacity planning static data");
-		ConcurrentHashMap<ApplianceInfo, CapacityPlanningData> capacityMetrics = new ConcurrentHashMap<ApplianceInfo, CapacityPlanningData>();
-		for(ApplianceInfo applianceInfo : configService.getAppliancesInCluster()) {
-			capacityMetrics.put(applianceInfo, new CapacityPlanningData(configService, applianceInfo));
-		}
+        logger.debug("Fetching new capacity planning static data");
+        ConcurrentHashMap<ApplianceInfo, CapacityPlanningData> capacityMetrics =
+                new ConcurrentHashMap<ApplianceInfo, CapacityPlanningData>();
+        for (ApplianceInfo applianceInfo : configService.getAppliancesInCluster()) {
+            capacityMetrics.put(applianceInfo, new CapacityPlanningData(configService, applianceInfo));
+        }
 
-		CPStaticData newStaticData = new CPStaticData(capacityMetrics, now);
-		cachedCPStaticData = newStaticData;
-		return cachedCPStaticData;
-	}
+        CPStaticData newStaticData = new CPStaticData(capacityMetrics, now);
+        cachedCPStaticData = newStaticData;
+        return cachedCPStaticData;
+    }
 
+    public static CPStaticData getCachedMetricsForAppliances(ConfigService configService) throws IOException {
+        return cachedCPStaticData;
+    }
 
-	public static CPStaticData getCachedMetricsForAppliances(ConfigService configService) throws IOException {
-		return cachedCPStaticData;
-	}
-	
-	public static class CPStaticData {
-		public ConcurrentHashMap<ApplianceInfo, CapacityPlanningData> cpApplianceMetrics;
+    public static class CPStaticData {
+        public ConcurrentHashMap<ApplianceInfo, CapacityPlanningData> cpApplianceMetrics;
         Instant timeofData;
 
-        public CPStaticData(ConcurrentHashMap<ApplianceInfo, CapacityPlanningData> cpApplianceMetrics, Instant timeofData) {
-			this.cpApplianceMetrics = cpApplianceMetrics;
-			this.timeofData = timeofData;
-		}
-	}
+        public CPStaticData(
+                ConcurrentHashMap<ApplianceInfo, CapacityPlanningData> cpApplianceMetrics, Instant timeofData) {
+            this.cpApplianceMetrics = cpApplianceMetrics;
+            this.timeofData = timeofData;
+        }
+    }
 
+    public float getEngineWriteThreadUsage(float writePeriod) {
+        engineWriteThreadUsage = (float) (totalChannelIOSeconds * 100 / writePeriod);
+        logger.debug("engineWriteThreadUsage for appliance " + identity + " is " + engineWriteThreadUsage);
+        return engineWriteThreadUsage;
+    }
 
-	public float getEngineWriteThreadUsage(float writePeriod) {
-		engineWriteThreadUsage = (float) (secondsConsumedByWriter*100/writePeriod);
-		logger.debug("engineWriteThreadUsage for appliance " + identity + " is " + engineWriteThreadUsage);
-		return engineWriteThreadUsage;
-	}
+    public ConcurrentHashMap<String, ETLMetrics> getEtlMetrics() {
+        return etlMetrics;
+    }
 
+    public float getCurrentTotalStorageRate() {
+        return currentTotalStorageRate;
+    }
 
-	public ConcurrentHashMap<String, ETLMetrics> getEtlMetrics() {
-		return etlMetrics;
-	}
+    /**
+     * Return the difference between the appliance aggregate info as of "now" and from the time we last fetched the static data.
+     * @param configService ConfigService
+     * @return ApplianceAggregateInfo  &emsp;
+     * @throws IOException  &emsp;
+     */
+    public ApplianceAggregateInfo getApplianceAggregateDifferenceFromLastFetch(ConfigService configService)
+            throws IOException {
+        ApplianceAggregateInfo freshData =
+                configService.getAggregatedApplianceInfo(configService.getAppliance(identity));
+        return freshData.getDifference(applianceAggregateInfoAsOfLastFetch);
+    }
 
+    public float getPercentageTimeForWriter() {
+        return percentageTimeForWriterAfterPVadded;
+    }
 
-	public float getCurrentTotalStorageRate() {
-		return currentTotalStorageRate;
-	}
-	
-	/**
-	 * Return the difference between the appliance aggregate info as of "now" and from the time we last fetched the static data.
-	 * @param configService ConfigService
-	 * @return ApplianceAggregateInfo  &emsp;
-	 * @throws IOException  &emsp;
-	 */
-	public ApplianceAggregateInfo getApplianceAggregateDifferenceFromLastFetch(ConfigService configService) throws IOException {
-		ApplianceAggregateInfo freshData = configService.getAggregatedApplianceInfo(configService.getAppliance(identity));
-		return freshData.getDifference(applianceAggregateInfoAsOfLastFetch);
-	}
+    public void setPercentageTimeForWriter(float percentageTimeForWriterAfterPVadded) {
+        this.percentageTimeForWriterAfterPVadded = percentageTimeForWriterAfterPVadded;
+    }
 
-	public float getPercentageTimeForWriter() {
-		return percentageTimeForWriterAfterPVadded;
-	}
+    public float getSecondsConsumedByWriter() {
+        return secondsConsumedByWriter;
+    }
 
+    public boolean isAvailable() {
+        return isAvailable;
+    }
 
-	public void setPercentageTimeForWriter(float percentageTimeForWriterAfterPVadded) {
-		this.percentageTimeForWriterAfterPVadded = percentageTimeForWriterAfterPVadded;
-	}
+    public void setAvailable(boolean isAvailable) {
+        this.isAvailable = isAvailable;
+    }
 
-
-	public float getSecondsConsumedByWriter() {
-		return secondsConsumedByWriter;
-	}
-
-
-	public boolean isAvailable() {
-		return isAvailable;
-	}
-
-
-	public void setAvailable(boolean isAvailable) {
-		this.isAvailable = isAvailable;
-	}
-	
-	
-	public String getStaticDataLastUpdated() { 
-		if(cachedCPStaticData != null) { 
-			return TimeUtils.convertToHumanReadableString(cachedCPStaticData.timeofData);
-		} else { 
-			return "Unknown";
-		}
-	}
+    public String getStaticDataLastUpdated() {
+        if (cachedCPStaticData != null) {
+            return TimeUtils.convertToHumanReadableString(cachedCPStaticData.timeofData);
+        } else {
+            return "Unknown";
+        }
+    }
 }

--- a/src/sitespecific/default/classpathfiles/archappl.properties
+++ b/src/sitespecific/default/classpathfiles/archappl.properties
@@ -69,6 +69,14 @@ org.epics.archiverappliance.engine.epics.scanJitterFactor=0.95
 # In this case, you can increase the number of SCAN threads used; the need for this is probably pretty rare 
 org.epics.archiverappliance.engine.epics.scanThreadCount=1
 
+# Maximum number of channels written concurrently within a single write cycle.
+# The engine uses Java 21 virtual threads to submit each channel's appendData() call in parallel.
+# 0 (default) means unlimited — all active channels are submitted simultaneously, which is ideal
+# for local SSD/NVMe where high concurrency is cheap.
+# For storage backends that thrash under load (NFS, shared SAN, spinning disk), set this to a low
+# value such as 4-8 to cap the number of simultaneous I/O operations.
+org.epics.archiverappliance.engine.epics.writeThreadCount=0
+
 
 # How should ETL handle out of space situations.
 # See the javadoc of org.epics.archiverappliance.etl.common.OutOfSpaceHandling for some options

--- a/src/sitespecific/default/classpathfiles/archappl.properties
+++ b/src/sitespecific/default/classpathfiles/archappl.properties
@@ -11,8 +11,10 @@ org.epics.archiverappliance.config.ConvertPVNameToKey.siteNameSpaceTerminator = 
 # We enforce a site specific minimum sampling period (read maximum rate) using this value 
 org.epics.archiverappliance.mgmt.bpl.ArchivePVAction.minimumSamplingPeriod = 0.1
 
-# We have a system wide buffer size (specified in seconds) for buffering the data in engine memory
-# This is a compromise between various factors including garbage collection, IOPS of the short term store and memory availability.
+# How often (in seconds) the engine saves buffered PV data to the short-term store.
+# Shorter values reduce memory use and data latency but increase storage I/O.
+# Reduce cautiously on NFS or network-attached storage; use the
+# "Equivalent sequential I/O load (%)" on the engine metrics page to check headroom.
 org.epics.archiverappliance.config.PVTypeInfo.secondsToBuffer = 10
 
 # Per FRIB/PSI, we have a configuration knob to increase/decrease the sample buffer size used by the engine for all PV's.

--- a/src/sitespecific/slacdev/classpathfiles/archappl.properties
+++ b/src/sitespecific/slacdev/classpathfiles/archappl.properties
@@ -69,6 +69,14 @@ org.epics.archiverappliance.engine.epics.scanJitterFactor=0.95
 # In this case, you can increase the number of SCAN threads used; the need for this is probably pretty rare 
 org.epics.archiverappliance.engine.epics.scanThreadCount=1
 
+# Maximum number of channels written concurrently within a single write cycle.
+# The engine uses Java 21 virtual threads to submit each channel's appendData() call in parallel.
+# 0 (default) means unlimited — all active channels are submitted simultaneously, which is ideal
+# for local SSD/NVMe where high concurrency is cheap.
+# For storage backends that thrash under load (NFS, shared SAN, spinning disk), set this to a low
+# value such as 4-8 to cap the number of simultaneous I/O operations.
+org.epics.archiverappliance.engine.epics.writeThreadCount=0
+
 
 # How should ETL handle out of space situations.
 # See the javadoc of org.epics.archiverappliance.etl.common.OutOfSpaceHandling for some options

--- a/src/sitespecific/slacdev/classpathfiles/archappl.properties
+++ b/src/sitespecific/slacdev/classpathfiles/archappl.properties
@@ -11,8 +11,10 @@ org.epics.archiverappliance.config.ConvertPVNameToKey.siteNameSpaceTerminator = 
 # We enforce a site specific minimum sampling period (read maximum rate) using this value 
 org.epics.archiverappliance.mgmt.bpl.ArchivePVAction.minimumSamplingPeriod = 0.1
 
-# We have a system wide buffer size (specified in seconds) for buffering the data in engine memory
-# This is a compromise between various factors including garbage collection, IOPS of the short term store and memory availability.
+# How often (in seconds) the engine saves buffered PV data to the short-term store.
+# Shorter values reduce memory use and data latency but increase storage I/O.
+# Reduce cautiously on NFS or network-attached storage; use the
+# "Equivalent sequential I/O load (%)" on the engine metrics page to check headroom.
 org.epics.archiverappliance.config.PVTypeInfo.secondsToBuffer = 10
 
 # Per FRIB/PSI, we have a configuration knob to increase/decrease the sample buffer size used by the engine for all PV's.

--- a/src/sitespecific/tests/classpathfiles/archappl.properties
+++ b/src/sitespecific/tests/classpathfiles/archappl.properties
@@ -11,8 +11,10 @@ org.epics.archiverappliance.config.ConvertPVNameToKey.siteNameSpaceTerminator = 
 # We enforce a site specific minimum sampling period (read maximum rate) using this value 
 org.epics.archiverappliance.mgmt.bpl.ArchivePVAction.minimumSamplingPeriod = 0.1
 
-# We have a system wide buffer size (specified in seconds) for buffering the data in engine memory
-# This is a compromise between various factors including garbage collection, IOPS of the short term store and memory availability.
+# How often (in seconds) the engine saves buffered PV data to the short-term store.
+# Shorter values reduce memory use and data latency but increase storage I/O.
+# Reduce cautiously on NFS or network-attached storage; use the
+# "Equivalent sequential I/O load (%)" on the engine metrics page to check headroom.
 org.epics.archiverappliance.config.PVTypeInfo.secondsToBuffer = 2
 
 # Per FRIB/PSI, we have a configuration knob to increase/decrease the sample buffer size used by the engine for all PV's.

--- a/src/sitespecific/tests/classpathfiles/archappl.properties
+++ b/src/sitespecific/tests/classpathfiles/archappl.properties
@@ -69,6 +69,14 @@ org.epics.archiverappliance.engine.epics.scanJitterFactor=0.95
 # In this case, you can increase the number of SCAN threads used; the need for this is probably pretty rare 
 org.epics.archiverappliance.engine.epics.scanThreadCount=1
 
+# Maximum number of channels written concurrently within a single write cycle.
+# The engine uses Java 21 virtual threads to submit each channel's appendData() call in parallel.
+# 0 (default) means unlimited — all active channels are submitted simultaneously, which is ideal
+# for local SSD/NVMe where high concurrency is cheap.
+# For storage backends that thrash under load (NFS, shared SAN, spinning disk), set this to a low
+# value such as 4-8 to cap the number of simultaneous I/O operations.
+org.epics.archiverappliance.engine.epics.writeThreadCount=0
+
 
 # How should ETL handle out of space situations.
 # See the javadoc of org.epics.archiverappliance.etl.common.OutOfSpaceHandling for some options

--- a/src/test/org/epics/archiverappliance/engine/test/SampleBufferHasCurrentSamplesTest.java
+++ b/src/test/org/epics/archiverappliance/engine/test/SampleBufferHasCurrentSamplesTest.java
@@ -1,0 +1,58 @@
+package org.epics.archiverappliance.engine.test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.epics.archiverappliance.common.TimeUtils;
+import org.epics.archiverappliance.config.ArchDBRTypes;
+import org.epics.archiverappliance.data.HashMapEvent;
+import org.epics.archiverappliance.engine.model.SampleBuffer;
+import org.epics.archiverappliance.engine.pv.PVMetrics;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+/**
+ * Unit tests for {@link SampleBuffer#hasCurrentSamples()}, which is used by
+ * WriterRunnable to skip idle channels without swapping their double-buffer.
+ */
+class SampleBufferHasCurrentSamplesTest {
+
+    private static SampleBuffer makeBuffer(String name) {
+        return new SampleBuffer(
+                name,
+                10,
+                ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                new PVMetrics(name, null, -1, ArchDBRTypes.DBR_SCALAR_DOUBLE));
+    }
+
+    private static HashMapEvent makeEvent() {
+        HashMap<String, Object> attrs = new HashMap<>();
+        attrs.put(HashMapEvent.SECS_FIELD_NAME, Long.toString(TimeUtils.getCurrentEpochSeconds()));
+        attrs.put(HashMapEvent.NANO_FIELD_NAME, "0");
+        attrs.put(HashMapEvent.VALUE_FIELD_NAME, 1.0);
+        return new HashMapEvent(ArchDBRTypes.DBR_SCALAR_DOUBLE, attrs);
+    }
+
+    @Test
+    void emptyBufferReturnsFalse() {
+        assertFalse(
+                makeBuffer("TEST:EMPTY").hasCurrentSamples(),
+                "Freshly created buffer should report no current samples");
+    }
+
+    @Test
+    void nonEmptyBufferReturnsTrue() {
+        SampleBuffer buffer = makeBuffer("TEST:NONEMPTY");
+        buffer.add(makeEvent());
+        assertTrue(buffer.hasCurrentSamples(), "Buffer with one sample should report current samples present");
+    }
+
+    @Test
+    void falseAfterResetSamples() {
+        SampleBuffer buffer = makeBuffer("TEST:AFTERRESET");
+        buffer.add(makeEvent());
+        buffer.resetSamples(); // swaps: previous = [event], current = new empty
+        assertFalse(buffer.hasCurrentSamples(), "After resetSamples() the fresh active buffer should be empty");
+    }
+}

--- a/src/test/org/epics/archiverappliance/engine/test/WriterRunnableTest.java
+++ b/src/test/org/epics/archiverappliance/engine/test/WriterRunnableTest.java
@@ -1,0 +1,575 @@
+package org.epics.archiverappliance.engine.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.epics.archiverappliance.Event;
+import org.epics.archiverappliance.EventStream;
+import org.epics.archiverappliance.Writer;
+import org.epics.archiverappliance.common.BasicContext;
+import org.epics.archiverappliance.common.TimeUtils;
+import org.epics.archiverappliance.config.ArchDBRTypes;
+import org.epics.archiverappliance.config.ConfigService;
+import org.epics.archiverappliance.data.HashMapEvent;
+import org.epics.archiverappliance.engine.model.ArchiveChannel;
+import org.epics.archiverappliance.engine.model.SampleBuffer;
+import org.epics.archiverappliance.engine.pv.EngineContext;
+import org.epics.archiverappliance.engine.pv.PVMetrics;
+import org.epics.archiverappliance.engine.writer.WriterRunnable;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Unit tests for {@link WriterRunnable} covering parallelism, concurrency safety,
+ * and correctness.
+ */
+class WriterRunnableTest {
+
+    /** Number of channels for the parallelism timing test */
+    private static final int PARALLEL_CHANNEL_COUNT = 200;
+    /** Channels and samples used for the data-integrity test */
+    private static final int DATA_CHANNEL_COUNT = 100;
+    private static final int SAMPLES_PER_CHANNEL = 20;
+    /** Per-channel I/O delay used in timing-sensitive tests */
+    private static final long WRITE_DELAY_MS = 50;
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds the mocked ConfigService + EngineContext that WriterRunnable requires.
+     *
+     * @param channelList    the channel map the engine context will return
+     * @param writeThreadCount  0 = unlimited (no semaphore), >0 caps concurrency
+     */
+    private ConfigService buildConfigService(
+            ConcurrentHashMap<String, ArchiveChannel> channelList, int writeThreadCount) {
+        EngineContext engineContext = mock(EngineContext.class);
+        when(engineContext.getChannelList()).thenReturn(channelList);
+        when(engineContext.getWriteThreadCount()).thenReturn(writeThreadCount);
+
+        Properties props = new Properties();
+        props.setProperty(
+                "org.epics.archiverappliance.engine.epics.writeThreadCount", Integer.toString(writeThreadCount));
+
+        ConfigService configService = mock(ConfigService.class);
+        when(configService.getEngineContext()).thenReturn(engineContext);
+        when(configService.getInstallationProperties()).thenReturn(props);
+        return configService;
+    }
+
+    private HashMapEvent makeEvent() {
+        return makeEventAt(TimeUtils.getCurrentEpochSeconds());
+    }
+
+    /**
+     * Creates an event with a specific EPICS-epoch timestamp and a value equal to that
+     * timestamp, so both fields can be used to assert event identity at the write site.
+     */
+    private HashMapEvent makeEventAt(long epicsSecs) {
+        HashMap<String, Object> attrs = new HashMap<>();
+        attrs.put(HashMapEvent.SECS_FIELD_NAME, Long.toString(epicsSecs));
+        attrs.put(HashMapEvent.NANO_FIELD_NAME, "0");
+        attrs.put(HashMapEvent.VALUE_FIELD_NAME, (double) epicsSecs);
+        return new HashMapEvent(ArchDBRTypes.DBR_SCALAR_DOUBLE, attrs);
+    }
+
+    /**
+     * Returns an event timestamped at the start of the next calendar year in EPICS epoch seconds.
+     * Adding this to a buffer that has already seen a current-year event will trigger the year
+     * listener.
+     */
+    private HashMapEvent makeNextYearEvent() {
+        int nextYear = LocalDate.now(ZoneOffset.UTC).getYear() + 1;
+        long javaEpochSecs =
+                LocalDate.of(nextYear, 1, 1).atStartOfDay(ZoneOffset.UTC).toEpochSecond();
+        // EPICS epoch starts Jan 1, 1990; subtract its Unix timestamp to get EPICS seconds
+        long epicsEpochOffset = Instant.parse("1990-01-01T00:00:00Z").getEpochSecond();
+        long epicsEpochSecs = javaEpochSecs - epicsEpochOffset;
+
+        HashMap<String, Object> attrs = new HashMap<>();
+        attrs.put(HashMapEvent.SECS_FIELD_NAME, Long.toString(epicsEpochSecs));
+        attrs.put(HashMapEvent.NANO_FIELD_NAME, "0");
+        attrs.put(HashMapEvent.VALUE_FIELD_NAME, 99.0);
+        return new HashMapEvent(ArchDBRTypes.DBR_SCALAR_DOUBLE, attrs);
+    }
+
+    /** A Writer that sleeps WRITE_DELAY_MS per call to simulate blocking I/O. */
+    static class SlowCountingWriter implements Writer {
+        private final AtomicInteger writeCount = new AtomicInteger(0);
+
+        @Override
+        public int appendData(BasicContext context, String pvName, EventStream stream) throws IOException {
+            try {
+                Thread.sleep(WRITE_DELAY_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            int count = 0;
+            for (@SuppressWarnings("unused") Event e : stream) count++;
+            writeCount.incrementAndGet();
+            return count;
+        }
+
+        @Override
+        public Event getLastKnownEvent(BasicContext context, String pvName) {
+            return null;
+        }
+
+        int getWriteCount() {
+            return writeCount.get();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * Channels with no buffered samples must not trigger appendData.
+     * Verifies that hasCurrentSamples() correctly gates the buffer swap and I/O submission.
+     * Uses 40 channels (20 active, 20 idle) to give the skip logic meaningful coverage.
+     */
+    @Test
+    void testIdleChannelsSkipped() {
+        int activeCount = 20;
+        int idleCount = 20;
+        Set<String> channelsWritten = ConcurrentHashMap.newKeySet();
+
+        Writer trackingWriter = new Writer() {
+            @Override
+            public int appendData(BasicContext ctx, String pvName, EventStream stream) {
+                channelsWritten.add(pvName);
+                for (@SuppressWarnings("unused") Event e : stream) {}
+                return 0;
+            }
+
+            @Override
+            public Event getLastKnownEvent(BasicContext ctx, String pvName) {
+                return null;
+            }
+        };
+
+        Set<String> expectedActive = new HashSet<>();
+        ConcurrentHashMap<String, ArchiveChannel> channelList = new ConcurrentHashMap<>();
+        WriterRunnable writerRunnable = new WriterRunnable(buildConfigService(channelList, 0));
+
+        for (int i = 0; i < activeCount + idleCount; i++) {
+            String name = "TEST:PV:" + i;
+            SampleBuffer buffer = new SampleBuffer(
+                    name, 10, ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                    new PVMetrics(name, null, -1, ArchDBRTypes.DBR_SCALAR_DOUBLE));
+            if (i < activeCount) {
+                buffer.add(makeEvent());
+                expectedActive.add(name);
+            }
+
+            ArchiveChannel channel = mock(ArchiveChannel.class);
+            when(channel.getName()).thenReturn(name);
+            when(channel.getSampleBuffer()).thenReturn(buffer);
+            when(channel.getWriter()).thenReturn(trackingWriter);
+            channelList.put(name, channel);
+            writerRunnable.addChannel(channel);
+        }
+
+        writerRunnable.run();
+        writerRunnable.shutdown();
+
+        assertEquals(expectedActive, channelsWritten,
+                "appendData must be called for exactly the " + activeCount
+                        + " active channels — no more, no fewer");
+    }
+
+    /**
+     * Every event buffered for every channel must arrive at the writer with its identity
+     * intact. Uses DATA_CHANNEL_COUNT channels × SAMPLES_PER_CHANNEL events each.
+     * Each event carries a unique EPICS timestamp; the writer collects the timestamps it
+     * sees per channel and we assert exact set equality against what was buffered.
+     */
+    @Test
+    void testAllActiveChannelsWritten() {
+        // base EPICS time; each event gets base + channel_index * stride + sample_index
+        // so all timestamps are unique across the entire test and within the current year.
+        long base = TimeUtils.getCurrentEpochSeconds();
+        int stride = SAMPLES_PER_CHANNEL + 1; // gap between channels avoids overlap
+
+        Map<String, Set<Instant>> expected = new HashMap<>();
+        ConcurrentHashMap<String, Set<Instant>> actual = new ConcurrentHashMap<>();
+
+        Writer verifyingWriter = new Writer() {
+            @Override
+            public int appendData(BasicContext ctx, String pvName, EventStream stream) {
+                Set<Instant> written = actual.computeIfAbsent(pvName, k -> ConcurrentHashMap.newKeySet());
+                int count = 0;
+                for (Event e : stream) {
+                    written.add(e.getEventTimeStamp());
+                    count++;
+                }
+                return count;
+            }
+
+            @Override
+            public Event getLastKnownEvent(BasicContext ctx, String pvName) {
+                return null;
+            }
+        };
+
+        ConcurrentHashMap<String, ArchiveChannel> channelList = new ConcurrentHashMap<>();
+        WriterRunnable writerRunnable = new WriterRunnable(buildConfigService(channelList, 0));
+
+        for (int i = 0; i < DATA_CHANNEL_COUNT; i++) {
+            String name = "TEST:PV:" + i;
+            SampleBuffer buffer = new SampleBuffer(
+                    name, SAMPLES_PER_CHANNEL + 5, ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                    new PVMetrics(name, null, -1, ArchDBRTypes.DBR_SCALAR_DOUBLE));
+
+            Set<Instant> channelExpected = new HashSet<>();
+            for (int s = 0; s < SAMPLES_PER_CHANNEL; s++) {
+                HashMapEvent event = makeEventAt(base + (long) i * stride + s);
+                buffer.add(event);
+                channelExpected.add(event.getEventTimeStamp());
+            }
+            expected.put(name, channelExpected);
+
+            ArchiveChannel channel = mock(ArchiveChannel.class);
+            when(channel.getName()).thenReturn(name);
+            when(channel.getSampleBuffer()).thenReturn(buffer);
+            when(channel.getWriter()).thenReturn(verifyingWriter);
+            channelList.put(name, channel);
+            writerRunnable.addChannel(channel);
+        }
+
+        writerRunnable.run();
+        writerRunnable.shutdown();
+
+        assertEquals(DATA_CHANNEL_COUNT, actual.size(),
+                "Every channel must have been written");
+        for (Map.Entry<String, Set<Instant>> entry : expected.entrySet()) {
+            assertEquals(entry.getValue(), actual.get(entry.getKey()),
+                    "Events for " + entry.getKey() + " must be written exactly as buffered — no loss, no duplication, no corruption");
+        }
+    }
+
+    /**
+     * With PARALLEL_CHANNEL_COUNT channels each requiring WRITE_DELAY_MS of I/O, the
+     * total wall-clock time must be far below the sequential upper bound, proving that
+     * virtual threads run the writes concurrently.
+     */
+    @Test
+    void testWritesRunInParallel() {
+        SlowCountingWriter slowWriter = new SlowCountingWriter();
+        ConcurrentHashMap<String, ArchiveChannel> channelList = new ConcurrentHashMap<>();
+        WriterRunnable writerRunnable = new WriterRunnable(buildConfigService(channelList, 0));
+
+        for (int i = 0; i < PARALLEL_CHANNEL_COUNT; i++) {
+            String name = "TEST:PV:" + i;
+            SampleBuffer buffer = new SampleBuffer(
+                    name, 10, ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                    new PVMetrics(name, null, -1, ArchDBRTypes.DBR_SCALAR_DOUBLE));
+            buffer.add(makeEvent());
+
+            ArchiveChannel channel = mock(ArchiveChannel.class);
+            when(channel.getName()).thenReturn(name);
+            when(channel.getSampleBuffer()).thenReturn(buffer);
+            when(channel.getWriter()).thenReturn(slowWriter);
+            channelList.put(name, channel);
+            writerRunnable.addChannel(channel);
+        }
+
+        long start = System.currentTimeMillis();
+        writerRunnable.run();
+        long elapsed = System.currentTimeMillis() - start;
+        writerRunnable.shutdown();
+
+        long sequentialMs = PARALLEL_CHANNEL_COUNT * WRITE_DELAY_MS;
+        assertEquals(PARALLEL_CHANNEL_COUNT, slowWriter.getWriteCount(),
+                "All " + PARALLEL_CHANNEL_COUNT + " channels must be written");
+        assertTrue(elapsed < sequentialMs,
+                "Parallel writes took " + elapsed + "ms; sequential would take ~" + sequentialMs
+                        + "ms — expected much less");
+    }
+
+    /**
+     * A second concurrent run() call while the first is still executing must be silently dropped
+     * by the AtomicBoolean reentrancy guard.
+     */
+    @Test
+    void testReentrancyGuardPreventsOverlap() throws Exception {
+        AtomicInteger appendDataCallCount = new AtomicInteger(0);
+        CountDownLatch firstRunStarted = new CountDownLatch(1);
+
+        Writer blockingWriter = new Writer() {
+            @Override
+            public int appendData(BasicContext ctx, String pvName, EventStream stream) throws IOException {
+                appendDataCallCount.incrementAndGet();
+                firstRunStarted.countDown();
+                try {
+                    Thread.sleep(300);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                // Consume the event stream
+                for (@SuppressWarnings("unused") Event e : stream) {}
+                return 0;
+            }
+
+            @Override
+            public Event getLastKnownEvent(BasicContext ctx, String pvName) {
+                return null;
+            }
+        };
+
+        String name = "TEST:PV:0";
+        SampleBuffer buffer = new SampleBuffer(
+                name,
+                10,
+                ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                new PVMetrics(name, null, -1, ArchDBRTypes.DBR_SCALAR_DOUBLE));
+        buffer.add(makeEvent());
+
+        ArchiveChannel channel = mock(ArchiveChannel.class);
+        when(channel.getName()).thenReturn(name);
+        when(channel.getSampleBuffer()).thenReturn(buffer);
+        when(channel.getWriter()).thenReturn(blockingWriter);
+
+        ConcurrentHashMap<String, ArchiveChannel> channelList = new ConcurrentHashMap<>();
+        channelList.put(name, channel);
+        WriterRunnable writerRunnable = new WriterRunnable(buildConfigService(channelList, 0));
+        writerRunnable.addChannel(channel);
+
+        // Start the first run in a virtual thread so it blocks in appendData
+        Thread firstRun = Thread.ofVirtual().start(() -> {
+            try {
+                writerRunnable.run();
+            } catch (Exception ignored) {
+            }
+        });
+
+        // Wait until the first run is inside appendData, then fire a second run
+        assertTrue(firstRunStarted.await(5, TimeUnit.SECONDS), "First run should have started within 5 seconds");
+        writerRunnable.run(); // must return immediately — isRunning is true
+
+        firstRun.join(5000);
+        writerRunnable.shutdown();
+
+        assertFalse(firstRun.isAlive(), "First run should have completed");
+        assertEquals(
+                1,
+                appendDataCallCount.get(),
+                "reentrancy guard must suppress the second run() — appendData called only once");
+    }
+
+    /**
+     * When writeThreadCount > 0, the Semaphore must cap the number of channel writes
+     * executing concurrently to that limit.
+     */
+    @Test
+    void testSemaphoreCapsMaxConcurrency() {
+        int cap = 3;
+        AtomicInteger concurrentWrites = new AtomicInteger(0);
+        AtomicInteger maxConcurrentWrites = new AtomicInteger(0);
+
+        Writer cappedWriter = new Writer() {
+            @Override
+            public int appendData(BasicContext ctx, String pvName, EventStream stream) throws IOException {
+                int current = concurrentWrites.incrementAndGet();
+                maxConcurrentWrites.updateAndGet(m -> Math.max(m, current));
+                try {
+                    Thread.sleep(WRITE_DELAY_MS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                concurrentWrites.decrementAndGet();
+                // Consume the event stream
+                for (@SuppressWarnings("unused") Event e : stream) {}
+                return 0;
+            }
+
+            @Override
+            public Event getLastKnownEvent(BasicContext ctx, String pvName) {
+                return null;
+            }
+        };
+
+        ConcurrentHashMap<String, ArchiveChannel> channelList = new ConcurrentHashMap<>();
+        // writeThreadCount = cap → semaphore limits to `cap` concurrent writes
+        WriterRunnable writerRunnable = new WriterRunnable(buildConfigService(channelList, cap));
+
+        for (int i = 0; i < 20; i++) {
+            String name = "TEST:PV:" + i;
+            SampleBuffer buffer = new SampleBuffer(
+                    name,
+                    10,
+                    ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                    new PVMetrics(name, null, -1, ArchDBRTypes.DBR_SCALAR_DOUBLE));
+            buffer.add(makeEvent());
+
+            ArchiveChannel channel = mock(ArchiveChannel.class);
+            when(channel.getName()).thenReturn(name);
+            when(channel.getSampleBuffer()).thenReturn(buffer);
+            when(channel.getWriter()).thenReturn(cappedWriter);
+            channelList.put(name, channel);
+            writerRunnable.addChannel(channel);
+        }
+
+        writerRunnable.run();
+        writerRunnable.shutdown();
+
+        assertTrue(
+                maxConcurrentWrites.get() <= cap,
+                "Semaphore should limit concurrent writes to " + cap + ", but observed " + maxConcurrentWrites.get());
+    }
+
+    /**
+     * Verifies that the year-change write path calls aboutToWriteBuffer().
+     * <p>
+     * The year listener is triggered by adding an event whose timestamp crosses the year
+     * boundary. aboutToWriteBuffer() is called synchronously before I/O is submitted, so
+     * no extra waiting is required to verify the call.
+     */
+    @Test
+    void testYearChangeCallsAboutToWriteBuffer() throws Exception {
+        CountDownLatch writeDone = new CountDownLatch(1);
+        Writer latchWriter = new Writer() {
+            @Override
+            public int appendData(BasicContext ctx, String pvName, EventStream stream) {
+                for (@SuppressWarnings("unused") Event e : stream) {}
+                writeDone.countDown();
+                return 0;
+            }
+
+            @Override
+            public Event getLastKnownEvent(BasicContext ctx, String pvName) {
+                return null;
+            }
+        };
+
+        String name = "TEST:YEARCHANGE:PV";
+        SampleBuffer buffer = new SampleBuffer(
+                name,
+                10,
+                ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                new PVMetrics(name, null, -1, ArchDBRTypes.DBR_SCALAR_DOUBLE));
+
+        ArchiveChannel channel = mock(ArchiveChannel.class);
+        when(channel.getName()).thenReturn(name);
+        when(channel.getSampleBuffer()).thenReturn(buffer);
+        when(channel.getWriter()).thenReturn(latchWriter);
+
+        ConcurrentHashMap<String, ArchiveChannel> channelList = new ConcurrentHashMap<>();
+        channelList.put(name, channel);
+        WriterRunnable writerRunnable = new WriterRunnable(buildConfigService(channelList, 0));
+        writerRunnable.addChannel(channel);
+
+        // Seed the buffer with a current-year event so the buffer's year is set
+        buffer.add(makeEvent());
+        // Adding a next-year event triggers the year listener → writeYearChange
+        buffer.add(makeNextYearEvent());
+
+        // Wait for the async appendData to complete (confirms the write was actually submitted)
+        assertTrue(writeDone.await(5, TimeUnit.SECONDS), "Year-change write should complete within 5 seconds");
+        writerRunnable.shutdown();
+
+        // aboutToWriteBuffer is called synchronously in writeYearChange before I/O is submitted
+        verify(channel).aboutToWriteBuffer(any());
+    }
+
+    /**
+     * Verifies that removeChannel flushes any buffered samples synchronously before
+     * the channel is removed, so no data is lost on archival stop.
+     */
+    @Test
+    void testRemoveChannelFlushesSynchronously() {
+        AtomicInteger appendCount = new AtomicInteger(0);
+        Writer trackingWriter = new Writer() {
+            @Override
+            public int appendData(BasicContext ctx, String pvName, EventStream stream) {
+                appendCount.incrementAndGet();
+                return 0;
+            }
+
+            @Override
+            public Event getLastKnownEvent(BasicContext ctx, String pvName) {
+                return null;
+            }
+        };
+
+        String name = "TEST:REMOVE:PV";
+        SampleBuffer buffer = new SampleBuffer(
+                name,
+                10,
+                ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                new PVMetrics(name, null, -1, ArchDBRTypes.DBR_SCALAR_DOUBLE));
+        buffer.add(makeEvent());
+
+        ArchiveChannel channel = mock(ArchiveChannel.class);
+        when(channel.getName()).thenReturn(name);
+        when(channel.getSampleBuffer()).thenReturn(buffer);
+        when(channel.getWriter()).thenReturn(trackingWriter);
+
+        ConcurrentHashMap<String, ArchiveChannel> channelList = new ConcurrentHashMap<>();
+        channelList.put(name, channel);
+        WriterRunnable writerRunnable = new WriterRunnable(buildConfigService(channelList, 0));
+        writerRunnable.addChannel(channel);
+
+        writerRunnable.removeChannel(name);
+        writerRunnable.shutdown();
+
+        assertEquals(
+                1,
+                appendCount.get(),
+                "removeChannel must flush buffered data synchronously before removing the channel");
+    }
+
+    /**
+     * Verifies that removeChannel does not call appendData when the buffer is empty,
+     * avoiding a spurious zero-length write on removal.
+     */
+    @Test
+    void testRemoveChannelSkipsFlushWhenEmpty() throws Exception {
+        Writer writer = mock(Writer.class);
+
+        String name = "TEST:REMOVE:EMPTY";
+        SampleBuffer buffer = new SampleBuffer(
+                name,
+                10,
+                ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                new PVMetrics(name, null, -1, ArchDBRTypes.DBR_SCALAR_DOUBLE));
+        // No samples added — buffer is empty
+
+        ArchiveChannel channel = mock(ArchiveChannel.class);
+        when(channel.getName()).thenReturn(name);
+        when(channel.getSampleBuffer()).thenReturn(buffer);
+        when(channel.getWriter()).thenReturn(writer);
+
+        ConcurrentHashMap<String, ArchiveChannel> channelList = new ConcurrentHashMap<>();
+        channelList.put(name, channel);
+        WriterRunnable writerRunnable = new WriterRunnable(buildConfigService(channelList, 0));
+        writerRunnable.addChannel(channel);
+
+        writerRunnable.removeChannel(name);
+        writerRunnable.shutdown();
+
+        verify(writer, never()).appendData(any(), any(), any());
+    }
+}

--- a/src/test/org/epics/archiverappliance/engine/test/WriterRunnableTest.java
+++ b/src/test/org/epics/archiverappliance/engine/test/WriterRunnableTest.java
@@ -48,6 +48,7 @@ class WriterRunnableTest {
     private static final int PARALLEL_CHANNEL_COUNT = 200;
     /** Channels and samples used for the data-integrity test */
     private static final int DATA_CHANNEL_COUNT = 100;
+
     private static final int SAMPLES_PER_CHANNEL = 20;
     /** Per-channel I/O delay used in timing-sensitive tests */
     private static final long WRITE_DELAY_MS = 50;
@@ -177,7 +178,9 @@ class WriterRunnableTest {
         for (int i = 0; i < activeCount + idleCount; i++) {
             String name = "TEST:PV:" + i;
             SampleBuffer buffer = new SampleBuffer(
-                    name, 10, ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                    name,
+                    10,
+                    ArchDBRTypes.DBR_SCALAR_DOUBLE,
                     new PVMetrics(name, null, -1, ArchDBRTypes.DBR_SCALAR_DOUBLE));
             if (i < activeCount) {
                 buffer.add(makeEvent());
@@ -195,9 +198,10 @@ class WriterRunnableTest {
         writerRunnable.run();
         writerRunnable.shutdown();
 
-        assertEquals(expectedActive, channelsWritten,
-                "appendData must be called for exactly the " + activeCount
-                        + " active channels — no more, no fewer");
+        assertEquals(
+                expectedActive,
+                channelsWritten,
+                "appendData must be called for exactly the " + activeCount + " active channels — no more, no fewer");
     }
 
     /**
@@ -240,7 +244,9 @@ class WriterRunnableTest {
         for (int i = 0; i < DATA_CHANNEL_COUNT; i++) {
             String name = "TEST:PV:" + i;
             SampleBuffer buffer = new SampleBuffer(
-                    name, SAMPLES_PER_CHANNEL + 5, ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                    name,
+                    SAMPLES_PER_CHANNEL + 5,
+                    ArchDBRTypes.DBR_SCALAR_DOUBLE,
                     new PVMetrics(name, null, -1, ArchDBRTypes.DBR_SCALAR_DOUBLE));
 
             Set<Instant> channelExpected = new HashSet<>();
@@ -262,11 +268,13 @@ class WriterRunnableTest {
         writerRunnable.run();
         writerRunnable.shutdown();
 
-        assertEquals(DATA_CHANNEL_COUNT, actual.size(),
-                "Every channel must have been written");
+        assertEquals(DATA_CHANNEL_COUNT, actual.size(), "Every channel must have been written");
         for (Map.Entry<String, Set<Instant>> entry : expected.entrySet()) {
-            assertEquals(entry.getValue(), actual.get(entry.getKey()),
-                    "Events for " + entry.getKey() + " must be written exactly as buffered — no loss, no duplication, no corruption");
+            assertEquals(
+                    entry.getValue(),
+                    actual.get(entry.getKey()),
+                    "Events for " + entry.getKey()
+                            + " must be written exactly as buffered — no loss, no duplication, no corruption");
         }
     }
 
@@ -284,7 +292,9 @@ class WriterRunnableTest {
         for (int i = 0; i < PARALLEL_CHANNEL_COUNT; i++) {
             String name = "TEST:PV:" + i;
             SampleBuffer buffer = new SampleBuffer(
-                    name, 10, ArchDBRTypes.DBR_SCALAR_DOUBLE,
+                    name,
+                    10,
+                    ArchDBRTypes.DBR_SCALAR_DOUBLE,
                     new PVMetrics(name, null, -1, ArchDBRTypes.DBR_SCALAR_DOUBLE));
             buffer.add(makeEvent());
 
@@ -302,9 +312,12 @@ class WriterRunnableTest {
         writerRunnable.shutdown();
 
         long sequentialMs = PARALLEL_CHANNEL_COUNT * WRITE_DELAY_MS;
-        assertEquals(PARALLEL_CHANNEL_COUNT, slowWriter.getWriteCount(),
+        assertEquals(
+                PARALLEL_CHANNEL_COUNT,
+                slowWriter.getWriteCount(),
                 "All " + PARALLEL_CHANNEL_COUNT + " channels must be written");
-        assertTrue(elapsed < sequentialMs,
+        assertTrue(
+                elapsed < sequentialMs,
                 "Parallel writes took " + elapsed + "ms; sequential would take ~" + sequentialMs
                         + "ms — expected much less");
     }


### PR DESCRIPTION
Main change is to set WriterRunnable to create a virtual thread per non empty archive channel to write each asynchronously. Should mean that the writing is much more performant and take advantage of modern faster storage and multiple CPUs. 

Also adds a proper shutdown hook for the WriterRunnable.