### PR TITLE
fix: truncate corrupt tail before appending to PB file

### DIFF
--- a/src/main/edu/stanford/slac/archiverappliance/plain/pb/PBAppendDataStateData.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/pb/PBAppendDataStateData.java
@@ -2,7 +2,6 @@ package edu.stanford.slac.archiverappliance.plain.pb;
 
 import edu.stanford.slac.archiverappliance.plain.AppendDataStateData;
 import edu.stanford.slac.archiverappliance.plain.EventFileWriter;
-import edu.stanford.slac.archiverappliance.plain.FileInfo;
 import edu.stanford.slac.archiverappliance.plain.PathResolver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -93,7 +92,11 @@ public class PBAppendDataStateData extends AppendDataStateData {
     private static void truncateCorruptFile(Path pvPath, long truncationPoint) throws IOException {
         long fileSize = Files.size(pvPath);
         if (truncationPoint < fileSize) {
-            logger.warn("Incomplete record detected at end of {} (likely a crash mid-write); truncating {} -> {} bytes before appending", pvPath, fileSize, truncationPoint);
+            logger.warn(
+                    "Incomplete record detected at end of {} (likely a crash mid-write); truncating {} -> {} bytes before appending",
+                    pvPath,
+                    fileSize,
+                    truncationPoint);
             try (FileChannel fc = FileChannel.open(pvPath, StandardOpenOption.WRITE)) {
                 fc.truncate(truncationPoint);
             }

--- a/src/main/edu/stanford/slac/archiverappliance/plain/pb/PBAppendDataStateData.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/pb/PBAppendDataStateData.java
@@ -16,6 +16,7 @@ import org.epics.archiverappliance.etl.ETLContext;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
+import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -69,7 +70,7 @@ public class PBAppendDataStateData extends AppendDataStateData {
 
     @Override
     public void updateStateBasedOnExistingFile(String pvName, Path pvPath) throws IOException {
-        FileInfo info = new PBFileInfo(pvPath);
+        PBFileInfo info = new PBFileInfo(pvPath);
         if (!info.getPVName().equals(pvName))
             throw new IOException("Trying to append data for " + pvName
                     + " to a file "
@@ -79,6 +80,14 @@ public class PBAppendDataStateData extends AppendDataStateData {
         this.previousYear = info.getDataYear();
         if (info.getLastEvent() != null) {
             this.lastKnownTimeStamp = info.getLastEvent().getEventTimeStamp();
+            long truncationPoint = info.getTruncationPoint();
+            long fileSize = Files.size(pvPath);
+            if (truncationPoint < fileSize) {
+                logger.warn("Incomplete record detected at end of {} (likely a crash mid-write); truncating {} -> {} bytes before appending", pvPath, fileSize, truncationPoint);
+                try (FileChannel fc = FileChannel.open(pvPath, StandardOpenOption.WRITE)) {
+                    fc.truncate(truncationPoint);
+                }
+            }
         } else {
             logger.error("Cannot determine last known timestamp when updating state for PV " + pvName
                     + " and path "

--- a/src/main/edu/stanford/slac/archiverappliance/plain/pb/PBAppendDataStateData.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/pb/PBAppendDataStateData.java
@@ -80,14 +80,7 @@ public class PBAppendDataStateData extends AppendDataStateData {
         this.previousYear = info.getDataYear();
         if (info.getLastEvent() != null) {
             this.lastKnownTimeStamp = info.getLastEvent().getEventTimeStamp();
-            long truncationPoint = info.getTruncationPoint();
-            long fileSize = Files.size(pvPath);
-            if (truncationPoint < fileSize) {
-                logger.warn("Incomplete record detected at end of {} (likely a crash mid-write); truncating {} -> {} bytes before appending", pvPath, fileSize, truncationPoint);
-                try (FileChannel fc = FileChannel.open(pvPath, StandardOpenOption.WRITE)) {
-                    fc.truncate(truncationPoint);
-                }
-            }
+            truncateCorruptFile(pvPath, info.getTruncationPoint());
         } else {
             logger.error("Cannot determine last known timestamp when updating state for PV " + pvName
                     + " and path "
@@ -95,6 +88,16 @@ public class PBAppendDataStateData extends AppendDataStateData {
         }
         this.writer = new PBEventFileWriter(pvName, pvPath, info.getType(), this.previousYear, true);
         this.previousFilePath = pvPath;
+    }
+
+    private static void truncateCorruptFile(Path pvPath, long truncationPoint) throws IOException {
+        long fileSize = Files.size(pvPath);
+        if (truncationPoint < fileSize) {
+            logger.warn("Incomplete record detected at end of {} (likely a crash mid-write); truncating {} -> {} bytes before appending", pvPath, fileSize, truncationPoint);
+            try (FileChannel fc = FileChannel.open(pvPath, StandardOpenOption.WRITE)) {
+                fc.truncate(truncationPoint);
+            }
+        }
     }
 
     @Override

--- a/src/main/edu/stanford/slac/archiverappliance/plain/pb/PBFileInfo.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/pb/PBFileInfo.java
@@ -36,6 +36,7 @@ public class PBFileInfo extends FileInfo {
     PayloadInfo info;
     long positionOfFirstSample = 0L;
     long positionOfLastSample = 0;
+    private long truncationPoint = 0;
 
     @Override
     public String toString() {
@@ -62,6 +63,7 @@ public class PBFileInfo extends FileInfo {
             positionOfFirstSample = lis.getCurrentPosition();
             // This is not strictly correct; but this will be adjusted below.
             positionOfLastSample = Files.size(path);
+            truncationPoint = Files.size(path);
 
             ArchDBRTypes type = ArchDBRTypes.valueOf(info.getType());
             Constructor<? extends DBRTimeEvent> unmarshallingConstructor =
@@ -120,6 +122,10 @@ public class PBFileInfo extends FileInfo {
         return positionOfLastSample;
     }
 
+    public long getTruncationPoint() {
+        return truncationPoint;
+    }
+
     /**
      * Checks the payload info and makes sure we are using appropriate files.
      * This assumes that the lis is positioned at the start and subsequently positions the lis just past the first line.
@@ -164,6 +170,7 @@ public class PBFileInfo extends FileInfo {
                 lastEvent = (DBRTimeEvent) unmarshallingConstructor.newInstance(getDataYear(), new ByteArray(lastLine));
                 lastEvent.getEventTimeStamp();
                 positionOfLastSample = posn;
+                truncationPoint = lis.getCurrentPosition();
                 return;
             } catch (PBParseException ex) {
                 logger.warn(

--- a/src/main/edu/stanford/slac/archiverappliance/plain/pb/PBFileInfo.java
+++ b/src/main/edu/stanford/slac/archiverappliance/plain/pb/PBFileInfo.java
@@ -157,7 +157,7 @@ public class PBFileInfo extends FileInfo {
         int lineTries = 0;
         byte[] lastLine = lis.readLine();
         while (lastLine == null && posn > 0 && lineTries < 1000) {
-            lis.seekToBeforePreviousLine(posn - 2);
+            lis.seekToBeforePreviousLine(posn);
             posn = lis.getCurrentPosition();
             lastLine = lis.readLine();
             lineTries++;
@@ -178,12 +178,12 @@ public class PBFileInfo extends FileInfo {
                                 + " seems to have some data corruption at the end of the file; moving onto the previous line",
                         ex);
                 lastEvent = null;
-                lis.seekToBeforePreviousLine(posn - 2);
+                lis.seekToBeforePreviousLine(posn);
                 posn = lis.getCurrentPosition();
                 lineTries = 0;
                 lastLine = lis.readLine();
                 while (lastLine == null && posn > 0 && lineTries < 1000) {
-                    lis.seekToBeforePreviousLine(posn - 2);
+                    lis.seekToBeforePreviousLine(posn);
                     posn = lis.getCurrentPosition();
                     lastLine = lis.readLine();
                     lineTries++;

--- a/src/test/org/epics/archiverappliance/etl/PbAppendCrashRecoveryTest.java
+++ b/src/test/org/epics/archiverappliance/etl/PbAppendCrashRecoveryTest.java
@@ -1,0 +1,109 @@
+package org.epics.archiverappliance.etl;
+
+import edu.stanford.slac.archiverappliance.PB.EPICSEvent.ScalarInt;
+import edu.stanford.slac.archiverappliance.PB.data.PBScalarInt;
+import edu.stanford.slac.archiverappliance.PB.utils.LineEscaper;
+import edu.stanford.slac.archiverappliance.plain.PathResolver;
+import edu.stanford.slac.archiverappliance.plain.pb.FileBackedPBEventStream;
+import edu.stanford.slac.archiverappliance.plain.pb.PBAppendDataStateData;
+import edu.stanford.slac.archiverappliance.plain.pb.PBEventFileWriter;
+import edu.stanford.slac.archiverappliance.plain.pb.PBFileInfo;
+import org.epics.archiverappliance.ByteArray;
+import org.epics.archiverappliance.Event;
+import org.epics.archiverappliance.common.BasicContext;
+import org.epics.archiverappliance.common.PartitionGranularity;
+import org.epics.archiverappliance.common.TimeUtils;
+import org.epics.archiverappliance.common.remotable.ArrayListEventStream;
+import org.epics.archiverappliance.common.remotable.RemotableEventStreamDesc;
+import org.epics.archiverappliance.config.ArchDBRTypes;
+import org.epics.archiverappliance.config.ConfigService;
+import org.epics.archiverappliance.config.PVNameToKeyMapping;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+public class PbAppendCrashRecoveryTest {
+
+    @Test
+    public void testAppendAfterCorruptionDoesNotEmbedGarbage() throws Exception {
+        Path testDir = Files.createTempDirectory("pb_crash_test");
+        try {
+            String pvName = "TESTPV";
+            short year = TimeUtils.getCurrentYear();
+            int initialCount = 5;
+            Path pbFile = testDir.resolve(pvName + ":" + year + ".pb");
+
+            // 1. Write a clean file with initialCount events
+            try (PBEventFileWriter writer = new PBEventFileWriter(pvName, pbFile, ArchDBRTypes.DBR_SCALAR_INT, year)) {
+                for (int i = 0; i < initialCount; i++) {
+                    byte[] escaped = LineEscaper.escapeNewLines(ScalarInt.newBuilder()
+                            .setSecondsintoyear(i * 60).setNano(0).setVal(i).build().toByteArray());
+                    writer.append(new PBScalarInt(year, new ByteArray(escaped)));
+                }
+            }
+            long cleanSize = Files.size(pbFile);
+
+            // Diagnostic: verify the clean file is readable before corrupting it
+            PBFileInfo cleanInfo = new PBFileInfo(pbFile);
+            Assertions.assertNotNull(cleanInfo.getLastEvent(), "clean file: last event must be readable");
+
+            // 2. Simulate crash mid-write: append partial proto bytes with no terminating \n
+            byte[] garbage = ScalarInt.newBuilder()
+                    .setSecondsintoyear(999 * 60).setNano(0).setVal(999).build().toByteArray();
+            Files.write(pbFile, garbage, StandardOpenOption.APPEND);
+            Assertions.assertTrue(Files.size(pbFile) > cleanSize);
+
+            // 3. PBFileInfo must detect corruption: truncationPoint == cleanSize, not the corrupt end
+            PBFileInfo info = new PBFileInfo(pbFile);
+            Assertions.assertNotNull(info.getLastEvent(), "last valid event must be found");
+            Assertions.assertTrue(info.getTruncationPoint() < Files.size(pbFile),
+                    "truncationPoint must be before corrupt tail");
+            Assertions.assertEquals(cleanSize, info.getTruncationPoint(),
+                    "truncationPoint must equal the pre-corruption file size");
+
+            // 4. Append new events via production path:
+            // partitionBoundaryAwareAppendData → preparePartition → updateStateBasedOnExistingFile
+            // (truncates corrupt tail) → writer.append for each event
+            int appendCount = 3;
+            PVNameToKeyMapping pv2key = new PVNameToKeyMapping() {
+                @Override public String convertPVNameToKey(String pv) { return pv + ":"; }
+                @Override public String[] breakIntoParts(String pv) { return new String[]{pv}; }
+                @Override public void initialize(ConfigService cs) {}
+                @Override public PVNameToKeyMapping overrideTerminator(char c) { return this; }
+            };
+            ArrayListEventStream appendStream = new ArrayListEventStream(
+                    appendCount, new RemotableEventStreamDesc(ArchDBRTypes.DBR_SCALAR_INT, pvName, year));
+            for (int i = initialCount; i < initialCount + appendCount; i++) {
+                appendStream.add(new PBScalarInt(year, ScalarInt.newBuilder()
+                        .setSecondsintoyear(i * 60).setNano(0).setVal(i)));
+            }
+            PBAppendDataStateData stateData = new PBAppendDataStateData(
+                    PartitionGranularity.PARTITION_YEAR, testDir.toString(), "test",
+                    null, pv2key, PathResolver.BASE_PATH_RESOLVER);
+            try (BasicContext ctx = new BasicContext()) {
+                stateData.partitionBoundaryAwareAppendData(ctx, pvName, appendStream, ".pb", null);
+            }
+
+            // Assert corrupt tail removed and new events appended:
+            // file must have grown past cleanSize (new data present) but not contain garbage
+            Assertions.assertTrue(Files.size(pbFile) > cleanSize,
+                    "file must be larger than clean baseline after appending new events");
+            int count = 0;
+            try (FileBackedPBEventStream stream = new FileBackedPBEventStream(
+                    pvName, pbFile, ArchDBRTypes.DBR_SCALAR_INT,
+                    0, Files.size(pbFile))) {
+                for (Event e : stream) {
+                    e.getEventTimeStamp(); // throws PBParseException if garbage embedded
+                    count++;
+                }
+            }
+            Assertions.assertEquals(initialCount + appendCount, count,
+                    "event count must equal initial + appended after corruption recovery");
+        } finally {
+            Files.walk(testDir).sorted(java.util.Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+        }
+    }
+}

--- a/src/test/org/epics/archiverappliance/etl/PbAppendCrashRecoveryTest.java
+++ b/src/test/org/epics/archiverappliance/etl/PbAppendCrashRecoveryTest.java
@@ -40,7 +40,11 @@ public class PbAppendCrashRecoveryTest {
             try (PBEventFileWriter writer = new PBEventFileWriter(pvName, pbFile, ArchDBRTypes.DBR_SCALAR_INT, year)) {
                 for (int i = 0; i < initialCount; i++) {
                     byte[] escaped = LineEscaper.escapeNewLines(ScalarInt.newBuilder()
-                            .setSecondsintoyear(i * 60).setNano(0).setVal(i).build().toByteArray());
+                            .setSecondsintoyear(i * 60)
+                            .setNano(0)
+                            .setVal(i)
+                            .build()
+                            .toByteArray());
                     writer.append(new PBScalarInt(year, new ByteArray(escaped)));
                 }
             }
@@ -52,58 +56,86 @@ public class PbAppendCrashRecoveryTest {
 
             // 2. Simulate crash mid-write: append partial proto bytes with no terminating \n
             byte[] garbage = ScalarInt.newBuilder()
-                    .setSecondsintoyear(999 * 60).setNano(0).setVal(999).build().toByteArray();
+                    .setSecondsintoyear(999 * 60)
+                    .setNano(0)
+                    .setVal(999)
+                    .build()
+                    .toByteArray();
             Files.write(pbFile, garbage, StandardOpenOption.APPEND);
             Assertions.assertTrue(Files.size(pbFile) > cleanSize);
 
             // 3. PBFileInfo must detect corruption: truncationPoint == cleanSize, not the corrupt end
             PBFileInfo info = new PBFileInfo(pbFile);
             Assertions.assertNotNull(info.getLastEvent(), "last valid event must be found");
-            Assertions.assertTrue(info.getTruncationPoint() < Files.size(pbFile),
-                    "truncationPoint must be before corrupt tail");
-            Assertions.assertEquals(cleanSize, info.getTruncationPoint(),
-                    "truncationPoint must equal the pre-corruption file size");
+            Assertions.assertTrue(
+                    info.getTruncationPoint() < Files.size(pbFile), "truncationPoint must be before corrupt tail");
+            Assertions.assertEquals(
+                    cleanSize, info.getTruncationPoint(), "truncationPoint must equal the pre-corruption file size");
 
             // 4. Append new events via production path:
             // partitionBoundaryAwareAppendData → preparePartition → updateStateBasedOnExistingFile
             // (truncates corrupt tail) → writer.append for each event
             int appendCount = 3;
             PVNameToKeyMapping pv2key = new PVNameToKeyMapping() {
-                @Override public String convertPVNameToKey(String pv) { return pv + ":"; }
-                @Override public String[] breakIntoParts(String pv) { return new String[]{pv}; }
-                @Override public void initialize(ConfigService cs) {}
-                @Override public PVNameToKeyMapping overrideTerminator(char c) { return this; }
+                @Override
+                public String convertPVNameToKey(String pv) {
+                    return pv + ":";
+                }
+
+                @Override
+                public String[] breakIntoParts(String pv) {
+                    return new String[] {pv};
+                }
+
+                @Override
+                public void initialize(ConfigService cs) {}
+
+                @Override
+                public PVNameToKeyMapping overrideTerminator(char c) {
+                    return this;
+                }
             };
             ArrayListEventStream appendStream = new ArrayListEventStream(
                     appendCount, new RemotableEventStreamDesc(ArchDBRTypes.DBR_SCALAR_INT, pvName, year));
             for (int i = initialCount; i < initialCount + appendCount; i++) {
-                appendStream.add(new PBScalarInt(year, ScalarInt.newBuilder()
-                        .setSecondsintoyear(i * 60).setNano(0).setVal(i)));
+                appendStream.add(new PBScalarInt(
+                        year,
+                        ScalarInt.newBuilder()
+                                .setSecondsintoyear(i * 60)
+                                .setNano(0)
+                                .setVal(i)));
             }
             PBAppendDataStateData stateData = new PBAppendDataStateData(
-                    PartitionGranularity.PARTITION_YEAR, testDir.toString(), "test",
-                    null, pv2key, PathResolver.BASE_PATH_RESOLVER);
+                    PartitionGranularity.PARTITION_YEAR,
+                    testDir.toString(),
+                    "test",
+                    null,
+                    pv2key,
+                    PathResolver.BASE_PATH_RESOLVER);
             try (BasicContext ctx = new BasicContext()) {
                 stateData.partitionBoundaryAwareAppendData(ctx, pvName, appendStream, ".pb", null);
             }
 
             // Assert corrupt tail removed and new events appended:
             // file must have grown past cleanSize (new data present) but not contain garbage
-            Assertions.assertTrue(Files.size(pbFile) > cleanSize,
+            Assertions.assertTrue(
+                    Files.size(pbFile) > cleanSize,
                     "file must be larger than clean baseline after appending new events");
             int count = 0;
-            try (FileBackedPBEventStream stream = new FileBackedPBEventStream(
-                    pvName, pbFile, ArchDBRTypes.DBR_SCALAR_INT,
-                    0, Files.size(pbFile))) {
+            try (FileBackedPBEventStream stream =
+                    new FileBackedPBEventStream(pvName, pbFile, ArchDBRTypes.DBR_SCALAR_INT, 0, Files.size(pbFile))) {
                 for (Event e : stream) {
                     e.getEventTimeStamp(); // throws PBParseException if garbage embedded
                     count++;
                 }
             }
-            Assertions.assertEquals(initialCount + appendCount, count,
+            Assertions.assertEquals(
+                    initialCount + appendCount,
+                    count,
                     "event count must equal initial + appended after corruption recovery");
         } finally {
-            Files.walk(testDir).sorted(java.util.Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+            Files.walk(testDir).sorted(java.util.Comparator.reverseOrder()).forEach(p -> p.toFile()
+                    .delete());
         }
     }
 }


### PR DESCRIPTION
This PR follows up on issue #500, where PB files were failing to move from STS to MTS during ETL processing.

The root cause was file corruption in STS: a process crash during a write could leave an incomplete protobuf record at the end of a file. Because the partial record was never truncated, subsequent appends could write valid records after the corrupted bytes, causing ETL processing to fail when reading the file.

This fix updates updateStateBasedOnExistingFile to truncate any corrupt tail before opening the append writer. As a result, partially written files are repaired on the next append instead of accumulating invalid data.
