### PR TITLE
Ignore the join files metadata

### DIFF
--- a/src/main/edu/stanford/slac/archiverappliance/plain/parquet/ParquetAppendDataStateData.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/parquet/ParquetAppendDataStateData.java
@@ -120,6 +120,7 @@ public class ParquetAppendDataStateData extends AppendDataStateData {
         if (recompress) {
             rewriteOptionsBuilder = rewriteOptionsBuilder.transform(compressionCodecName);
         }
+        rewriteOptionsBuilder = rewriteOptionsBuilder.ignoreJoinFilesMetadata(true);
         RewriteOptions rewriteOptions = rewriteOptionsBuilder.build();
         try (ParquetRewriter rewriter = new ParquetRewriter(rewriteOptions)) {
             rewriter.processBlocks();


### PR DESCRIPTION
This should mean we dont get extra metadata when combining a lot of smaller files.