### PR TITLE
For packed files, return the path of the file system if a root folder

### DIFF
--- a/src/main/org/epics/archiverappliance/utils/nio/ArchPaths.java
+++ b/src/main/org/epics/archiverappliance/utils/nio/ArchPaths.java
@@ -65,6 +65,9 @@ public class ArchPaths implements Closeable {
         }
 
         if (pvPath.isRootFolderOnly()) {
+            if(pvPath.isPackFile()) {
+                return Paths.get(pvPath.getParentPathForCreation());
+            }
             return Paths.get(pvPath.getFullPath());
         }
 


### PR DESCRIPTION
Eliminates a spurious log message that can fill the log files on startup