### PR TITLE
Fix install scripts executable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -590,6 +590,21 @@ tasks.register<Tar>("buildRelease") {
 		include("quickstart.sh")
 	}
 	from(samplesFolder) {
+		filePermissions {
+			user {
+				read = true
+				write = true
+				execute = true
+			}
+			group {
+				read = true
+				execute = true
+			}
+			other {
+				read = true
+				execute = true
+			}
+		}
 		include(
 			"sampleStartup.sh",
 			"deployMultipleTomcats.py",


### PR DESCRIPTION
Adds execute permission to scripts when packing to avoid  "Permission denied" error when running  `single_machine_install.sh`, otherwise execute permission needs to be added manually before running `single_machine_install.sh`.