### PR TITLE
docs: add & configure the mermaid plugin

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
 	"sphinx>=8.2",
 	"sphinx-copybutton>=0.5.2",
 	"sphinx_rtd_theme>=3.0",
+	"sphinxcontrib-mermaid>=2.0.0",
 	"sphinxcontrib-openapi>=0.9.0",
 	"sphinxext-opengraph>=0.13.0",
 	"sphinxext-rediraffe>=0.3.0",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,7 @@ extensions = [
     "myst_parser",
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
+    "sphinxcontrib.mermaid",
     "sphinxcontrib.openapi",
     "sphinxext.opengraph",
     "sphinxext.rediraffe",


### PR DESCRIPTION
Diagrams were added in #376, but without the plugin nothing is showing up, and warnings shows during the Sphinx build.

Proof of work: https://epicsarchiver--530.org.readthedocs.build/en/530/sysadmin/guides/reassign.html