### PR TITLE
Delete any existing entry in the tar file only after successfully appending the updated content.

### DIFF
--- a/src/main/org/epics/archiverappliance/utils/nio/tar/TarSeekableByteChannel.java
+++ b/src/main/org/epics/archiverappliance/utils/nio/tar/TarSeekableByteChannel.java
@@ -65,10 +65,11 @@ public class TarSeekableByteChannel implements SeekableByteChannel {
                     logger.debug("{} is the last entry in the tar file", tarEntry.entryName());
                     lastFilenInTar = true;
                 }
+
+                TarEntry toBeDeletedTarEntry = null;
                 if (this.tarEntry.isInsideTar()) {
                     if (!lastFilenInTar) {
-                        this.gfs.tarFile.markFileAsDeleted(this.tarEntry);
-                        logger.debug("Done deleting any existing tar entries for {}", this.tarEntry.entryName());
+                        toBeDeletedTarEntry = this.tarEntry;
                     }
                 }
                 if (!Files.exists(this.gfs.getTarPath())
@@ -86,6 +87,13 @@ public class TarSeekableByteChannel implements SeekableByteChannel {
                 } else {
                     this.gfs.tarFile.appendFiles(Arrays.asList(appendTarEntry));
                 }
+
+                if (toBeDeletedTarEntry != null) {
+                    this.gfs.tarFile.markFileAsDeleted(this.tarEntry);
+                    logger.debug("Done deleting previously existing tar entries for {}", this.tarEntry.entryName());
+                    toBeDeletedTarEntry = null;
+                }
+
                 this.gfs.reloadCatalog();
 
                 logger.debug(


### PR DESCRIPTION
Minor change to better protect against data loss. We should rarely/never encounter this situation with our intended use cases but still this should help in case we run into any exceptions appending the new content. At the very least, the older content is still there and can perhaps be used for repairs.