### PR TITLE
Fix mgmt help links

### DIFF
--- a/src/main/org/epics/archiverappliance/mgmt/staticcontent/appliance.html
+++ b/src/main/org/epics/archiverappliance/mgmt/staticcontent/appliance.html
@@ -102,7 +102,7 @@
 
         // Set up help
         $("#help").click(function () {
-          window.open("help/user/userguide.html#Appliances");
+          window.open("help/index.html");
         });
       });
     </script>

--- a/src/main/org/epics/archiverappliance/mgmt/staticcontent/index.html
+++ b/src/main/org/epics/archiverappliance/mgmt/staticcontent/index.html
@@ -225,16 +225,10 @@
 
         // Set up help
         $("#help").click(function () {
-          window.open("help/user/userguide.html#ArchivePV");
+          window.open("help/index.html");
         });
 
-        $(document).ready(function () {
-          // Set up help
-          $("#help").click(function () {
-            window.open("help/user/userguide.html#Reports");
-          });
-          $("#pvStopArchivingParams").hide();
-        });
+        $("#pvStopArchivingParams").hide();
       });
     </script>
   </body>

--- a/src/main/org/epics/archiverappliance/mgmt/staticcontent/integration.html
+++ b/src/main/org/epics/archiverappliance/mgmt/staticcontent/integration.html
@@ -214,7 +214,7 @@
 
         // Set up help
         $("#help").click(function () {
-          window.open("help/user/userguide.html#Integrations");
+          window.open("help/index.html");
         });
       });
     </script>

--- a/src/main/org/epics/archiverappliance/mgmt/staticcontent/metrics.html
+++ b/src/main/org/epics/archiverappliance/mgmt/staticcontent/metrics.html
@@ -120,7 +120,7 @@
 
         // Set up help
         $("#help").click(function () {
-          window.open("help/user/userguide.html#Metrics");
+          window.open("help/index.html");
         });
       });
     </script>

--- a/src/main/org/epics/archiverappliance/mgmt/staticcontent/reports.html
+++ b/src/main/org/epics/archiverappliance/mgmt/staticcontent/reports.html
@@ -180,7 +180,7 @@
         $(document).ready(function () {
           // Set up help
           $("#help").click(function () {
-            window.open("help/user/userguide.html#Reports");
+            window.open("help/index.html");
           });
           $("#pvStopArchivingParams").hide();
         });

--- a/src/main/org/epics/archiverappliance/mgmt/staticcontent/storage.html
+++ b/src/main/org/epics/archiverappliance/mgmt/staticcontent/storage.html
@@ -125,7 +125,7 @@
 
         // Set up help
         $("#help").click(function () {
-          window.open("help/user/userguide.html#Storage");
+          window.open("help/index.html");
         });
       });
     </script>


### PR DESCRIPTION
It seems that from Release 2.4.1, the help link still points to the old **help/user/userguide.html**, which cannot be accessed anymore.

This PR changes the help links in **index.htm**, **reports.html,** **metrics.html**, **storage.html,** **appliance.html** and **integration.htm**, from "help/user/userguide.html" to "help/index.html".

It also removes one redundant **$(document).ready()** in index.html.

<img width="1615" height="728" alt="image" src="https://github.com/user-attachments/assets/f7431b17-28a7-4a57-bba0-a4e24208d9ed" />
